### PR TITLE
Unify current-head Codex repair proof projection

### DIFF
--- a/src/codex-connector-tracked-pr-test-helpers.ts
+++ b/src/codex-connector-tracked-pr-test-helpers.ts
@@ -272,6 +272,8 @@ export function createCodexConnectorTrackedReviewResidueScenario({
         next_action: "continue",
         summary: verifiedRepair.summary,
         recorded_at: verifiedRepair.ranAt,
+        processed_review_thread_ids: [`${threadId}@${headSha}`],
+        processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
       },
     ];
   }

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -61,6 +61,7 @@ function currentConfiguredBotThreads(config: SupervisorConfig, reviewThreads: Re
 function currentHeadCodexTurnVerificationArtifact(
   record: Pick<IssueRunRecord, "timeline_artifacts">,
   pr: Pick<GitHubPullRequest, "headRefOid">,
+  currentThreads: ReviewThread[],
 ): TimelineArtifact | null {
   return (record.timeline_artifacts ?? []).find(
     (artifact) =>
@@ -68,7 +69,8 @@ function currentHeadCodexTurnVerificationArtifact(
       artifact.gate === "codex_turn" &&
       artifact.outcome === "passed" &&
       artifact.head_sha === pr.headRefOid &&
-      artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") !== true,
+      artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") !== true &&
+      repairArtifactCoversCurrentThreads(artifact, pr, currentThreads),
   ) ?? null;
 }
 
@@ -207,7 +209,7 @@ export function projectCurrentHeadCodexRepairProof(args: {
     return null;
   }
 
-  const currentHeadVerification = currentHeadCodexTurnVerificationArtifact(args.record, args.pr);
+  const currentHeadVerification = currentHeadCodexTurnVerificationArtifact(args.record, args.pr, currentThreads);
   if (!currentHeadVerification) {
     return null;
   }

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -1,4 +1,5 @@
 import {
+  codexConnectorMustFixReviewThreads,
   hasCodexConnectorFindingReviewComment,
   latestCodexConnectorPSeverity,
 } from "./codex-connector-review-policy";
@@ -99,13 +100,25 @@ function repairArtifactCoversCurrentThreads(
   const processedThreadIds = artifact.processed_review_thread_ids ?? [];
   const processedThreadFingerprints = artifact.processed_review_thread_fingerprints ?? [];
   return currentThreads.every((thread) => {
+    const headScopedKey = processedReviewThreadKey(thread.id, pr.headRefOid);
     const latestFingerprint = latestReviewThreadCommentFingerprint(thread);
-    if (latestFingerprint) {
-      return processedThreadFingerprints.includes(
+    if (
+      latestFingerprint &&
+      processedThreadFingerprints.includes(
         processedReviewThreadFingerprintKey(thread.id, pr.headRefOid, latestFingerprint),
-      );
+      )
+    ) {
+      return true;
     }
-    return processedThreadIds.includes(processedReviewThreadKey(thread.id, pr.headRefOid));
+    if (!processedThreadIds.includes(headScopedKey)) {
+      return false;
+    }
+    if (!latestFingerprint) {
+      return true;
+    }
+
+    const threadFingerprintPrefix = `${headScopedKey}#`;
+    return !processedThreadFingerprints.some((key) => key.startsWith(threadFingerprintPrefix));
   });
 }
 
@@ -120,8 +133,12 @@ function headScopedProcessedThreadEvidenceCount(
   );
 }
 
-function currentConfiguredThreadsAreLowSeverityRepairResidue(currentThreads: ReviewThread[]): boolean {
-  return currentThreads.every((thread) => latestCodexConnectorPSeverity(thread) === "P2");
+function currentRepairResidueThreads(currentThreads: ReviewThread[]): ReviewThread[] | null {
+  const mustFixThreads = codexConnectorMustFixReviewThreads(currentThreads);
+  if (!mustFixThreads.every((thread) => latestCodexConnectorPSeverity(thread) === "P2")) {
+    return null;
+  }
+  return mustFixThreads;
 }
 
 function isCurrentHeadNoMajorMergeGuardFailure(
@@ -181,35 +198,40 @@ export function projectCurrentHeadCodexRepairProof(args: {
   }
 
   const currentThreads = currentConfiguredBotThreads(args.config, args.reviewThreads);
-  if (!currentThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))) {
+  const repairResidueThreads = currentRepairResidueThreads(currentThreads);
+  if (!repairResidueThreads) {
     return null;
   }
-  if (!currentConfiguredThreadsAreLowSeverityRepairResidue(currentThreads)) {
+  if (
+    repairResidueThreads.length > 0 &&
+    !repairResidueThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
+  ) {
     return null;
   }
 
   const structuredArtifact = currentHeadVerifiedRepairResidueArtifact(args.record, args.pr);
-  if (structuredArtifact && repairArtifactCoversCurrentThreads(structuredArtifact, args.pr, currentThreads)) {
+  if (structuredArtifact && repairArtifactCoversCurrentThreads(structuredArtifact, args.pr, repairResidueThreads)) {
     return {
       source: "structured_artifact",
       summary: structuredArtifact.summary || "verified_current_head_repair_review_thread_residue_artifact",
       processedThreadEvidenceCount: structuredArtifact.processed_review_thread_ids?.length ?? 0,
-      currentConfiguredThreadCount: currentThreads.length,
+      currentConfiguredThreadCount: repairResidueThreads.length,
     };
+  }
+
+  if (repairResidueThreads.length === 0) {
+    return null;
   }
 
   const processedThreadEvidenceCount = headScopedProcessedThreadEvidenceCount(args.record, args.pr);
   if (processedThreadEvidenceCount === 0) {
     return null;
   }
-  if (currentThreads.length === 0) {
-    return null;
-  }
   if (!isCurrentHeadNoMajorMergeGuardFailure(args.record, args.pr)) {
     return null;
   }
 
-  const currentHeadVerification = currentHeadCodexTurnVerificationArtifact(args.record, args.pr, currentThreads);
+  const currentHeadVerification = currentHeadCodexTurnVerificationArtifact(args.record, args.pr, repairResidueThreads);
   if (!currentHeadVerification) {
     return null;
   }
@@ -218,7 +240,7 @@ export function projectCurrentHeadCodexRepairProof(args: {
     source: "legacy_processed_thread_evidence",
     summary: `legacy_processed_thread_evidence:${currentHeadVerification.summary || currentHeadVerification.command || "current_head_codex_turn_verification"}`,
     processedThreadEvidenceCount,
-    currentConfiguredThreadCount: currentThreads.length,
+    currentConfiguredThreadCount: repairResidueThreads.length,
   };
 }
 

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -1,0 +1,195 @@
+import {
+  hasCodexConnectorFindingReviewComment,
+  latestCodexConnectorPSeverity,
+} from "./codex-connector-review-policy";
+import { configuredReviewProviderKinds } from "./core/review-providers";
+import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig, TimelineArtifact } from "./core/types";
+import { currentHeadLocalCiMissing, hasConfiguredLocalCiCommand } from "./local-ci-policy";
+import { hasProcessedReviewThread } from "./review-handling";
+import { configuredBotReviewThreads, manualReviewThreads } from "./review-thread-reporting";
+
+export const VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET =
+  "verified_current_head_repair_review_thread_residue";
+
+export type CurrentHeadCodexRepairProofSource =
+  | "structured_artifact"
+  | "legacy_processed_thread_evidence";
+
+export interface CurrentHeadCodexRepairProofProjection {
+  source: CurrentHeadCodexRepairProofSource;
+  summary: string;
+  processedThreadEvidenceCount: number;
+  currentConfiguredThreadCount: number;
+}
+
+function checksPresentAndGreen(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
+  return checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
+}
+
+function configuredReviewProvidersAreCodexOnly(config: SupervisorConfig): boolean {
+  const providerKinds = configuredReviewProviderKinds(config);
+  return providerKinds.length > 0 && providerKinds.every((kind) => kind === "codex");
+}
+
+function unresolvedConfiguredBotThreadsAreCodexConnectorOnly(
+  config: SupervisorConfig,
+  reviewThreads: ReviewThread[],
+): boolean {
+  return configuredBotReviewThreads(config, reviewThreads)
+    .filter((thread) => !thread.isResolved)
+    .every(hasCodexConnectorFindingReviewComment);
+}
+
+function currentConfiguredBotThreads(config: SupervisorConfig, reviewThreads: ReviewThread[]): ReviewThread[] {
+  return configuredBotReviewThreads(config, reviewThreads)
+    .filter((thread) => !thread.isResolved && !thread.isOutdated);
+}
+
+function currentHeadCodexTurnVerificationArtifact(
+  record: Pick<IssueRunRecord, "timeline_artifacts">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): TimelineArtifact | null {
+  return (record.timeline_artifacts ?? []).find(
+    (artifact) =>
+      artifact.type === "verification_result" &&
+      artifact.gate === "codex_turn" &&
+      artifact.outcome === "passed" &&
+      artifact.head_sha === pr.headRefOid &&
+      artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") !== true,
+  ) ?? null;
+}
+
+function currentHeadVerifiedRepairResidueArtifact(
+  record: Pick<IssueRunRecord, "timeline_artifacts">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): TimelineArtifact | null {
+  return (record.timeline_artifacts ?? []).find(
+    (artifact) =>
+      artifact.type === "verification_result" &&
+      artifact.outcome === "passed" &&
+      artifact.head_sha === pr.headRefOid &&
+      artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
+      (artifact.processed_review_thread_ids?.length ?? 0) > 0,
+  ) ?? null;
+}
+
+function headScopedProcessedThreadEvidenceCount(
+  record: Pick<IssueRunRecord, "processed_review_thread_ids" | "processed_review_thread_fingerprints">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): number {
+  const headToken = `@${pr.headRefOid}`;
+  return (
+    (record.processed_review_thread_ids ?? []).filter((key) => key.includes(headToken)).length +
+    (record.processed_review_thread_fingerprints ?? []).filter((key) => key.includes(headToken)).length
+  );
+}
+
+function currentConfiguredThreadsAreLowSeverityRepairResidue(currentThreads: ReviewThread[]): boolean {
+  return currentThreads.every((thread) => latestCodexConnectorPSeverity(thread) === "P2");
+}
+
+function isCurrentHeadNoMajorMergeGuardFailure(
+  record: Pick<IssueRunRecord, "blocked_reason" | "last_failure_context" | "last_failure_signature">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): boolean {
+  const signature = record.last_failure_signature ?? "";
+  const contextSignature = record.last_failure_context?.signature ?? "";
+  const contextDetails = record.last_failure_context?.details ?? "";
+  return [signature, contextSignature, contextDetails].some((value) =>
+    value.includes("missing_current_head_codex_no_major") &&
+    (!value.includes("auto-merge-refused:") || value.includes(pr.headRefOid)),
+  );
+}
+
+function humanReviewBlocksProjection(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+  reviewThreads: ReviewThread[],
+): boolean {
+  if (!config.humanReviewBlocksMerge) {
+    return false;
+  }
+  return (
+    manualReviewThreads(config, reviewThreads).length > 0 ||
+    pr.reviewDecision === "REVIEW_REQUIRED" ||
+    pr.reviewDecision === "CHANGES_REQUESTED"
+  );
+}
+
+function projectionSafetyGatesPass(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): boolean {
+  return (
+    args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true &&
+    configuredReviewProvidersAreCodexOnly(args.config) &&
+    checksPresentAndGreen(args.checks) &&
+    args.record.last_head_sha === args.pr.headRefOid &&
+    (!hasConfiguredLocalCiCommand(args.config) || !currentHeadLocalCiMissing(args.record, args.pr)) &&
+    !humanReviewBlocksProjection(args.config, args.pr, args.reviewThreads) &&
+    unresolvedConfiguredBotThreadsAreCodexConnectorOnly(args.config, args.reviewThreads)
+  );
+}
+
+export function projectCurrentHeadCodexRepairProof(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): CurrentHeadCodexRepairProofProjection | null {
+  if (!projectionSafetyGatesPass(args)) {
+    return null;
+  }
+
+  const currentThreads = currentConfiguredBotThreads(args.config, args.reviewThreads);
+  if (!currentThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))) {
+    return null;
+  }
+  if (!currentConfiguredThreadsAreLowSeverityRepairResidue(currentThreads)) {
+    return null;
+  }
+
+  const structuredArtifact = currentHeadVerifiedRepairResidueArtifact(args.record, args.pr);
+  if (structuredArtifact) {
+    return {
+      source: "structured_artifact",
+      summary: structuredArtifact.summary || "verified_current_head_repair_review_thread_residue_artifact",
+      processedThreadEvidenceCount: structuredArtifact.processed_review_thread_ids?.length ?? 0,
+      currentConfiguredThreadCount: currentThreads.length,
+    };
+  }
+
+  const processedThreadEvidenceCount = headScopedProcessedThreadEvidenceCount(args.record, args.pr);
+  if (processedThreadEvidenceCount === 0) {
+    return null;
+  }
+  if (currentThreads.length === 0) {
+    return null;
+  }
+  if (!isCurrentHeadNoMajorMergeGuardFailure(args.record, args.pr)) {
+    return null;
+  }
+
+  const currentHeadVerification = currentHeadCodexTurnVerificationArtifact(args.record, args.pr);
+  if (!currentHeadVerification) {
+    return null;
+  }
+
+  return {
+    source: "legacy_processed_thread_evidence",
+    summary: `legacy_processed_thread_evidence:${currentHeadVerification.summary || currentHeadVerification.command || "current_head_codex_turn_verification"}`,
+    processedThreadEvidenceCount,
+    currentConfiguredThreadCount: currentThreads.length,
+  };
+}
+
+export function hasCurrentHeadVerifiedRepairResidueArtifact(
+  record: Pick<IssueRunRecord, "timeline_artifacts">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): boolean {
+  return currentHeadVerifiedRepairResidueArtifact(record, pr) !== null;
+}

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -12,6 +12,7 @@ import {
   processedReviewThreadFingerprintKey,
   processedReviewThreadKey,
 } from "./review-handling";
+import { reviewDecisionBlocksCurrentHeadRepairProjection } from "./review-decision-blocking-policy";
 import {
   configuredBotReviewThreads,
   latestReviewCommentAuthorIsAllowedBot,
@@ -85,8 +86,19 @@ function currentHeadVerifiedRepairResidueArtifact(
       artifact.outcome === "passed" &&
       artifact.head_sha === pr.headRefOid &&
       artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
-      (artifact.processed_review_thread_ids?.length ?? 0) > 0,
+      artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0,
   ) ?? null;
+}
+
+function artifactHeadScopedProcessedThreadEvidenceCount(
+  artifact: Pick<TimelineArtifact, "processed_review_thread_ids" | "processed_review_thread_fingerprints">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): number {
+  const headToken = `@${pr.headRefOid}`;
+  return (
+    (artifact.processed_review_thread_ids ?? []).filter((key) => key.includes(headToken)).length +
+    (artifact.processed_review_thread_fingerprints ?? []).filter((key) => key.includes(headToken)).length
+  );
 }
 
 function repairArtifactCoversCurrentThreads(
@@ -95,7 +107,7 @@ function repairArtifactCoversCurrentThreads(
   currentThreads: ReviewThread[],
 ): boolean {
   if (currentThreads.length === 0) {
-    return true;
+    return artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0;
   }
   const processedThreadIds = artifact.processed_review_thread_ids ?? [];
   const processedThreadFingerprints = artifact.processed_review_thread_fingerprints ?? [];
@@ -158,14 +170,11 @@ function humanReviewBlocksProjection(
   pr: GitHubPullRequest,
   reviewThreads: ReviewThread[],
 ): boolean {
-  if (!config.humanReviewBlocksMerge) {
-    return false;
-  }
-  return (
-    manualReviewThreads(config, reviewThreads).length > 0 ||
-    pr.reviewDecision === "REVIEW_REQUIRED" ||
-    pr.reviewDecision === "CHANGES_REQUESTED"
-  );
+  return reviewDecisionBlocksCurrentHeadRepairProjection({
+    humanReviewBlocksMerge: Boolean(config.humanReviewBlocksMerge),
+    manualThreadCount: manualReviewThreads(config, reviewThreads).length,
+    pr,
+  });
 }
 
 function projectionSafetyGatesPass(args: {
@@ -217,10 +226,6 @@ export function projectCurrentHeadCodexRepairProof(args: {
       processedThreadEvidenceCount: structuredArtifact.processed_review_thread_ids?.length ?? 0,
       currentConfiguredThreadCount: repairResidueThreads.length,
     };
-  }
-
-  if (repairResidueThreads.length === 0) {
-    return null;
   }
 
   const processedThreadEvidenceCount = headScopedProcessedThreadEvidenceCount(args.record, args.pr);

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -80,6 +80,7 @@ function currentHeadCodexTurnVerificationArtifact(
 function currentHeadVerifiedRepairResidueArtifact(
   record: Pick<IssueRunRecord, "timeline_artifacts">,
   pr: Pick<GitHubPullRequest, "headRefOid">,
+  currentThreads?: ReviewThread[],
 ): TimelineArtifact | null {
   return (record.timeline_artifacts ?? []).find(
     (artifact) =>
@@ -87,7 +88,8 @@ function currentHeadVerifiedRepairResidueArtifact(
       artifact.outcome === "passed" &&
       artifact.head_sha === pr.headRefOid &&
       artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
-      artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0,
+      artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0 &&
+      (!currentThreads || repairArtifactCoversCurrentThreads(artifact, pr, currentThreads)),
   ) ?? null;
 }
 
@@ -240,8 +242,8 @@ export function projectCurrentHeadCodexRepairProof(args: {
     return null;
   }
 
-  const structuredArtifact = currentHeadVerifiedRepairResidueArtifact(args.record, args.pr);
-  if (structuredArtifact && repairArtifactCoversCurrentThreads(structuredArtifact, args.pr, repairResidueThreads)) {
+  const structuredArtifact = currentHeadVerifiedRepairResidueArtifact(args.record, args.pr, repairResidueThreads);
+  if (structuredArtifact) {
     return {
       source: "structured_artifact",
       summary: structuredArtifact.summary || "verified_current_head_repair_review_thread_residue_artifact",

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -15,6 +15,7 @@ import {
 import { reviewDecisionBlocksCurrentHeadRepairProjection } from "./review-decision-blocking-policy";
 import {
   configuredBotReviewThreads,
+  latestReviewComment,
   latestReviewCommentAuthorIsAllowedBot,
   manualReviewThreads,
 } from "./review-thread-reporting";
@@ -130,8 +131,29 @@ function repairArtifactCoversCurrentThreads(
     }
 
     const threadFingerprintPrefix = `${headScopedKey}#`;
-    return !processedThreadFingerprints.some((key) => key.startsWith(threadFingerprintPrefix));
+    return (
+      !processedThreadFingerprints.some((key) => key.startsWith(threadFingerprintPrefix)) &&
+      latestReviewThreadCommentPredatesArtifact(thread, artifact)
+    );
   });
+}
+
+function latestReviewThreadCommentPredatesArtifact(
+  thread: ReviewThread,
+  artifact: Pick<TimelineArtifact, "recorded_at">,
+): boolean {
+  const latestComment = latestReviewComment(thread);
+  if (!latestComment) {
+    return true;
+  }
+
+  const latestCommentMs = Date.parse(latestComment.createdAt);
+  const artifactRecordedMs = Date.parse(artifact.recorded_at);
+  if (Number.isNaN(latestCommentMs) || Number.isNaN(artifactRecordedMs)) {
+    return false;
+  }
+
+  return latestCommentMs <= artifactRecordedMs;
 }
 
 function headScopedProcessedThreadEvidenceCount(

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -1,10 +1,12 @@
 import {
   codexConnectorMustFixReviewThreads,
   hasCodexConnectorFindingReviewComment,
+  latestCodexConnectorReviewComment,
   latestCodexConnectorPSeverity,
 } from "./codex-connector-review-policy";
 import { configuredReviewProviderKinds } from "./core/review-providers";
 import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig, TimelineArtifact } from "./core/types";
+import { hasCodexConnectorStrongRiskWording } from "./external-review/external-review-normalization";
 import { currentHeadLocalCiMissing, hasConfiguredLocalCiCommand } from "./local-ci-policy";
 import {
   hasProcessedReviewThread,
@@ -177,6 +179,35 @@ function currentRepairResidueThreads(currentThreads: ReviewThread[]): ReviewThre
   return mustFixThreads;
 }
 
+function unresolvedCodexConnectorMustFixThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
+  return reviewThreads.filter((thread) => {
+    if (thread.isResolved) {
+      return false;
+    }
+
+    const latestReview = latestCodexConnectorReviewComment(thread);
+    if (!latestReview) {
+      return false;
+    }
+
+    return (
+      latestReview.severity === "P0" ||
+      latestReview.severity === "P1" ||
+      latestReview.severity === "P2" ||
+      (latestReview.severity === "P3" && hasCodexConnectorStrongRiskWording(latestReview.body))
+    );
+  });
+}
+
+function allUnresolvedCodexConnectorMustFixThreadsAreP2(
+  config: SupervisorConfig,
+  reviewThreads: ReviewThread[],
+): boolean {
+  return unresolvedCodexConnectorMustFixThreads(
+    configuredBotReviewThreads(config, reviewThreads),
+  ).every((thread) => latestCodexConnectorPSeverity(thread) === "P2");
+}
+
 function isCurrentHeadNoMajorMergeGuardFailure(
   record: Pick<IssueRunRecord, "blocked_reason" | "last_failure_context" | "last_failure_signature">,
   pr: Pick<GitHubPullRequest, "headRefOid">,
@@ -232,7 +263,7 @@ export function projectCurrentHeadCodexRepairProof(args: {
 
   const currentThreads = currentConfiguredBotThreads(args.config, args.reviewThreads);
   const repairResidueThreads = currentRepairResidueThreads(currentThreads);
-  if (!repairResidueThreads) {
+  if (!repairResidueThreads || !allUnresolvedCodexConnectorMustFixThreadsAreP2(args.config, args.reviewThreads)) {
     return null;
   }
   if (

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -5,8 +5,17 @@ import {
 import { configuredReviewProviderKinds } from "./core/review-providers";
 import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig, TimelineArtifact } from "./core/types";
 import { currentHeadLocalCiMissing, hasConfiguredLocalCiCommand } from "./local-ci-policy";
-import { hasProcessedReviewThread } from "./review-handling";
-import { configuredBotReviewThreads, manualReviewThreads } from "./review-thread-reporting";
+import {
+  hasProcessedReviewThread,
+  latestReviewThreadCommentFingerprint,
+  processedReviewThreadFingerprintKey,
+  processedReviewThreadKey,
+} from "./review-handling";
+import {
+  configuredBotReviewThreads,
+  latestReviewCommentAuthorIsAllowedBot,
+  manualReviewThreads,
+} from "./review-thread-reporting";
 
 export const VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET =
   "verified_current_head_repair_review_thread_residue";
@@ -37,7 +46,11 @@ function unresolvedConfiguredBotThreadsAreCodexConnectorOnly(
 ): boolean {
   return configuredBotReviewThreads(config, reviewThreads)
     .filter((thread) => !thread.isResolved)
-    .every(hasCodexConnectorFindingReviewComment);
+    .every(
+      (thread) =>
+        latestReviewCommentAuthorIsAllowedBot(config, thread) &&
+        hasCodexConnectorFindingReviewComment(thread),
+    );
 }
 
 function currentConfiguredBotThreads(config: SupervisorConfig, reviewThreads: ReviewThread[]): ReviewThread[] {
@@ -73,6 +86,27 @@ function currentHeadVerifiedRepairResidueArtifact(
   ) ?? null;
 }
 
+function repairArtifactCoversCurrentThreads(
+  artifact: TimelineArtifact,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  currentThreads: ReviewThread[],
+): boolean {
+  if (currentThreads.length === 0) {
+    return true;
+  }
+  const processedThreadIds = artifact.processed_review_thread_ids ?? [];
+  const processedThreadFingerprints = artifact.processed_review_thread_fingerprints ?? [];
+  return currentThreads.every((thread) => {
+    const latestFingerprint = latestReviewThreadCommentFingerprint(thread);
+    if (latestFingerprint) {
+      return processedThreadFingerprints.includes(
+        processedReviewThreadFingerprintKey(thread.id, pr.headRefOid, latestFingerprint),
+      );
+    }
+    return processedThreadIds.includes(processedReviewThreadKey(thread.id, pr.headRefOid));
+  });
+}
+
 function headScopedProcessedThreadEvidenceCount(
   record: Pick<IssueRunRecord, "processed_review_thread_ids" | "processed_review_thread_fingerprints">,
   pr: Pick<GitHubPullRequest, "headRefOid">,
@@ -94,10 +128,9 @@ function isCurrentHeadNoMajorMergeGuardFailure(
 ): boolean {
   const signature = record.last_failure_signature ?? "";
   const contextSignature = record.last_failure_context?.signature ?? "";
-  const contextDetails = record.last_failure_context?.details ?? "";
-  return [signature, contextSignature, contextDetails].some((value) =>
-    value.includes("missing_current_head_codex_no_major") &&
-    (!value.includes("auto-merge-refused:") || value.includes(pr.headRefOid)),
+  const contextDetails = record.last_failure_context?.details ?? [];
+  return [signature, contextSignature, ...contextDetails].some((value) =>
+    value.includes("missing_current_head_codex_no_major") && value.includes(pr.headRefOid),
   );
 }
 
@@ -154,7 +187,7 @@ export function projectCurrentHeadCodexRepairProof(args: {
   }
 
   const structuredArtifact = currentHeadVerifiedRepairResidueArtifact(args.record, args.pr);
-  if (structuredArtifact) {
+  if (structuredArtifact && repairArtifactCoversCurrentThreads(structuredArtifact, args.pr, currentThreads)) {
     return {
       source: "structured_artifact",
       summary: structuredArtifact.summary || "verified_current_head_repair_review_thread_residue_artifact",

--- a/src/decision-kernel/v2-explain.test.ts
+++ b/src/decision-kernel/v2-explain.test.ts
@@ -526,6 +526,7 @@ test("buildDecisionKernelV2ExplainDto requires Codex no-major evidence for Codex
     pr: pullRequest({
       reviewDecision: "CHANGES_REQUESTED",
       configuredBotTopLevelReviewStrength: "blocking",
+      configuredBotOnlyChangesRequestedReview: true,
       configuredBotCurrentHeadObservedAt: "2026-06-08T00:06:00.000Z",
       configuredBotCurrentHeadObservationSource: "review_thread",
       configuredBotCurrentHeadStatusState: "SUCCESS",

--- a/src/decision-kernel/v2-explain.test.ts
+++ b/src/decision-kernel/v2-explain.test.ts
@@ -524,6 +524,8 @@ test("buildDecisionKernelV2ExplainDto requires Codex no-major evidence for Codex
       provider_success_head_sha: "head-current",
     }),
     pr: pullRequest({
+      reviewDecision: "CHANGES_REQUESTED",
+      configuredBotTopLevelReviewStrength: "blocking",
       configuredBotCurrentHeadObservedAt: "2026-06-08T00:06:00.000Z",
       configuredBotCurrentHeadObservationSource: "review_thread",
       configuredBotCurrentHeadStatusState: "SUCCESS",

--- a/src/decision-kernel/v2-explain.test.ts
+++ b/src/decision-kernel/v2-explain.test.ts
@@ -545,12 +545,25 @@ test("buildDecisionKernelV2ExplainDto treats verified current-head repair residu
       configuredBotInitialGraceWaitSeconds: 0,
       configuredBotSettledWaitSeconds: 0,
       verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+      localCiCommand: "npm run verify:pre-pr",
     }),
     issueNumber: 2301,
     title: "Phase 3.2",
     record: record({
+      blocked_reason: "verification",
+      last_failure_signature: "auto-merge-refused:head-current:missing_current_head_codex_no_major",
       processed_review_thread_ids: ["thread-codex-p2@head-current"],
       processed_review_thread_fingerprints: ["thread-codex-p2@head-current#comment-codex-p2"],
+      latest_local_ci_result: {
+        outcome: "passed",
+        summary: "Configured local CI command passed before auto-merging PR.",
+        ran_at: "2026-06-08T00:06:30.000Z",
+        head_sha: "head-current",
+        execution_mode: "shell",
+        command: "npm run verify:pre-pr",
+        failure_class: null,
+        remediation_target: null,
+      },
       timeline_artifacts: [
         {
           type: "verification_result",

--- a/src/decision-kernel/v2-explain.test.ts
+++ b/src/decision-kernel/v2-explain.test.ts
@@ -575,6 +575,8 @@ test("buildDecisionKernelV2ExplainDto treats verified current-head repair residu
           next_action: "continue",
           summary: "Focused verifier passed after the repair commit.",
           recorded_at: "2026-06-08T00:06:00.000Z",
+          processed_review_thread_ids: ["thread-codex-p2@head-current"],
+          processed_review_thread_fingerprints: ["thread-codex-p2@head-current#comment-codex-p2"],
         },
       ],
     }),

--- a/src/decision-kernel/v2-explain.ts
+++ b/src/decision-kernel/v2-explain.ts
@@ -33,6 +33,7 @@ import {
   hasConfiguredProviderSuccess,
   hasVerifiedCurrentHeadRepairReviewMetadataResidue,
 } from "../pull-request-state-codex-residue-policy";
+import { aggregateHumanReviewDecisionBlocker } from "../review-decision-blocking-policy";
 import { configuredBotReviewThreads, manualReviewThreads } from "../review-thread-reporting";
 import { mergeConflictDetected } from "../supervisor/supervisor-reporting";
 import type { PrLifecycleFactInventory } from "./pr-lifecycle-state";
@@ -467,17 +468,36 @@ function mergeReadyBlockedByFinalGuard(args: {
 
   const autoMergePath = autoMergePathForConfig(args.config);
   const requiresCodexNoMajor = autoMergePath === "codex_connector_no_major";
+  const verifiedCurrentHeadRepairResidue = hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+    config: args.config,
+    record: args.record,
+    pr: args.pr,
+    checks: args.checks,
+    reviewThreads: args.reviewThreads,
+  });
   const currentHeadCodexNoMajor =
-    hasCurrentHeadCodexNoMajor(args.record, args.pr) ||
-    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
-      config: args.config,
-      record: args.record,
-      pr: args.pr,
-      checks: args.checks,
-      reviewThreads: args.reviewThreads,
-    });
+    hasCurrentHeadCodexNoMajor(args.record, args.pr) || verifiedCurrentHeadRepairResidue;
+  const effectiveConfiguredBotBlockers = effectiveConfiguredBotReviewThreadsForState(
+    args.config,
+    args.record,
+    args.pr,
+    args.checks,
+    args.reviewThreads,
+  ).length;
+  const effectiveHumanBlockers = args.config.humanReviewBlocksMerge
+    ? manualReviewThreads(args.config, args.reviewThreads).length
+    : 0;
 
-  if (args.config.humanReviewBlocksMerge && isBlockingHumanReviewDecision(args.pr, requiresCodexNoMajor)) {
+  if (
+    aggregateHumanReviewDecisionBlocker({
+      humanReviewBlocksMerge: Boolean(args.config.humanReviewBlocksMerge),
+      requiresCodexNoMajor,
+      verifiedCurrentHeadRepairResidue,
+      effectiveConfiguredBotBlockerCount: effectiveConfiguredBotBlockers,
+      effectiveHumanBlockerCount: effectiveHumanBlockers,
+      pr: args.pr,
+    })
+  ) {
     return true;
   }
 
@@ -489,13 +509,7 @@ function mergeReadyBlockedByFinalGuard(args: {
     return true;
   }
 
-  return effectiveConfiguredBotReviewThreadsForState(
-    args.config,
-    args.record,
-    args.pr,
-    args.checks,
-    args.reviewThreads,
-  ).length > 0;
+  return effectiveConfiguredBotBlockers > 0;
 }
 
 type V2AutoMergePath = "codex_connector_no_major" | "configured_bot_provider" | null;
@@ -507,14 +521,6 @@ function autoMergePathForConfig(config: SupervisorConfig): V2AutoMergePath {
   }
 
   return config.codexConnectorAutoMergeEnabled === true ? "codex_connector_no_major" : null;
-}
-
-function isBlockingHumanReviewDecision(pr: GitHubPullRequest, requiresCodexNoMajor: boolean): boolean {
-  return (
-    pr.reviewDecision === "REVIEW_REQUIRED" ||
-    (pr.reviewDecision === "CHANGES_REQUESTED" &&
-      (requiresCodexNoMajor || pr.configuredBotTopLevelReviewStrength !== "nitpick_only"))
-  );
 }
 
 function hasCurrentHeadCodexNoMajor(record: IssueRunRecord, pr: GitHubPullRequest): boolean {

--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -78,6 +78,7 @@ const EXPECTED_TOP_LEVEL_ENTRIES = {
     "recovery-workspace-reconciliation.ts",
     "remediation-targets.ts",
     "requirements-blocker-issue-comment.ts",
+    "review-decision-blocking-policy.ts",
     "review-handling.ts",
     "review-role-detector.ts",
     "review-thread-reporting.ts",

--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -28,6 +28,7 @@ const EXPECTED_TOP_LEVEL_ENTRIES = {
     "committed-guardrails.ts",
     "conversation-resolution-blocker-diagnostics.ts",
     "conversation-resolution-policy.ts",
+    "current-head-codex-repair-proof.ts",
     "decision-kernel-v2.ts",
     "diagnostics-dto.ts",
     "doctor.ts",

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -34,6 +34,9 @@ export interface PullRequestCopilotReviewLifecycleResponse {
     } | null>;
   } | null;
   reviews?: {
+    pageInfo?: {
+      hasPreviousPage?: boolean | null;
+    } | null;
     nodes?: Array<{
       author?: {
         login?: string | null;
@@ -230,6 +233,7 @@ export function mapCopilotReviewLifecycleFacts(
   lifecycle: PullRequestCopilotReviewLifecycleResponse | null | undefined,
 ): CopilotReviewLifecycleFacts {
   return {
+    reviewsComplete: lifecycle?.reviews?.pageInfo?.hasPreviousPage === true ? false : true,
     reviewRequests:
       lifecycle?.reviewRequests?.nodes
         ?.map((node) => extractReviewerLogin(node?.requestedReviewer))

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -364,5 +364,6 @@ export function applyConfiguredBotReviewSummary(
     configuredBotDraftSkipAt: summary?.draftSkipAt ?? null,
     configuredBotTopLevelReviewStrength: summary?.topLevelReview.strength ?? null,
     configuredBotTopLevelReviewSubmittedAt: summary?.topLevelReview.submittedAt ?? null,
+    configuredBotOnlyChangesRequestedReview: summary?.topLevelReview.configuredBotOnlyChangesRequestedReview ?? null,
   };
 }

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -191,6 +191,9 @@ export class GitHubPullRequestHydrator {
               }
             }
             reviews(last: 100) {
+              pageInfo {
+                hasPreviousPage
+              }
               nodes {
                 submittedAt
                 state

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -538,6 +538,65 @@ test("buildConfiguredBotReviewSummary marks aggregate changes requested as confi
   assert.equal(summary.topLevelReview.configuredBotOnlyChangesRequestedReview, true);
 });
 
+test("buildConfiguredBotReviewSummary does not prove bot-only changes requested from a truncated review window", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewsComplete: false,
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:04:00Z",
+        state: "CHANGES_REQUESTED",
+        body: "Nitpick: rename this helper for consistency.",
+      },
+    ],
+    comments: [],
+    issueComments: [],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"]);
+
+  assert.deepEqual(summary.topLevelReview, {
+    strength: "nitpick_only",
+    submittedAt: "2026-03-13T02:04:00Z",
+  });
+  assert.equal(summary.topLevelReview.configuredBotOnlyChangesRequestedReview, null);
+});
+
+test("buildConfiguredBotReviewSummary keeps human changes requested active across comment-only follow-up reviews", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "octocat",
+        submittedAt: "2026-03-13T02:02:00Z",
+        state: "CHANGES_REQUESTED",
+        body: "Please address these concerns.",
+      },
+      {
+        authorLogin: "octocat",
+        submittedAt: "2026-03-13T02:03:00Z",
+        state: "COMMENTED",
+        body: "Thanks for the update; still reviewing.",
+      },
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:04:00Z",
+        state: "CHANGES_REQUESTED",
+        body: "Nitpick: rename this helper for consistency.",
+      },
+    ],
+    comments: [],
+    issueComments: [],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"]);
+
+  assert.equal(summary.topLevelReview.configuredBotOnlyChangesRequestedReview, false);
+});
+
 test("buildConfiguredBotReviewSummary treats configured-bot rate limit issue comments as a temporary requested state", () => {
   const facts: CopilotReviewLifecycleFacts = {
     reviewRequests: [],

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -480,7 +480,8 @@ test("buildConfiguredBotReviewSummary keeps top-level review strength scoped to 
     timeline: [],
   };
 
-  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"]), {
+  const summary = buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"]);
+  assert.deepEqual(summary, {
     lifecycle: {
       state: "arrived",
       requestedAt: null,
@@ -497,6 +498,44 @@ test("buildConfiguredBotReviewSummary keeps top-level review strength scoped to 
     rateLimitWarningAt: null,
     draftSkipAt: null,
   });
+  assert.equal(summary.topLevelReview.configuredBotOnlyChangesRequestedReview, false);
+});
+
+test("buildConfiguredBotReviewSummary marks aggregate changes requested as configured-bot-only when no human blocker remains", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "octocat",
+        submittedAt: "2026-03-13T02:02:00Z",
+        state: "CHANGES_REQUESTED",
+        body: "Please address these concerns.",
+      },
+      {
+        authorLogin: "octocat",
+        submittedAt: "2026-03-13T02:03:00Z",
+        state: "APPROVED",
+        body: "Looks good now.",
+      },
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:04:00Z",
+        state: "CHANGES_REQUESTED",
+        body: "Nitpick: rename this helper for consistency.",
+      },
+    ],
+    comments: [],
+    issueComments: [],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"]);
+
+  assert.deepEqual(summary.topLevelReview, {
+    strength: "nitpick_only",
+    submittedAt: "2026-03-13T02:04:00Z",
+  });
+  assert.equal(summary.topLevelReview.configuredBotOnlyChangesRequestedReview, true);
 });
 
 test("buildConfiguredBotReviewSummary treats configured-bot rate limit issue comments as a temporary requested state", () => {

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -69,6 +69,7 @@ export interface CopilotReviewLifecycle {
 export interface ConfiguredBotTopLevelReviewSummary {
   strength: "nitpick_only" | "blocking" | null;
   submittedAt: string | null;
+  configuredBotOnlyChangesRequestedReview?: boolean | null;
 }
 
 export interface ConfiguredBotReviewSummary {
@@ -494,6 +495,39 @@ function inferConfiguredBotTopLevelReviewSummary(
   return latestConfiguredReview;
 }
 
+function inferConfiguredBotOnlyChangesRequestedReview(
+  facts: CopilotReviewLifecycleFacts,
+  reviewBotLogins: string[],
+): boolean | null {
+  const configuredReviewBots = new Set(normalizeReviewBotLogins(reviewBotLogins));
+  if (configuredReviewBots.size === 0) {
+    return null;
+  }
+
+  const latestReviewsByAuthor = new Map<string, { submittedAtMs: number; state: string | null }>();
+  for (const review of facts.reviews) {
+    const authorLogin = normalizeLogin(review.authorLogin);
+    if (!authorLogin) {
+      continue;
+    }
+
+    const submittedAtMs = parseTimestamp(review.submittedAt);
+    const existing = latestReviewsByAuthor.get(authorLogin);
+    if (!existing || submittedAtMs >= existing.submittedAtMs) {
+      latestReviewsByAuthor.set(authorLogin, { submittedAtMs, state: normalizeLogin(review.state)?.replace(/\s+/g, "_") ?? null });
+    }
+  }
+
+  const changesRequestedAuthors = Array.from(latestReviewsByAuthor.entries())
+    .filter(([, review]) => review.state === "changes_requested")
+    .map(([authorLogin]) => authorLogin);
+  if (changesRequestedAuthors.length === 0) {
+    return null;
+  }
+
+  return changesRequestedAuthors.every((authorLogin) => configuredReviewBots.has(authorLogin));
+}
+
 function reviewedCommitFromBody(body: string | null | undefined): string | null {
   const match = body?.match(/\bReviewed commit:\s*([0-9a-f]{7,40})\b/i);
   return match?.[1] ?? null;
@@ -808,9 +842,14 @@ export function buildConfiguredBotReviewSummary(
   codexConnectorReviewRequestIdentity?: CodexConnectorReviewRequestIdentity | null,
 ): ConfiguredBotReviewSummary {
   const currentHeadObservation = inferConfiguredBotCurrentHeadObservation(facts, reviewBotLogins, currentHeadOid);
+  const topLevelReview = inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins);
+  Object.defineProperty(topLevelReview, "configuredBotOnlyChangesRequestedReview", {
+    enumerable: false,
+    value: inferConfiguredBotOnlyChangesRequestedReview(facts, reviewBotLogins),
+  });
   const summary = {
     lifecycle: inferCopilotReviewLifecycle(facts, reviewBotLogins),
-    topLevelReview: inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins),
+    topLevelReview,
     ...(codexConnectorReviewRequestIdentity
       ? {
           codexConnectorReviewRequest: findCodexConnectorReviewRequest(facts.issueComments, codexConnectorReviewRequestIdentity),

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -13,6 +13,7 @@ import {
 import type { CopilotReviewState } from "./types";
 
 export interface CopilotReviewLifecycleFacts {
+  reviewsComplete?: boolean;
   reviewRequests: string[];
   reviews: Array<{
     authorLogin: string | null;
@@ -495,6 +496,10 @@ function inferConfiguredBotTopLevelReviewSummary(
   return latestConfiguredReview;
 }
 
+function normalizeReviewState(state: string | null | undefined): string | null {
+  return normalizeLogin(state)?.replace(/\s+/g, "_") ?? null;
+}
+
 function inferConfiguredBotOnlyChangesRequestedReview(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
@@ -503,29 +508,43 @@ function inferConfiguredBotOnlyChangesRequestedReview(
   if (configuredReviewBots.size === 0) {
     return null;
   }
+  if (facts.reviewsComplete === false) {
+    return null;
+  }
 
-  const latestReviewsByAuthor = new Map<string, { submittedAtMs: number; state: string | null }>();
-  for (const review of facts.reviews) {
+  const changesRequestedAuthors = new Set<string>();
+  const chronologicalReviews = facts.reviews
+    .map((review, index) => ({
+      ...review,
+      index,
+      submittedAtMs: parseTimestamp(review.submittedAt),
+      state: normalizeReviewState(review.state),
+    }))
+    .sort((left, right) =>
+      left.submittedAtMs === right.submittedAtMs ? left.index - right.index : left.submittedAtMs - right.submittedAtMs,
+    );
+
+  for (const review of chronologicalReviews) {
     const authorLogin = normalizeLogin(review.authorLogin);
     if (!authorLogin) {
       continue;
     }
 
-    const submittedAtMs = parseTimestamp(review.submittedAt);
-    const existing = latestReviewsByAuthor.get(authorLogin);
-    if (!existing || submittedAtMs >= existing.submittedAtMs) {
-      latestReviewsByAuthor.set(authorLogin, { submittedAtMs, state: normalizeLogin(review.state)?.replace(/\s+/g, "_") ?? null });
+    if (review.state === "changes_requested") {
+      changesRequestedAuthors.add(authorLogin);
+      continue;
+    }
+
+    if (review.state === "approved" || review.state === "dismissed") {
+      changesRequestedAuthors.delete(authorLogin);
     }
   }
 
-  const changesRequestedAuthors = Array.from(latestReviewsByAuthor.entries())
-    .filter(([, review]) => review.state === "changes_requested")
-    .map(([authorLogin]) => authorLogin);
-  if (changesRequestedAuthors.length === 0) {
+  if (changesRequestedAuthors.size === 0) {
     return null;
   }
 
-  return changesRequestedAuthors.every((authorLogin) => configuredReviewBots.has(authorLogin));
+  return Array.from(changesRequestedAuthors).every((authorLogin) => configuredReviewBots.has(authorLogin));
 }
 
 function reviewedCommitFromBody(body: string | null | undefined): string | null {

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -47,6 +47,7 @@ export interface GitHubPullRequest {
   configuredBotDraftSkipAt?: string | null;
   configuredBotTopLevelReviewStrength?: "nitpick_only" | "blocking" | null;
   configuredBotTopLevelReviewSubmittedAt?: string | null;
+  configuredBotOnlyChangesRequestedReview?: boolean | null;
   requiredConversationResolution?: {
     state: "enabled" | "disabled" | "unavailable" | "unknown";
     source?: string | null;

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -36,11 +36,10 @@ import {
   summarizeChecks,
 } from "./supervisor/supervisor-reporting";
 import {
-  buildStaleReviewBotThreadDiagnostics,
   buildStaleReviewBotRemediation,
-  hasCurrentHeadVerifiedRepairResidueArtifact,
   isProvenStaleReviewMetadataClassification,
 } from "./supervisor/stale-review-bot-remediation";
+import { projectCurrentHeadCodexRepairProof } from "./current-head-codex-repair-proof";
 import {
   configuredBotCurrentHeadSignalPending,
   copilotReviewPending,
@@ -52,24 +51,6 @@ import {
 function isIssueJournalThreadPath(thread: Pick<ReviewThread, "path">): boolean {
   const normalizedPath = thread.path?.replace(/\\/g, "/") ?? "";
   return /^\.codex-supervisor\/.+\/issue-journal\.md$/.test(normalizedPath);
-}
-
-function checksPresentAndGreen(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
-  return checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
-}
-
-function configuredReviewProvidersAreCodexOnly(config: SupervisorConfig): boolean {
-  const providerKinds = configuredReviewProviderKinds(config);
-  return providerKinds.length > 0 && providerKinds.every((kind) => kind === "codex");
-}
-
-function unresolvedConfiguredBotThreadsAreCodexConnectorOnly(
-  config: SupervisorConfig,
-  reviewThreads: ReviewThread[],
-): boolean {
-  return configuredBotReviewThreads(config, reviewThreads)
-    .filter((thread) => !thread.isResolved)
-    .every(hasCodexConnectorFindingReviewComment);
 }
 
 function allowJournalOnlyConfiguredBotThreadException(
@@ -335,51 +316,7 @@ export function hasVerifiedCurrentHeadRepairReviewMetadataResidue(args: {
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
 }): boolean {
-  if (args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve !== true) {
-    return false;
-  }
-
-  if (!checksPresentAndGreen(args.checks)) {
-    return false;
-  }
-
-  if (!configuredReviewProvidersAreCodexOnly(args.config)) {
-    return false;
-  }
-
-  if (
-    pullRequestHeadMatchesRecord(args.record, args.pr) &&
-    codexConnectorMustFixReviewThreads(args.reviewThreads).length === 0 &&
-    unresolvedConfiguredBotThreadsAreCodexConnectorOnly(args.config, args.reviewThreads) &&
-    hasCurrentHeadVerifiedRepairResidueArtifact(args.record, args.pr)
-  ) {
-    return true;
-  }
-
-  const recordForClassification = recordForCodexStaleReviewMetadataClassification(args);
-  if (!recordForClassification) {
-    return false;
-  }
-
-  const remediation = buildStaleReviewBotRemediation({
-    config: args.config,
-    record: recordForClassification,
-    pr: args.pr,
-    checks: args.checks,
-    reviewThreads: args.reviewThreads,
-  });
-  if (remediation?.classification !== "verified_current_head_repair_pending_thread_resolution") {
-    return false;
-  }
-
-  const diagnostics = buildStaleReviewBotThreadDiagnostics({
-    config: args.config,
-    record: recordForClassification,
-    pr: args.pr,
-    checks: args.checks,
-    reviewThreads: args.reviewThreads,
-  });
-  return diagnostics?.autoRepairSuppressedReason === "none";
+  return projectCurrentHeadCodexRepairProof(args) !== null;
 }
 
 function configuredBotThreadsAllowCodexConnectorCurrentHeadWait(args: {

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -319,6 +319,25 @@ export function hasVerifiedCurrentHeadRepairReviewMetadataResidue(args: {
   return projectCurrentHeadCodexRepairProof(args) !== null;
 }
 
+export function currentHeadRepairProofSatisfiesConfiguredProviderSignal(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): boolean {
+  const proof = projectCurrentHeadCodexRepairProof(args);
+  if (!proof) {
+    return false;
+  }
+
+  if (!configuredBotCurrentHeadSignalPending(args.config, args.record, args.pr)) {
+    return true;
+  }
+
+  return proof.currentConfiguredThreadCount > 0;
+}
+
 function configuredBotThreadsAllowCodexConnectorCurrentHeadWait(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -350,7 +369,7 @@ export function shouldWaitForCodexConnectorCurrentHeadReview(args: {
   unresolvedBotThreads: ReviewThread[];
   nowMs: number;
 }): boolean {
-  if (hasVerifiedCurrentHeadRepairReviewMetadataResidue(args)) {
+  if (currentHeadRepairProofSatisfiesConfiguredProviderSignal(args)) {
     return false;
   }
 
@@ -447,7 +466,7 @@ export function hasConfiguredProviderSuccess(
   }
 
   if (
-    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+    currentHeadRepairProofSatisfiesConfiguredProviderSignal({
       config,
       record,
       pr,

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -22,6 +22,7 @@ import {
   createCodexConnectorTrackedReviewResidueScenario,
 } from "./codex-connector-tracked-pr-test-helpers";
 import {
+  currentHeadRepairProofSatisfiesConfiguredProviderSignal,
   hasConfiguredProviderSuccess,
   hasVerifiedCurrentHeadRepairReviewMetadataResidue,
 } from "./pull-request-state-codex-residue-policy";
@@ -777,6 +778,164 @@ test("legacy current-head processed-thread repair proof can replace Codex no-maj
   );
   assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), "ready_to_merge");
   assert.equal(hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), true);
+});
+
+test("legacy current-head repair proof does not satisfy GitHub review-required decisions", () => {
+  const issueNumber = 2375;
+  const prNumber = 399;
+  const headSha = "02642468db1df175a92ec8d332fdf64e7754a3ab";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_review_required_residue",
+    commentId: "PRRC_review_required_residue",
+    path: "web/src/App.tsx",
+    line: 912,
+    severity: "P2",
+    commentBody: "P2: Require termination code fields before submit.",
+    discussionUrl: "https://example.test/pr/399#discussion_r3409030368",
+    verifiedRepair: {
+      summary: "Verified current head addresses the review findings.",
+      ranAt: "2026-06-14T04:58:52.932Z",
+      command: "npm run verify:pre-pr",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: false,
+    codexConnectorAutoMergeEnabled: true,
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "verification",
+    last_failure_signature: `${headSha}:missing_current_head_codex_no_major`,
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI command passed before auto-merging PR #399.",
+      ran_at: "2026-06-14T04:59:01.275Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "npm run verify:pre-pr",
+      failure_class: null,
+      remediation_target: null,
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-14T05:12:43Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+    reviewDecision: "REVIEW_REQUIRED",
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [],
+    }),
+    true,
+  );
+  assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, []), "pr_open");
+});
+
+test("cleared legacy repair proof does not replace a required Codex current-head signal", () => {
+  const issueNumber = 2375;
+  const prNumber = 399;
+  const headSha = "03642468db1df175a92ec8d332fdf64e7754a3ab";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_wait_after_residue_cleanup",
+    commentId: "PRRC_wait_after_residue_cleanup",
+    path: "web/src/App.tsx",
+    line: 913,
+    severity: "P2",
+    commentBody: "P2: Require termination code fields before submit.",
+    discussionUrl: "https://example.test/pr/399#discussion_r3409030369",
+    verifiedRepair: {
+      summary: "Verified current head addresses the review findings.",
+      ranAt: "2026-06-14T04:58:52.932Z",
+      command: "npm run verify:pre-pr",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    codexConnectorAutoMergeEnabled: true,
+    localCiCommand: "npm run verify:pre-pr",
+    configuredBotRequireCurrentHeadSignal: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "verification",
+    last_failure_signature: `${headSha}:missing_current_head_codex_no_major`,
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI command passed before auto-merging PR #399.",
+      ran_at: "2026-06-14T04:59:01.275Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "npm run verify:pre-pr",
+      failure_class: null,
+      remediation_target: null,
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    currentHeadCiGreenAt: "2026-06-14T05:00:00Z",
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotCurrentHeadObservationSource: null,
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: null,
+  });
+  const nowMs = Date.parse("2026-06-14T05:00:30Z");
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [],
+    }),
+    true,
+  );
+  assert.equal(
+    currentHeadRepairProofSatisfiesConfiguredProviderSignal({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [],
+    }),
+    false,
+  );
+  assert.equal(
+    currentHeadRepairProofSatisfiesConfiguredProviderSignal({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    true,
+  );
+  assert.equal(hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, []), false);
+  assert.equal(inferGitHubWaitStep(config, record, pr, scenario.passingChecks, [], nowMs), "configured_bot_current_head_signal_wait");
+  assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [], nowMs), "waiting_ci");
 });
 
 test("legacy current-head processed-thread repair proof requires current-head no-major refusal evidence", () => {

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -965,6 +965,14 @@ test("cleared legacy repair proof does not replace a required Codex current-head
   assert.equal(hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, []), false);
   assert.equal(inferGitHubWaitStep(config, record, pr, scenario.passingChecks, [], nowMs), "configured_bot_current_head_signal_wait");
   assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [], nowMs), "waiting_ci");
+  assert.equal(
+    inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [], Date.parse("2026-06-14T05:11:00Z")),
+    "blocked",
+  );
+  assert.equal(
+    blockedReasonFromReviewState(config, record, pr, scenario.passingChecks, [], Date.parse("2026-06-14T05:11:00Z")),
+    "review_bot_timeout",
+  );
 });
 
 test("legacy current-head processed-thread repair proof requires current-head no-major refusal evidence", () => {
@@ -1535,6 +1543,100 @@ test("current-head repair proof ignores non-blocking P3 nitpicks while rejecting
       pr,
       checks: scenario.passingChecks,
       reviewThreads: [scenario.reviewThread, p3EscalatedThread],
+    }),
+    false,
+  );
+});
+
+test("current-head repair proof rejects unresolved outdated high-severity Codex residue", () => {
+  const issueNumber = 2376;
+  const prNumber = 406;
+  const headSha = "7f1f51ea7ff5f861ae7dc7c8b43892ea20f5c406";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-p2-repaired-with-outdated-p1",
+    commentId: "comment-p2-repaired-with-outdated-p1",
+    path: "src/current-head-proof.ts",
+    line: 71,
+    severity: "P2",
+    commentBody: "P2: This repaired thread has structured proof.",
+    discussionUrl: "https://example.test/pr/406#discussion_r406",
+    verifiedRepair: {
+      summary: "Verified current head addresses the P2 review finding.",
+      ranAt: "2026-06-14T05:25:00Z",
+      command: "npm run verify:pre-pr",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const outdatedP1Thread = createReviewThread({
+    id: "thread-outdated-p1",
+    isOutdated: true,
+    path: "src/current-head-proof.ts",
+    line: 73,
+    comments: {
+      nodes: [
+        {
+          id: "comment-outdated-p1",
+          body: "P1: This unresolved stale finding still represents high-severity residue.",
+          createdAt: "2026-06-14T05:24:00Z",
+          url: "https://example.test/pr/406#discussion_r407",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run verify:pre-pr",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head repair verifier passed for the P2 finding.",
+        recorded_at: "2026-06-14T05:25:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [
+          `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+        ],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    true,
+  );
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread, outdatedP1Thread],
     }),
     false,
   );

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -1240,6 +1240,80 @@ test("verified current-head repair artifact accepts id-only scoped coverage when
   );
 });
 
+test("verified current-head repair artifact rejects id-only coverage after newer thread comments", () => {
+  const issueNumber = 2376;
+  const prNumber = 404;
+  const headSha = "5f1f51ea7ff5f861ae7dc7c8b43892ea20f5404";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-artifact-id-only-newer-comment",
+    commentId: "comment-artifact-id-only-original",
+    path: "src/current-head-proof.ts",
+    line: 59,
+    severity: "P2",
+    commentBody: "P2: Artifact id-only coverage should not prove a later reply.",
+    discussionUrl: "https://example.test/pr/404#discussion_r405",
+  });
+  const updatedThread = {
+    ...scenario.reviewThread,
+    comments: {
+      nodes: [
+        ...scenario.reviewThread.comments.nodes,
+        {
+          id: "comment-artifact-id-only-follow-up",
+          body: "P2: The current head still needs another repair.",
+          createdAt: "2026-06-14T05:16:00Z",
+          url: "https://example.test/pr/404#discussion_r406",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot" as const,
+          },
+        },
+      ],
+    },
+  };
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm test -- src/current-head-proof.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head repair verifier passed before fingerprints existed.",
+        recorded_at: "2026-06-14T05:15:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [updatedThread],
+    }),
+    false,
+  );
+});
+
 test("current-head repair proof ignores non-blocking P3 nitpicks while rejecting escalated P3 blockers", () => {
   const issueNumber = 2376;
   const prNumber = 405;

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -747,6 +747,35 @@ test("legacy current-head processed-thread repair proof can replace Codex no-maj
       checks: scenario.passingChecks,
       reviewThreads: [scenario.reviewThread],
     }),
+    false,
+  );
+  assert.notEqual(
+    inferStateFromPullRequest(
+      config,
+      record,
+      createPullRequest({
+        ...pr,
+        reviewDecision: "CHANGES_REQUESTED",
+        configuredBotTopLevelReviewStrength: "blocking",
+      }),
+      scenario.passingChecks,
+      [scenario.reviewThread],
+    ),
+    "ready_to_merge",
+  );
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr: createPullRequest({
+        ...pr,
+        reviewDecision: "CHANGES_REQUESTED",
+        configuredBotTopLevelReviewStrength: "blocking",
+        configuredBotOnlyChangesRequestedReview: true,
+      }),
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
     true,
   );
   assert.equal(
@@ -1181,6 +1210,97 @@ test("verified current-head repair artifact must cover current unresolved thread
       reviewThreads: [uncoveredThread],
     }),
     false,
+  );
+});
+
+test("verified current-head repair artifact searches later artifacts for current-thread coverage", () => {
+  const issueNumber = 2376;
+  const prNumber = 401;
+  const headSha = "2f1f51ea7ff5f861ae7dc7c8b43892ea20f5d401";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-artifact-later-covered",
+    commentId: "comment-artifact-later-covered",
+    path: "src/current-head-proof.ts",
+    line: 52,
+    severity: "P2",
+    commentBody: "P2: This current-head thread needs the later artifact.",
+    discussionUrl: "https://example.test/pr/401#discussion_r403",
+  });
+  const staleThread = createReviewThread({
+    id: "thread-artifact-stale",
+    path: "src/current-head-proof.ts",
+    line: 50,
+    comments: {
+      nodes: [
+        {
+          id: "comment-artifact-stale",
+          body: "P2: This older finding was verified first.",
+          createdAt: "2026-06-14T04:50:00Z",
+          url: "https://example.test/pr/401#discussion_r400",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm test -- src/current-head-proof.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Only the stale current-head thread was verified.",
+        recorded_at: "2026-06-14T05:03:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${staleThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [`${staleThread.id}@${headSha}#${staleThread.comments.nodes[0]?.id}`],
+      },
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm test -- src/current-head-proof.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "The current P2 thread was verified by a later artifact.",
+        recorded_at: "2026-06-14T05:05:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [
+          `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+        ],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    true,
   );
 });
 

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -810,6 +810,78 @@ test("legacy current-head processed-thread repair proof requires current-head no
   );
 });
 
+test("legacy current-head processed-thread repair proof requires scoped verifier evidence", () => {
+  const issueNumber = 2376;
+  const prNumber = 403;
+  const headSha = "4f1f51ea7ff5f861ae7dc7c8b43892ea20f5c403";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-legacy-unscoped-verifier",
+    commentId: "comment-legacy-unscoped-verifier",
+    path: "src/current-head-proof.ts",
+    line: 57,
+    severity: "P2",
+    commentBody: "P2: Legacy proof must be scoped to this finding.",
+    discussionUrl: "https://example.test/pr/403#discussion_r403",
+    verifiedRepair: {
+      summary: "A generic verifier passed on this head before the review finding.",
+      ranAt: "2026-06-14T05:12:00Z",
+      command: "npm run verify:pre-pr",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "verification",
+    last_failure_signature: `auto-merge-refused:${headSha}:missing_current_head_codex_no_major`,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run verify:pre-pr",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "A generic verifier passed on this head before the review finding.",
+        recorded_at: "2026-06-14T05:12:00Z",
+      },
+    ],
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI command passed before auto-merging PR #403.",
+      ran_at: "2026-06-14T05:13:00Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "npm run verify:pre-pr",
+      failure_class: null,
+      remediation_target: null,
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    false,
+  );
+});
+
 test("verified current-head repair artifact must cover current unresolved threads", () => {
   const issueNumber = 2376;
   const prNumber = 401;

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -727,6 +727,44 @@ test("legacy current-head processed-thread repair proof can replace Codex no-maj
   assert.equal(
     hasVerifiedCurrentHeadRepairReviewMetadataResidue({
       config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [],
+    }),
+    true,
+  );
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr: createPullRequest({
+        ...pr,
+        reviewDecision: "CHANGES_REQUESTED",
+        configuredBotTopLevelReviewStrength: "blocking",
+      }),
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    true,
+  );
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr: createPullRequest({
+        ...pr,
+        reviewDecision: "CHANGES_REQUESTED",
+        configuredBotTopLevelReviewStrength: null,
+      }),
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    false,
+  );
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
       record: createRecord({
         ...record,
         latest_local_ci_result: null,
@@ -805,6 +843,26 @@ test("legacy current-head processed-thread repair proof requires current-head no
       pr,
       checks: scenario.passingChecks,
       reviewThreads: [scenario.reviewThread],
+    }),
+    false,
+  );
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [],
+    }),
+    false,
+  );
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [],
     }),
     false,
   );

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -967,6 +967,168 @@ test("verified current-head repair artifact must cover current unresolved thread
   );
 });
 
+test("verified current-head repair artifact accepts id-only scoped coverage when no artifact fingerprint exists", () => {
+  const issueNumber = 2376;
+  const prNumber = 404;
+  const headSha = "5f1f51ea7ff5f861ae7dc7c8b43892ea20f5c404";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-artifact-id-only",
+    commentId: "comment-artifact-id-only",
+    path: "src/current-head-proof.ts",
+    line: 59,
+    severity: "P2",
+    commentBody: "P2: Artifact id-only coverage should still prove this repaired thread.",
+    discussionUrl: "https://example.test/pr/404#discussion_r404",
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm test -- src/current-head-proof.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head repair verifier passed before fingerprints existed.",
+        recorded_at: "2026-06-14T05:15:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    true,
+  );
+});
+
+test("current-head repair proof ignores non-blocking P3 nitpicks while rejecting escalated P3 blockers", () => {
+  const issueNumber = 2376;
+  const prNumber = 405;
+  const headSha = "6f1f51ea7ff5f861ae7dc7c8b43892ea20f5c405";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-p2-repaired-with-p3-nitpick",
+    commentId: "comment-p2-repaired-with-p3-nitpick",
+    path: "src/current-head-proof.ts",
+    line: 61,
+    severity: "P2",
+    commentBody: "P2: This repaired thread should remain covered by the proof.",
+    discussionUrl: "https://example.test/pr/405#discussion_r405",
+  });
+  const p3NitpickThread = createReviewThread({
+    id: "thread-p3-nitpick",
+    path: "src/current-head-proof.ts",
+    line: 63,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p3-nitpick",
+          body: "P3: Consider renaming this helper for clarity.",
+          createdAt: "2026-06-14T05:18:00Z",
+          url: "https://example.test/pr/405#discussion_r406",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const p3EscalatedThread = createReviewThread({
+    id: "thread-p3-escalated",
+    path: "src/current-head-proof.ts",
+    line: 65,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p3-escalated",
+          body: "P3: Missing verification risks a regression.",
+          createdAt: "2026-06-14T05:19:00Z",
+          url: "https://example.test/pr/405#discussion_r407",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm test -- src/current-head-proof.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head repair verifier passed for the P2 finding.",
+        recorded_at: "2026-06-14T05:20:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [
+          `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+        ],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread, p3NitpickThread],
+    }),
+    true,
+  );
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread, p3EscalatedThread],
+    }),
+    false,
+  );
+});
+
 test("current-head repair proof rejects configured bot threads updated by humans", () => {
   const issueNumber = 2376;
   const prNumber = 402;

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -741,6 +741,239 @@ test("legacy current-head processed-thread repair proof can replace Codex no-maj
   assert.equal(hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), true);
 });
 
+test("legacy current-head processed-thread repair proof requires current-head no-major refusal evidence", () => {
+  const issueNumber = 2376;
+  const prNumber = 400;
+  const headSha = "01642468db1df175a92ec8d332fdf64e7754a3ab";
+  const oldHeadSha = "old1642468db1df175a92ec8d332fdf64e7754a3";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_legacy_old_head_refusal",
+    commentId: "PRRC_legacy_old_head_refusal",
+    path: "web/src/App.tsx",
+    line: 912,
+    severity: "P2",
+    commentBody: "P2: Require current-head no-major refusal evidence.",
+    discussionUrl: "https://example.test/pr/400#discussion_r400",
+    verifiedRepair: {
+      summary: "Verified current head addresses the review findings.",
+      ranAt: "2026-06-14T04:58:52.932Z",
+      command: "npm run verify:pre-pr",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "verification",
+    last_failure_signature: `auto-merge-refused:${oldHeadSha}:missing_current_head_codex_no_major`,
+    last_failure_context: {
+      category: "blocked",
+      summary: "Old auto-merge guard refusal should not prove the current head.",
+      signature: `auto-merge-refused:${oldHeadSha}:missing_current_head_codex_no_major`,
+      command: null,
+      details: ["missing_current_head_codex_no_major"],
+      url: null,
+      updated_at: "2026-06-14T04:59:01.275Z",
+    },
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI command passed before auto-merging PR #400.",
+      ran_at: "2026-06-14T04:59:01.275Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "npm run verify:pre-pr",
+      failure_class: null,
+      remediation_target: null,
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    false,
+  );
+});
+
+test("verified current-head repair artifact must cover current unresolved threads", () => {
+  const issueNumber = 2376;
+  const prNumber = 401;
+  const headSha = "2f1f51ea7ff5f861ae7dc7c8b43892ea20f5c401";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-artifact-covered",
+    commentId: "comment-artifact-covered",
+    path: "src/current-head-proof.ts",
+    line: 52,
+    severity: "P2",
+    commentBody: "P2: This older current-head thread was covered by the artifact.",
+    discussionUrl: "https://example.test/pr/401#discussion_r401",
+  });
+  const uncoveredThread = createReviewThread({
+    id: "thread-artifact-uncovered",
+    path: "src/current-head-proof.ts",
+    line: 54,
+    comments: {
+      nodes: [
+        {
+          id: "comment-artifact-uncovered",
+          body: "P2: This newer current-head thread still needs explicit proof.",
+          createdAt: "2026-06-14T05:02:00Z",
+          url: "https://example.test/pr/401#discussion_r402",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    processed_review_thread_ids: [
+      `${scenario.reviewThread.id}@${headSha}`,
+      `${uncoveredThread.id}@${headSha}`,
+    ],
+    processed_review_thread_fingerprints: [
+      `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+      `${uncoveredThread.id}@${headSha}#${uncoveredThread.comments.nodes[0]?.id}`,
+    ],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm test -- src/current-head-proof.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Only the older current-head thread was verified.",
+        recorded_at: "2026-06-14T05:03:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [
+          `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+        ],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [uncoveredThread],
+    }),
+    false,
+  );
+});
+
+test("current-head repair proof rejects configured bot threads updated by humans", () => {
+  const issueNumber = 2376;
+  const prNumber = 402;
+  const headSha = "3f1f51ea7ff5f861ae7dc7c8b43892ea20f5c402";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-human-updated",
+    commentId: "comment-human-updated-codex",
+    path: "src/current-head-proof.ts",
+    line: 55,
+    severity: "P2",
+    commentBody: "P2: Codex opened this finding.",
+    discussionUrl: "https://example.test/pr/402#discussion_r402",
+    verifiedRepair: {
+      summary: "Verified current head addresses the review findings.",
+      ranAt: "2026-06-14T05:08:00Z",
+      command: "npm run verify:pre-pr",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const humanUpdatedThread = {
+    ...scenario.reviewThread,
+    comments: {
+      nodes: [
+        ...scenario.reviewThread.comments.nodes,
+        {
+          id: "comment-human-updated-human",
+          body: "I still need to inspect this manually.",
+          createdAt: "2026-06-14T05:09:00Z",
+          url: "https://example.test/pr/402#discussion_r403",
+          author: {
+            login: "human-reviewer",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  };
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "verification",
+    last_failure_signature: `auto-merge-refused:${headSha}:missing_current_head_codex_no_major`,
+    processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [],
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI command passed before auto-merging PR #402.",
+      ran_at: "2026-06-14T05:10:00Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "npm run verify:pre-pr",
+      failure_class: null,
+      remediation_target: null,
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadStatusState: null,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [humanUpdatedThread],
+    }),
+    false,
+  );
+});
+
 test("verified current-head repair artifact does not clear non-Codex configured bot blockers", () => {
   const issueNumber = 2101;
   const prNumber = 121;

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -609,7 +609,27 @@ test("verified current-head repair residue evidence can replace Codex no-major e
     configuredBotInitialGraceWaitSeconds: 0,
     verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
   });
-  const record = createRecord(scenario.recordPatch);
+  const record = createRecord({
+    ...scenario.recordPatch,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npx tsx --test src/pull-request-state-policy.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head verifier passed.",
+        recorded_at: "2026-05-15T00:18:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [
+          `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+        ],
+      },
+    ],
+  });
   const pr = createPullRequest({
     ...scenario.pullRequestPatch,
     configuredBotCurrentHeadObservedAt: "2026-05-15T00:17:00Z",
@@ -640,6 +660,85 @@ test("verified current-head repair residue evidence can replace Codex no-major e
   );
   assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, []), "ready_to_merge");
   assert.equal(inferGitHubWaitStep(config, record, pr, scenario.passingChecks, []), null);
+});
+
+test("legacy current-head processed-thread repair proof can replace Codex no-major evidence", () => {
+  const issueNumber = 2375;
+  const prNumber = 399;
+  const headSha = "01642468db1df175a92ec8d332fdf64e7754a3ab";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_hrcore_399_termination_code_fields",
+    commentId: "PRRC_hrcore_399_termination_code_fields",
+    path: "web/src/App.tsx",
+    line: 911,
+    severity: "P2",
+    commentBody: "P2: Require termination code fields before submit.",
+    discussionUrl: "https://example.test/pr/399#discussion_r3409030367",
+    verifiedRepair: {
+      summary: "Verified current head addresses the review findings.",
+      ranAt: "2026-06-14T04:58:52.932Z",
+      command: "npm run verify:pre-pr",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    codexConnectorAutoMergeEnabled: true,
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "verification",
+    last_failure_signature: `${headSha}:missing_current_head_codex_no_major`,
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI command passed before auto-merging PR #399.",
+      ran_at: "2026-06-14T04:59:01.275Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "npm run verify:pre-pr",
+      failure_class: null,
+      remediation_target: null,
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-14T05:12:43Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    true,
+  );
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record: createRecord({
+        ...record,
+        latest_local_ci_result: null,
+      }),
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    false,
+  );
+  assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), "ready_to_merge");
+  assert.equal(hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), true);
 });
 
 test("verified current-head repair artifact does not clear non-Codex configured bot blockers", () => {
@@ -871,6 +970,36 @@ test("verified current-head repair residue can rely on persisted auto-resolve pr
       pr,
       checks: scenario.passingChecks,
       reviewThreads: [scenario.reviewThread],
+    }),
+    true,
+  );
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [
+        createReviewThread({
+          id: "thread-current-head-repair-unprocessed",
+          path: "src/current-head-proof.ts",
+          line: 46,
+          comments: {
+            nodes: [
+              {
+                id: "comment-current-head-repair-unprocessed",
+                body: "P2: This new current-head finding still needs a repair.",
+                createdAt: "2026-05-15T00:22:00Z",
+                url: "https://example.test/pr/120#discussion_unprocessed",
+                author: {
+                  login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+                  typeName: "Bot",
+                },
+              },
+            ],
+          },
+        }),
+      ],
     }),
     false,
   );

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -217,6 +217,15 @@ export function blockedReasonFromReviewState(
     reviewThreads,
   });
   const configuredReviewMetadataSatisfied = provenCodexStaleReviewMetadata || verifiedCurrentHeadRepairResidue;
+  const configuredReviewMetadataWaitSatisfied =
+    provenCodexStaleReviewMetadata ||
+    currentHeadRepairProofSatisfiesConfiguredProviderSignal({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+    });
   const unresolvedBotThreads = effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads);
   const botReviewDecisionResidueSatisfied = verifiedConfiguredBotReviewDecisionResidueSatisfied({
     verifiedCurrentHeadRepairResidue,
@@ -240,7 +249,7 @@ export function blockedReasonFromReviewState(
   if (
     copilotTimeout.timedOut &&
     copilotTimeout.action === "block" &&
-    !configuredReviewMetadataSatisfied &&
+    !configuredReviewMetadataWaitSatisfied &&
     !staleCodexWaitHasOnlyOutdatedResidue
   ) {
     return "review_bot_timeout";

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -52,6 +52,7 @@ import {
 import { reviewLoopRetryBudgetExhaustedForThread } from "./review-handling";
 import {
   effectiveConfiguredBotReviewThreadsForState,
+  currentHeadRepairProofSatisfiesConfiguredProviderSignal,
   hasConfiguredProviderSuccess,
   hasProvenCodexConnectorStaleReviewMetadata,
   hasVerifiedCurrentHeadRepairReviewMetadataResidue,
@@ -310,6 +311,15 @@ export function inferStateFromPullRequest(
     reviewThreads,
   });
   const configuredReviewMetadataSatisfied = provenCodexStaleReviewMetadata || verifiedCurrentHeadRepairResidue;
+  const configuredReviewMetadataWaitSatisfied =
+    provenCodexStaleReviewMetadata ||
+    currentHeadRepairProofSatisfiesConfiguredProviderSignal({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+    });
   const unresolvedBotThreads = effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads);
   const botReviewDecisionResidueSatisfied = verifiedConfiguredBotReviewDecisionResidueSatisfied({
     verifiedCurrentHeadRepairResidue,
@@ -355,7 +365,7 @@ export function inferStateFromPullRequest(
   }
 
   if (
-    !configuredReviewMetadataSatisfied &&
+    !configuredReviewMetadataWaitSatisfied &&
     shouldWaitForCodexConnectorCurrentHeadReview({
       config,
       record,
@@ -587,7 +597,7 @@ export function inferStateFromPullRequest(
   if (
     copilotTimeout.timedOut &&
     copilotTimeout.action === "block" &&
-    !configuredReviewMetadataSatisfied &&
+    !configuredReviewMetadataWaitSatisfied &&
     !staleCodexWaitHasOnlyOutdatedResidue
   ) {
     return "blocked";
@@ -596,7 +606,7 @@ export function inferStateFromPullRequest(
   if (
     copilotTimeout.timedOut &&
     copilotTimeout.action === "request_review_comment" &&
-    !configuredReviewMetadataSatisfied &&
+    !configuredReviewMetadataWaitSatisfied &&
     !staleCodexWaitHasOnlyOutdatedResidue
   ) {
     return "waiting_ci";
@@ -619,7 +629,7 @@ export function inferStateFromPullRequest(
   }
 
   if (
-    !configuredReviewMetadataSatisfied &&
+    !configuredReviewMetadataWaitSatisfied &&
     !staleCodexWaitHasOnlyOutdatedResidue &&
     configuredBotCurrentHeadSignalPending(config, record, pr) &&
     !copilotTimeout.timedOut
@@ -687,7 +697,7 @@ export function inferGitHubWaitStep(
   const copilotTimeout = determineCopilotReviewTimeout(config, record, pr, nowMs);
   const staleCodexWaitHasOnlyOutdatedResidue =
     reviewThreads.length > 0 && staleSameHeadCodexWaitHasOnlyOutdatedResidue(config, record, pr, checks, reviewThreads);
-  const verifiedCurrentHeadRepairResidue = hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+  const verifiedCurrentHeadRepairResidue = currentHeadRepairProofSatisfiesConfiguredProviderSignal({
     config,
     record,
     pr,

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -59,6 +59,7 @@ import {
   shouldWaitForCodexConnectorCurrentHeadReview,
   staleSameHeadCodexWaitHasOnlyOutdatedResidue,
 } from "./pull-request-state-codex-residue-policy";
+import { verifiedConfiguredBotReviewDecisionResidueSatisfied } from "./review-decision-blocking-policy";
 import { displayLocalCiCommand } from "./core/config-parsing";
 import { nowIso } from "./core/utils";
 import { hasQueuedReadyPromotionPathHygieneRepair } from "./ready-promotion-path-hygiene-repair";
@@ -129,11 +130,19 @@ export function buildCopilotReviewTimeoutFailureContext(
 }
 
 function mergeConditionsSatisfied(pr: GitHubPullRequest, checks: PullRequestCheck[]): boolean {
+  return mergeConditionsSatisfiedWithReview(pr, checks, reviewSatisfied(pr));
+}
+
+function mergeConditionsSatisfiedWithReview(
+  pr: GitHubPullRequest,
+  checks: PullRequestCheck[],
+  reviewDecisionSatisfied: boolean,
+): boolean {
   const checkSummary = summarizeChecks(checks);
   return (
     pr.state === "OPEN" &&
     !pr.isDraft &&
-    reviewSatisfied(pr) &&
+    reviewDecisionSatisfied &&
     checkSummary.allPassing &&
     pr.mergeStateStatus === "CLEAN"
   );
@@ -208,6 +217,12 @@ export function blockedReasonFromReviewState(
   });
   const configuredReviewMetadataSatisfied = provenCodexStaleReviewMetadata || verifiedCurrentHeadRepairResidue;
   const unresolvedBotThreads = effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads);
+  const botReviewDecisionResidueSatisfied = verifiedConfiguredBotReviewDecisionResidueSatisfied({
+    verifiedCurrentHeadRepairResidue,
+    effectiveConfiguredBotBlockerCount: unresolvedBotThreads.length,
+    effectiveHumanBlockerCount: manualThreads.length,
+    pr,
+  });
   const staleBotThreads =
     manualThreads.length === 0 && !configuredReviewMetadataSatisfied
       ? staleConfiguredBotReviewThreads(config, record, pr, unresolvedBotThreads)
@@ -249,6 +264,7 @@ export function blockedReasonFromReviewState(
 
   if (
     pr.reviewDecision === "CHANGES_REQUESTED" &&
+    !botReviewDecisionResidueSatisfied &&
     (pr.configuredBotTopLevelReviewStrength === "blocking" ||
       (config.humanReviewBlocksMerge && pr.configuredBotTopLevelReviewStrength !== "nitpick_only"))
   ) {
@@ -295,6 +311,13 @@ export function inferStateFromPullRequest(
   });
   const configuredReviewMetadataSatisfied = provenCodexStaleReviewMetadata || verifiedCurrentHeadRepairResidue;
   const unresolvedBotThreads = effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads);
+  const botReviewDecisionResidueSatisfied = verifiedConfiguredBotReviewDecisionResidueSatisfied({
+    verifiedCurrentHeadRepairResidue,
+    effectiveConfiguredBotBlockerCount: unresolvedBotThreads.length,
+    effectiveHumanBlockerCount: manualThreads.length,
+    pr,
+  });
+  const reviewDecisionSatisfiedForState = reviewSatisfied(pr) || botReviewDecisionResidueSatisfied;
   const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(unresolvedBotThreads);
   const codexConnectorMustFixThreadIds = new Set(codexConnectorMustFixThreads.map((thread) => thread.id));
   const retryFingerprintForThread = (thread: ReviewThread) =>
@@ -347,7 +370,7 @@ export function inferStateFromPullRequest(
     return "waiting_ci";
   }
 
-  if (pr.reviewDecision === "CHANGES_REQUESTED") {
+  if (pr.reviewDecision === "CHANGES_REQUESTED" && !botReviewDecisionResidueSatisfied) {
     if (
       processedCodexConnectorMustFixThreadsExhaustedRepeatBudget({
         config,
@@ -612,11 +635,11 @@ export function inferStateFromPullRequest(
     return "waiting_ci";
   }
 
-  if (!pullRequestHeadMatchesRecord(record, pr) && mergeConditionsSatisfied(pr, checks)) {
+  if (!pullRequestHeadMatchesRecord(record, pr) && mergeConditionsSatisfiedWithReview(pr, checks, reviewDecisionSatisfiedForState)) {
     return "stabilizing";
   }
 
-  if (mergeConditionsSatisfied(pr, checks)) {
+  if (mergeConditionsSatisfiedWithReview(pr, checks, reviewDecisionSatisfiedForState)) {
     return "ready_to_merge";
   }
 

--- a/src/review-decision-blocking-policy.ts
+++ b/src/review-decision-blocking-policy.ts
@@ -1,0 +1,73 @@
+import type { GitHubPullRequest } from "./core/types";
+
+export type BlockingReviewDecision = "REVIEW_REQUIRED" | "CHANGES_REQUESTED";
+
+function configuredBotReviewDecisionResidue(
+  pr: Pick<GitHubPullRequest, "configuredBotTopLevelReviewStrength">,
+): boolean {
+  return (
+    pr.configuredBotTopLevelReviewStrength === "blocking" ||
+    pr.configuredBotTopLevelReviewStrength === "nitpick_only"
+  );
+}
+
+export function verifiedConfiguredBotReviewDecisionResidueSatisfied(args: {
+  verifiedCurrentHeadRepairResidue: boolean;
+  effectiveConfiguredBotBlockerCount: number;
+  effectiveHumanBlockerCount: number;
+  pr: Pick<GitHubPullRequest, "configuredBotTopLevelReviewStrength">;
+}): boolean {
+  return (
+    args.verifiedCurrentHeadRepairResidue &&
+    args.effectiveConfiguredBotBlockerCount === 0 &&
+    args.effectiveHumanBlockerCount === 0 &&
+    configuredBotReviewDecisionResidue(args.pr)
+  );
+}
+
+export function reviewDecisionBlocksCurrentHeadRepairProjection(args: {
+  humanReviewBlocksMerge: boolean;
+  manualThreadCount: number;
+  pr: Pick<GitHubPullRequest, "reviewDecision" | "configuredBotTopLevelReviewStrength">;
+}): boolean {
+  if (!args.humanReviewBlocksMerge) {
+    return false;
+  }
+  if (args.manualThreadCount > 0 || args.pr.reviewDecision === "REVIEW_REQUIRED") {
+    return true;
+  }
+  return args.pr.reviewDecision === "CHANGES_REQUESTED" && !configuredBotReviewDecisionResidue(args.pr);
+}
+
+export function aggregateHumanReviewDecisionBlocker(args: {
+  humanReviewBlocksMerge: boolean;
+  requiresCodexNoMajor: boolean;
+  verifiedCurrentHeadRepairResidue: boolean;
+  effectiveConfiguredBotBlockerCount: number;
+  effectiveHumanBlockerCount: number;
+  pr: Pick<GitHubPullRequest, "reviewDecision" | "configuredBotTopLevelReviewStrength">;
+}): BlockingReviewDecision | null {
+  if (!args.humanReviewBlocksMerge) {
+    return null;
+  }
+  if (args.pr.reviewDecision === "REVIEW_REQUIRED") {
+    return "REVIEW_REQUIRED";
+  }
+  if (args.pr.reviewDecision !== "CHANGES_REQUESTED") {
+    return null;
+  }
+  if (
+    verifiedConfiguredBotReviewDecisionResidueSatisfied({
+      verifiedCurrentHeadRepairResidue: args.verifiedCurrentHeadRepairResidue,
+      effectiveConfiguredBotBlockerCount: args.effectiveConfiguredBotBlockerCount,
+      effectiveHumanBlockerCount: args.effectiveHumanBlockerCount,
+      pr: args.pr,
+    })
+  ) {
+    return null;
+  }
+  if (!args.requiresCodexNoMajor && args.pr.configuredBotTopLevelReviewStrength === "nitpick_only") {
+    return null;
+  }
+  return "CHANGES_REQUESTED";
+}

--- a/src/review-decision-blocking-policy.ts
+++ b/src/review-decision-blocking-policy.ts
@@ -3,11 +3,12 @@ import type { GitHubPullRequest } from "./core/types";
 export type BlockingReviewDecision = "REVIEW_REQUIRED" | "CHANGES_REQUESTED";
 
 function configuredBotReviewDecisionResidue(
-  pr: Pick<GitHubPullRequest, "configuredBotTopLevelReviewStrength">,
+  pr: Pick<GitHubPullRequest, "configuredBotTopLevelReviewStrength" | "configuredBotOnlyChangesRequestedReview">,
 ): boolean {
   return (
-    pr.configuredBotTopLevelReviewStrength === "blocking" ||
-    pr.configuredBotTopLevelReviewStrength === "nitpick_only"
+    pr.configuredBotOnlyChangesRequestedReview === true &&
+    (pr.configuredBotTopLevelReviewStrength === "blocking" ||
+      pr.configuredBotTopLevelReviewStrength === "nitpick_only")
   );
 }
 
@@ -15,7 +16,7 @@ export function verifiedConfiguredBotReviewDecisionResidueSatisfied(args: {
   verifiedCurrentHeadRepairResidue: boolean;
   effectiveConfiguredBotBlockerCount: number;
   effectiveHumanBlockerCount: number;
-  pr: Pick<GitHubPullRequest, "reviewDecision" | "configuredBotTopLevelReviewStrength">;
+  pr: Pick<GitHubPullRequest, "reviewDecision" | "configuredBotTopLevelReviewStrength" | "configuredBotOnlyChangesRequestedReview">;
 }): boolean {
   return (
     args.pr.reviewDecision === "CHANGES_REQUESTED" &&
@@ -29,7 +30,7 @@ export function verifiedConfiguredBotReviewDecisionResidueSatisfied(args: {
 export function reviewDecisionBlocksCurrentHeadRepairProjection(args: {
   humanReviewBlocksMerge: boolean;
   manualThreadCount: number;
-  pr: Pick<GitHubPullRequest, "reviewDecision" | "configuredBotTopLevelReviewStrength">;
+  pr: Pick<GitHubPullRequest, "reviewDecision" | "configuredBotTopLevelReviewStrength" | "configuredBotOnlyChangesRequestedReview">;
 }): boolean {
   if (!args.humanReviewBlocksMerge) {
     return false;
@@ -46,7 +47,7 @@ export function aggregateHumanReviewDecisionBlocker(args: {
   verifiedCurrentHeadRepairResidue: boolean;
   effectiveConfiguredBotBlockerCount: number;
   effectiveHumanBlockerCount: number;
-  pr: Pick<GitHubPullRequest, "reviewDecision" | "configuredBotTopLevelReviewStrength">;
+  pr: Pick<GitHubPullRequest, "reviewDecision" | "configuredBotTopLevelReviewStrength" | "configuredBotOnlyChangesRequestedReview">;
 }): BlockingReviewDecision | null {
   if (!args.humanReviewBlocksMerge) {
     return null;

--- a/src/review-decision-blocking-policy.ts
+++ b/src/review-decision-blocking-policy.ts
@@ -15,9 +15,10 @@ export function verifiedConfiguredBotReviewDecisionResidueSatisfied(args: {
   verifiedCurrentHeadRepairResidue: boolean;
   effectiveConfiguredBotBlockerCount: number;
   effectiveHumanBlockerCount: number;
-  pr: Pick<GitHubPullRequest, "configuredBotTopLevelReviewStrength">;
+  pr: Pick<GitHubPullRequest, "reviewDecision" | "configuredBotTopLevelReviewStrength">;
 }): boolean {
   return (
+    args.pr.reviewDecision === "CHANGES_REQUESTED" &&
     args.verifiedCurrentHeadRepairResidue &&
     args.effectiveConfiguredBotBlockerCount === 0 &&
     args.effectiveHumanBlockerCount === 0 &&

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -913,6 +913,7 @@ export async function executeCodexTurnPhase(
               postPublicationReviewPersistence.hasVerifiedNoSourceChangeReviewThreadEvidence,
             verifiedNoSourceChangeReviewThreads:
               postPublicationReviewPersistence.verifiedNoSourceChangeReviewThreads,
+            reviewThreadsToProcess,
           });
         const preserveStaleNoPrRecoveryTracking =
           pr === null &&

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -937,6 +937,79 @@ test("buildStaleReviewBotRemediation classifies explicit P2 repair evidence with
   assert.equal(remediation?.verificationEvidenceSummary, "Focused current-head repair verifier passed.");
 });
 
+test("buildStaleReviewBotRemediation surfaces legacy current-head repair proof source", () => {
+  const issueNumber = 2375;
+  const prNumber = 399;
+  const headSha = "01642468db1df175a92ec8d332fdf64e7754a3ab";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_hrcore_399_termination_code_fields",
+    commentId: "PRRC_hrcore_399_termination_code_fields",
+    path: "web/src/App.tsx",
+    line: 911,
+    severity: "P2",
+    commentBody: "P2: Require termination code fields before submit.",
+    discussionUrl: "https://example.test/pr/399#discussion_r3409030367",
+    verifiedRepair: {
+      summary: "Verified current head addresses the review findings.",
+      ranAt: "2026-06-14T04:58:52.932Z",
+      command: "npm run verify:pre-pr",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "verification",
+    last_failure_signature: `auto-merge-refused:${headSha}:missing_current_head_codex_no_major`,
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI command passed before auto-merging PR #399.",
+      ran_at: "2026-06-14T04:59:01.275Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "npm run verify:pre-pr",
+      failure_class: null,
+      remediation_target: null,
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-14T05:12:43Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+  });
+  const diagnostics = buildStaleReviewBotThreadDiagnostics({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+    remediation,
+  });
+
+  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
+  assert.match(remediation?.verificationEvidenceSummary ?? "", /^legacy_processed_thread_evidence:/);
+  assert.equal(remediation?.missingProbeReason, null);
+  assert.equal(diagnostics?.verifiedStaleResidueThreads, 1);
+  assert.equal(diagnostics?.autoRepairSuppressedReason, "none");
+});
+
 test("buildStaleReviewBotRemediation rejects local-CI-only P2 repair evidence without no-major signal", () => {
   const issueNumber = 113;
   const prNumber = 118;

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -13,7 +13,6 @@ import {
   codexConnectorMustFixReviewThreads,
   commitShasEqualForComparison,
   evaluateCodexConnectorConvergencePolicy,
-  hasCodexConnectorFindingReviewComment,
   latestCodexConnectorReviewCommentFingerprint,
   latestCodexConnectorPSeverity,
   latestCodexConnectorReviewComment,
@@ -30,6 +29,7 @@ import {
   configuredReviewProviderKinds,
   normalizeReviewProviderLogin,
 } from "../core/review-providers";
+import { projectCurrentHeadCodexRepairProof } from "../current-head-codex-repair-proof";
 import {
   STALE_REVIEW_BOT_MANUAL_NEXT_STEP,
   VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
@@ -40,6 +40,11 @@ import {
   type StaleReviewBotAutoRepairSuppressedReason,
   type StaleReviewBotClassificationPolicyDecision,
 } from "./stale-review-bot-classification-policy";
+
+export {
+  hasCurrentHeadVerifiedRepairResidueArtifact,
+  VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
+} from "../current-head-codex-repair-proof";
 
 export interface StaleReviewBotRemediationDto {
   issueNumber: number;
@@ -78,9 +83,6 @@ export interface StaleReviewBotThreadDiagnosticsDto {
 }
 
 type RepositoryFileContents = Record<string, string | null | undefined>;
-
-export const VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET =
-  "verified_current_head_repair_review_thread_residue";
 
 export function formatStaleReviewBotTokenValue(value: string): string {
   return value.replace(/\r?\n/gu, "\\n");
@@ -128,20 +130,6 @@ function codeCiState(
 
 function allChecksPassing(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
   return checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
-}
-
-function configuredReviewProvidersAreCodexOnly(config: SupervisorConfig): boolean {
-  const providerKinds = configuredReviewProviderKinds(config);
-  return providerKinds.length > 0 && providerKinds.every((kind) => kind === "codex");
-}
-
-function unresolvedConfiguredBotThreadsAreCodexConnectorOnly(
-  config: SupervisorConfig,
-  reviewThreads: ReviewThread[],
-): boolean {
-  return configuredBotReviewThreads(config, reviewThreads)
-    .filter((thread) => !thread.isResolved)
-    .every(hasCodexConnectorFindingReviewComment);
 }
 
 function isConfiguredReviewBotCheck(
@@ -350,34 +338,6 @@ function hasCurrentHeadLocalCiVerification(
   return record.latest_local_ci_result?.outcome === "passed" && record.latest_local_ci_result.head_sha === pr.headRefOid;
 }
 
-export function hasCurrentHeadVerifiedRepairResidueArtifact(
-  record: Pick<IssueRunRecord, "timeline_artifacts">,
-  pr: Pick<GitHubPullRequest, "headRefOid">,
-): boolean {
-  return (record.timeline_artifacts ?? []).some(
-    (artifact) =>
-      artifact.type === "verification_result" &&
-      artifact.outcome === "passed" &&
-      artifact.head_sha === pr.headRefOid &&
-      artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
-      (artifact.processed_review_thread_ids?.length ?? 0) > 0,
-  );
-}
-
-function currentHeadVerifiedRepairResidueArtifact(
-  record: Pick<IssueRunRecord, "timeline_artifacts">,
-  pr: Pick<GitHubPullRequest, "headRefOid">,
-) {
-  return (record.timeline_artifacts ?? []).find(
-    (artifact) =>
-      artifact.type === "verification_result" &&
-      artifact.outcome === "passed" &&
-      artifact.head_sha === pr.headRefOid &&
-      artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
-      (artifact.processed_review_thread_ids?.length ?? 0) > 0,
-  ) ?? null;
-}
-
 export function currentHeadVerifiedRepairResidueArtifactEvidenceSummary(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -385,19 +345,7 @@ export function currentHeadVerifiedRepairResidueArtifactEvidenceSummary(args: {
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
 }): string | null {
-  if (
-    args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve !== true ||
-    !configuredReviewProvidersAreCodexOnly(args.config) ||
-    !allChecksPassing(args.checks) ||
-    args.record.last_head_sha !== args.pr.headRefOid ||
-    codexConnectorMustFixReviewThreads(args.reviewThreads).length > 0 ||
-    !unresolvedConfiguredBotThreadsAreCodexConnectorOnly(args.config, args.reviewThreads)
-  ) {
-    return null;
-  }
-
-  const artifact = currentHeadVerifiedRepairResidueArtifact(args.record, args.pr);
-  return artifact?.summary || "verified_current_head_repair_review_thread_residue_artifact";
+  return projectCurrentHeadCodexRepairProof(args)?.summary ?? null;
 }
 
 function hasCurrentHeadNoSourceChangeCodexTurnVerification(
@@ -1058,7 +1006,21 @@ export function buildStaleReviewBotRemediation(args: {
   reviewThreads?: ReviewThread[];
   repositoryFileContents?: RepositoryFileContents;
 }): StaleReviewBotRemediationDto | null {
-  if (args.record.blocked_reason !== "stale_review_bot" && args.record.blocked_reason !== "manual_review") {
+  const verifiedCurrentHeadRepairProof =
+    args.config && args.pr
+      ? projectCurrentHeadCodexRepairProof({
+          config: args.config,
+          record: args.record,
+          pr: args.pr,
+          checks: args.checks,
+          reviewThreads: args.reviewThreads ?? [],
+        })
+      : null;
+  if (
+    args.record.blocked_reason !== "stale_review_bot" &&
+    args.record.blocked_reason !== "manual_review" &&
+    !verifiedCurrentHeadRepairProof
+  ) {
     return null;
   }
 

--- a/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
@@ -587,6 +587,102 @@ test("status --why surfaces artifact-backed verified repair residue after thread
   assert.doesNotMatch(status, /^operator_action action=manual_review /m);
 });
 
+test("status --why surfaces legacy processed-thread repair proof while idle", async (t) => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];
+  fixture.config.localCiCommand = "npm run verify:pre-pr";
+  fixture.config.verifiedCurrentHeadRepairReviewThreadAutoResolve = true;
+  const issueNumber = 406;
+  const prNumber = 506;
+  const headSha = "01642468db1df175a92ec8d332fdf64e7754a3ab";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-406",
+    commentId: "comment-406",
+    path: "web/src/App.tsx",
+    line: 911,
+    severity: "P2",
+    commentBody: "P2: Require termination code fields before submit.",
+    discussionUrl: "https://example.test/pr/506#discussion_r406",
+    verifiedRepair: {
+      summary: "Verified current head addresses the review findings.",
+      ranAt: "2026-06-14T04:58:52.932Z",
+      command: "npm run verify:pre-pr",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        ...scenario.recordPatch,
+        state: "blocked",
+        blocked_reason: "verification",
+        last_failure_signature: `auto-merge-refused:${headSha}:missing_current_head_codex_no_major`,
+        workspace: path.join(fixture.workspaceRoot, `issue-${issueNumber}`),
+        journal_path: null,
+        latest_local_ci_result: {
+          outcome: "passed",
+          summary: "Configured local CI command passed before auto-merging PR #506.",
+          ran_at: "2026-06-14T04:59:01.275Z",
+          head_sha: headSha,
+          execution_mode: "shell",
+          command: "npm run verify:pre-pr",
+          failure_class: null,
+          remediation_target: null,
+        },
+      }),
+    },
+  };
+  await fs.writeFile(fixture.stateFile, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  t.after(async () => {
+    await fs.rm(path.dirname(fixture.repoPath), { recursive: true, force: true });
+  });
+
+  const trackedIssue = createTrackedStatusIssue({
+    issueNumber,
+    title: "Status why idle legacy Codex verified repair residue",
+    summary: "Status should surface legacy processed-thread repair proof.",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-14T05:12:43Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+  const supervisor = new Supervisor(fixture.config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getIssue: async () => trackedIssue,
+    listCandidateIssues: async () => [trackedIssue],
+    listAllIssues: async () => [trackedIssue],
+    getPullRequestIfExists: async () => pr,
+    resolvePullRequestForBranch: async () => pr,
+    getChecks: async () => scenario.passingChecks,
+    getUnresolvedReviewThreads: async () => [scenario.reviewThread],
+  };
+
+  const status = await supervisor.status({ why: true });
+
+  assert.match(
+    status,
+    /^no_active_tracked_record issue=#406 classification=stale_review_bot_remediation state=blocked reason=verified_current_head_repair_pending_thread_resolution$/m,
+  );
+  assert.match(
+    status,
+    /^stale_review_bot_remediation issue=#406 pr=#506 reason=stale_review_bot code_ci=green current_head_sha=01642468db1df175a92ec8d332fdf64e7754a3ab processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=missing review_thread_url=https:\/\/example\.test\/pr\/506#discussion_r406 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=legacy_processed_thread_evidence:Verified_current_head_addresses_the_review_findings\. summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+  );
+  assert.match(
+    status,
+    /^stale_review_bot_terminal_stop issue=#406 pr=#506 reason=metadata_only_review_thread_resolution_pending classification=verified_current_head_repair_pending_thread_resolution .*auto_repair_suppressed_reason=none next_action=merge_ready$/m,
+  );
+  assert.match(status, /^codex_connector_operator_diagnostic .*next_action=merge_ready$/m);
+  assert.doesNotMatch(status, /^operator_action action=resolve_stale_review_bot /m);
+  assert.doesNotMatch(status, /^operator_action action=manual_review /m);
+});
+
 test("status --why uses the shared stale review-bot presenter for active verified repair residue", async (t) => {
   const fixture = await createSupervisorFixture();
   fixture.config.reviewBotLogins = [CODEX_CONNECTOR_REVIEW_BOT_LOGIN];

--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -400,6 +400,7 @@ test("handlePostTurnMergeAndCompletion treats verified current-head repair resid
     ...scenario.pullRequestPatch,
     reviewDecision: "CHANGES_REQUESTED",
     configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotOnlyChangesRequestedReview: true,
     configuredBotCurrentHeadObservedAt: "2026-06-13T00:17:00Z",
     configuredBotCurrentHeadObservationSource: "review_thread",
   });

--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -398,6 +398,8 @@ test("handlePostTurnMergeAndCompletion treats verified current-head repair resid
   });
   const pr = createPullRequest({
     ...scenario.pullRequestPatch,
+    reviewDecision: "CHANGES_REQUESTED",
+    configuredBotTopLevelReviewStrength: "blocking",
     configuredBotCurrentHeadObservedAt: "2026-06-13T00:17:00Z",
     configuredBotCurrentHeadObservationSource: "review_thread",
   });

--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -365,6 +365,7 @@ test("handlePostTurnMergeAndCompletion treats verified current-head repair resid
     configuredBotInitialGraceWaitSeconds: 0,
     configuredBotSettledWaitSeconds: 0,
     verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+    localCiCommand: "npm run verify:pre-pr",
   });
   const issue: GitHubIssue = {
     number: issueNumber,
@@ -410,7 +411,26 @@ test("handlePostTurnMergeAndCompletion treats verified current-head repair resid
         branch,
         blocked_reason: null,
         last_error: null,
-        last_failure_context: null,
+        last_failure_context: {
+          category: "blocked",
+          summary: "Final auto-merge guard refused without Codex no-major evidence.",
+          signature: "auto-merge-refused:head-verified-repair-residue:missing_current_head_codex_no_major",
+          command: null,
+          details: ["missing_current_head_codex_no_major"],
+          url: null,
+          updated_at: "2026-06-14T00:20:00Z",
+        },
+        last_failure_signature: "auto-merge-refused:head-verified-repair-residue:missing_current_head_codex_no_major",
+        latest_local_ci_result: {
+          outcome: "passed",
+          summary: "Configured local CI command passed before auto-merging PR #399.",
+          ran_at: "2026-06-14T04:59:01.275Z",
+          head_sha: "head-verified-repair-residue",
+          execution_mode: "shell",
+          command: "npm run verify:pre-pr",
+          failure_class: null,
+          remediation_target: null,
+        },
       }),
     },
   };
@@ -453,6 +473,10 @@ test("handlePostTurnMergeAndCompletion treats verified current-head repair resid
   assert.match(
     merged.last_auto_merge_guard_context?.details.join("\\n") ?? "",
     /codex_verified_current_head_repair_residue=yes/,
+  );
+  assert.match(
+    merged.last_auto_merge_guard_context?.details.join("\\n") ?? "",
+    /codex_repair_proof_source=legacy_processed_thread_evidence/,
   );
 });
 

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -24,6 +24,7 @@ import {
   inferGitHubWaitStep,
 } from "../pull-request-state";
 import { projectCurrentHeadCodexRepairProof } from "../current-head-codex-repair-proof";
+import { aggregateHumanReviewDecisionBlocker } from "../review-decision-blocking-policy";
 import { hasCodexConnectorPrSuccessCurrentHeadObservation } from "../codex-connector-review-policy";
 import {
   syncCopilotReviewRequestObservation,
@@ -279,13 +280,14 @@ function finalAutoMergeGuard(args: {
   const verifiedCurrentHeadRepairResidue = verifiedCurrentHeadRepairProof !== null;
   const currentHeadCodexNoMajor = hasCurrentHeadCodexNoMajor(record, currentPr) || verifiedCurrentHeadRepairResidue;
   const requiresCodexNoMajor = autoMergePath === "codex_connector_no_major";
-  const aggregateHumanReviewBlocker =
-    config.humanReviewBlocksMerge &&
-    (currentPr.reviewDecision === "REVIEW_REQUIRED" ||
-      (currentPr.reviewDecision === "CHANGES_REQUESTED" &&
-        (requiresCodexNoMajor || currentPr.configuredBotTopLevelReviewStrength !== "nitpick_only")))
-      ? currentPr.reviewDecision
-      : null;
+  const aggregateHumanReviewBlocker = aggregateHumanReviewDecisionBlocker({
+    humanReviewBlocksMerge: Boolean(config.humanReviewBlocksMerge),
+    requiresCodexNoMajor,
+    verifiedCurrentHeadRepairResidue,
+    effectiveConfiguredBotBlockerCount: effectiveConfiguredBotBlockers,
+    effectiveHumanBlockerCount: effectiveHumanBlockers,
+    pr: currentPr,
+  });
   const localCiResult = record.latest_local_ci_result ?? null;
   const localCiConfigured = hasConfiguredLocalCiCommand(config);
   const localCiMissing = localCiConfigured && currentHeadLocalCiMissing(record, currentPr);

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -23,7 +23,7 @@ import {
   inferStateFromPullRequest,
   inferGitHubWaitStep,
 } from "../pull-request-state";
-import { hasVerifiedCurrentHeadRepairReviewMetadataResidue } from "../pull-request-state-codex-residue-policy";
+import { projectCurrentHeadCodexRepairProof } from "../current-head-codex-repair-proof";
 import { hasCodexConnectorPrSuccessCurrentHeadObservation } from "../codex-connector-review-policy";
 import {
   syncCopilotReviewRequestObservation,
@@ -269,13 +269,14 @@ function finalAutoMergeGuard(args: {
     reviewThreads,
   ).length;
   const effectiveHumanBlockers = config.humanReviewBlocksMerge ? manualReviewThreads(config, reviewThreads).length : 0;
-  const verifiedCurrentHeadRepairResidue = hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+  const verifiedCurrentHeadRepairProof = projectCurrentHeadCodexRepairProof({
     config,
     record,
     pr: currentPr,
     checks,
     reviewThreads,
   });
+  const verifiedCurrentHeadRepairResidue = verifiedCurrentHeadRepairProof !== null;
   const currentHeadCodexNoMajor = hasCurrentHeadCodexNoMajor(record, currentPr) || verifiedCurrentHeadRepairResidue;
   const requiresCodexNoMajor = autoMergePath === "codex_connector_no_major";
   const aggregateHumanReviewBlocker =
@@ -298,6 +299,7 @@ function finalAutoMergeGuard(args: {
       ? `codex_current_head_no_major=${currentHeadCodexNoMajor ? "yes" : "no"}`
       : "codex_current_head_no_major=not_required",
     `codex_verified_current_head_repair_residue=${verifiedCurrentHeadRepairResidue ? "yes" : "no"}`,
+    `codex_repair_proof_source=${verifiedCurrentHeadRepairProof?.source ?? "none"}`,
     `configured_bot_blockers=${effectiveConfiguredBotBlockers}`,
     `human_blockers=${effectiveHumanBlockers}`,
     `review_decision=${currentPr.reviewDecision ?? "none"}`,
@@ -842,6 +844,7 @@ export class Supervisor {
               state: "merging",
               blocked_reason: null,
               last_failure_context: null,
+              last_failure_signature: null,
               last_auto_merge_guard_context: autoMergeGuard.evidence,
               last_head_sha: currentPr.headRefOid,
             });

--- a/src/turn-execution-post-publication-review.test.ts
+++ b/src/turn-execution-post-publication-review.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./pull-request-state-test-helpers";
 import { CODEX_CONNECTOR_REVIEW_BOT_LOGIN } from "./codex-connector-tracked-pr-test-helpers";
 
-test("buildPostPublicationCodexVerificationTimelineArtifacts persists scoped thread keys for normal repair turns", () => {
+test("buildPostPublicationCodexVerificationTimelineArtifacts persists scoped thread keys for blocked normal repair turns", () => {
   const headSha = "head-normal-repair";
   const reviewThread = createReviewThread({
     id: "thread-normal-repair",
@@ -36,7 +36,7 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts persists scoped thr
     codexVerificationCommand: "npm test -- src/review.test.ts",
     workspaceStatus: { headSha },
     structuredSummary: "Focused repair verifier passed.",
-    postRunState: "ready_to_merge",
+    postRunState: "blocked",
     hasVerifiedNoSourceChangeReviewThreadEvidence: false,
     verifiedNoSourceChangeReviewThreads: [],
     reviewThreadsToProcess: [reviewThread],

--- a/src/turn-execution-post-publication-review.test.ts
+++ b/src/turn-execution-post-publication-review.test.ts
@@ -1,0 +1,51 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { buildPostPublicationCodexVerificationTimelineArtifacts } from "./turn-execution-post-publication-review";
+import {
+  createPullRequest,
+  createRecord,
+  createReviewThread,
+} from "./pull-request-state-test-helpers";
+import { CODEX_CONNECTOR_REVIEW_BOT_LOGIN } from "./codex-connector-tracked-pr-test-helpers";
+
+test("buildPostPublicationCodexVerificationTimelineArtifacts persists scoped thread keys for normal repair turns", () => {
+  const headSha = "head-normal-repair";
+  const reviewThread = createReviewThread({
+    id: "thread-normal-repair",
+    path: "src/review.ts",
+    line: 42,
+    comments: {
+      nodes: [
+        {
+          id: "comment-normal-repair",
+          body: "P2: Verify this repaired finding before merge.",
+          createdAt: "2026-06-14T05:22:00Z",
+          url: "https://example.test/pr/406#discussion_r406",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const artifacts = buildPostPublicationCodexVerificationTimelineArtifacts({
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    codexVerificationCommand: "npm test -- src/review.test.ts",
+    workspaceStatus: { headSha },
+    structuredSummary: "Focused repair verifier passed.",
+    postRunState: "ready_to_merge",
+    hasVerifiedNoSourceChangeReviewThreadEvidence: false,
+    verifiedNoSourceChangeReviewThreads: [],
+    reviewThreadsToProcess: [reviewThread],
+  });
+
+  assert.equal(artifacts?.length, 1);
+  assert.deepEqual(artifacts?.[0]?.repair_targets, undefined);
+  assert.deepEqual(artifacts?.[0]?.processed_review_thread_ids, [`${reviewThread.id}@${headSha}`]);
+  assert.deepEqual(artifacts?.[0]?.processed_review_thread_fingerprints, [
+    `${reviewThread.id}@${headSha}#comment-normal-repair`,
+  ]);
+});

--- a/src/turn-execution-post-publication-review.ts
+++ b/src/turn-execution-post-publication-review.ts
@@ -34,6 +34,25 @@ function sameRepairTargets(left: string[] | null | undefined, right: string[] | 
   return sameStringList(left, right);
 }
 
+function processedReviewThreadIdsForHead(threads: ReviewThread[], headSha: string | null): string[] | undefined {
+  if (!headSha || threads.length === 0) {
+    return undefined;
+  }
+  return threads.map((thread) => processedReviewThreadKey(thread.id, headSha));
+}
+
+function processedReviewThreadFingerprintsForHead(threads: ReviewThread[], headSha: string | null): string[] | undefined {
+  if (!headSha || threads.length === 0) {
+    return undefined;
+  }
+  return threads.flatMap((thread) => {
+    const fingerprint = latestReviewThreadCommentFingerprint(thread);
+    return fingerprint
+      ? [processedReviewThreadFingerprintKey(thread.id, headSha, fingerprint)]
+      : [];
+  });
+}
+
 export interface PostPublicationReviewPersistence {
   processedReviewThreadPatch: Pick<
     IssueRunRecord,
@@ -118,6 +137,7 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   postRunState: IssueRunRecord["state"];
   hasVerifiedNoSourceChangeReviewThreadEvidence: boolean;
   verifiedNoSourceChangeReviewThreads: ReviewThread[];
+  reviewThreadsToProcess: ReviewThread[];
 }): TimelineArtifact[] | null {
   const currentPrHeadSha = args.currentPr?.headRefOid ?? null;
   const codexTurnVerificationHeadSha =
@@ -131,21 +151,17 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   const codexTurnVerificationRepairTargets = args.hasVerifiedNoSourceChangeReviewThreadEvidence
     ? ["verified_no_source_change_review_thread_residue"]
     : undefined;
+  const codexTurnVerificationReviewThreads =
+    codexTurnVerificationRepairTargets
+      ? args.verifiedNoSourceChangeReviewThreads
+      : args.reviewThreadsToProcess;
   const codexTurnVerificationReviewThreadIds =
-    codexTurnVerificationRepairTargets && currentPrHeadSha
-      ? args.verifiedNoSourceChangeReviewThreads.map((thread) =>
-          processedReviewThreadKey(thread.id, currentPrHeadSha),
-        )
-      : undefined;
+    processedReviewThreadIdsForHead(codexTurnVerificationReviewThreads, currentPrHeadSha);
   const codexTurnVerificationReviewThreadFingerprints =
-    codexTurnVerificationRepairTargets && currentPrHeadSha
-      ? args.verifiedNoSourceChangeReviewThreads.flatMap((thread) => {
-          const fingerprint = latestReviewThreadCommentFingerprint(thread);
-          return fingerprint
-            ? [processedReviewThreadFingerprintKey(thread.id, currentPrHeadSha, fingerprint)]
-            : [];
-        })
-      : undefined;
+    processedReviewThreadFingerprintsForHead(codexTurnVerificationReviewThreads, currentPrHeadSha);
+  const hasCodexTurnVerificationReviewThreadEvidence =
+    (codexTurnVerificationReviewThreadIds?.length ?? 0) > 0 ||
+    (codexTurnVerificationReviewThreadFingerprints?.length ?? 0) > 0;
   const codexTurnVerificationTimelineArtifacts =
     args.currentPr &&
     args.codexVerificationCommand &&
@@ -163,8 +179,10 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
             summary: conciseCodexVerificationSummary(args.structuredSummary),
             recorded_at: new Date().toISOString(),
             ...(codexTurnVerificationRepairTargets
+              ? { repair_targets: codexTurnVerificationRepairTargets }
+              : {}),
+            ...(hasCodexTurnVerificationReviewThreadEvidence
               ? {
-                  repair_targets: codexTurnVerificationRepairTargets,
                   processed_review_thread_ids: codexTurnVerificationReviewThreadIds ?? [],
                   processed_review_thread_fingerprints: codexTurnVerificationReviewThreadFingerprints ?? [],
                 }

--- a/src/turn-execution-post-publication-review.ts
+++ b/src/turn-execution-post-publication-review.ts
@@ -140,14 +140,6 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   reviewThreadsToProcess: ReviewThread[];
 }): TimelineArtifact[] | null {
   const currentPrHeadSha = args.currentPr?.headRefOid ?? null;
-  const codexTurnVerificationHeadSha =
-    args.currentPr &&
-    args.codexVerificationCommand &&
-    args.workspaceStatus.headSha === args.currentPr.headRefOid &&
-    args.postRunState !== "failed" &&
-    (args.postRunState !== "blocked" || args.hasVerifiedNoSourceChangeReviewThreadEvidence)
-      ? args.currentPr.headRefOid
-      : null;
   const codexTurnVerificationRepairTargets = args.hasVerifiedNoSourceChangeReviewThreadEvidence
     ? ["verified_no_source_change_review_thread_residue"]
     : undefined;
@@ -162,6 +154,16 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   const hasCodexTurnVerificationReviewThreadEvidence =
     (codexTurnVerificationReviewThreadIds?.length ?? 0) > 0 ||
     (codexTurnVerificationReviewThreadFingerprints?.length ?? 0) > 0;
+  const codexTurnVerificationHeadSha =
+    args.currentPr &&
+    args.codexVerificationCommand &&
+    args.workspaceStatus.headSha === args.currentPr.headRefOid &&
+    args.postRunState !== "failed" &&
+    (args.postRunState !== "blocked" ||
+      args.hasVerifiedNoSourceChangeReviewThreadEvidence ||
+      hasCodexTurnVerificationReviewThreadEvidence)
+      ? args.currentPr.headRefOid
+      : null;
   const codexTurnVerificationTimelineArtifacts =
     args.currentPr &&
     args.codexVerificationCommand &&


### PR DESCRIPTION
## Summary
- Add a shared current-head Codex repair proof projection used by final auto-merge guard, PR state policy, stale-review remediation, diagnostics, and Decision Kernel v2 explain surfaces.
- Keep structured `repair_targets` artifacts as the primary proof source, and add a guarded legacy fallback for current-head processed-thread evidence after `missing_current_head_codex_no_major` guard refusal.
- Fail closed for non-Codex/mixed providers, stale heads, unprocessed current threads, P1+ unresolved repair residue, missing checks/local CI, and human review blockers.

Closes #2375

## Verification
- `npx tsx --test src/family-directory-layout.test.ts src/supervisor/supervisor-pr-readiness.test.ts src/pull-request-state-policy.test.ts src/supervisor/stale-review-bot-remediation.test.ts src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts src/decision-kernel/v2-explain.test.ts`
- `npm run verify:supervisor-pre-pr`

## Notes
- `npm run verify:pre-pr` still fails on existing `origin/main` baseline failures unrelated to this branch. I confirmed the same focused failures in a detached `origin/main` worktree: external-review family layout, P3 nitpick current-head wait, replay corpus manifest, prepared stale-review residue eligibility, and tracked PR lifecycle stale/manual review expectation.