### PR TITLE
[codex] Persist scoped repair proof artifacts

### DIFF
--- a/src/core/workspace.test.ts
+++ b/src/core/workspace.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import test from "node:test";
 import { promisify } from "node:util";
 import { SupervisorConfig } from "./types";
-import { ensureWorkspace, listTrackedTopLevelEntries } from "./workspace";
+import { ensureWorkspace, listChangedTrackedFilesBetween, listTrackedTopLevelEntries } from "./workspace";
 import { DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH, issueJournalPath, syncIssueJournal } from "./journal";
 
 const execFileAsync = promisify(execFile);
@@ -135,6 +135,32 @@ exec "$REAL_GIT" "$@"
     await fs.rm(fakeRoot, { recursive: true, force: true });
   }
 }
+
+test("listChangedTrackedFilesBetween includes deletion-only tracked changes", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-changed-files-"));
+  try {
+    const repoPath = path.join(root, "repo");
+    await fs.mkdir(repoPath, { recursive: true });
+    await git(repoPath, "init", "-b", "main");
+    await git(repoPath, "config", "user.name", "Codex Test");
+    await git(repoPath, "config", "user.email", "codex@example.test");
+    await fs.writeFile(path.join(repoPath, "delete-me.ts"), "export const deleted = true;\n", "utf8");
+    await git(repoPath, "add", "delete-me.ts");
+    await git(repoPath, "commit", "-m", "Add tracked file");
+    const baseSha = await gitOutput(repoPath, "rev-parse", "HEAD");
+
+    await fs.rm(path.join(repoPath, "delete-me.ts"));
+    await git(repoPath, "add", "-A");
+    await git(repoPath, "commit", "-m", "Delete tracked file");
+
+    assert.deepEqual(
+      await listChangedTrackedFilesBetween(repoPath, baseSha, "HEAD"),
+      ["delete-me.ts"],
+    );
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+});
 
 async function createRepositoryFixture(): Promise<SupervisorConfig> {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-workspace-"));

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -20,6 +20,10 @@ const LIVE_ISSUE_JOURNAL_PATH_GLOB =
 const LIVE_ISSUE_JOURNAL_PATH_REGEX =
   /^\.codex-supervisor\/issues\/\d+\/issue-journal\.md$/u;
 
+function normalizeGitRelativePath(relativePath: string): string {
+  return relativePath.replace(/\\/g, "/").replace(/^(?:\.\/)+/u, "");
+}
+
 function assertIssueNumber(issueNumber: number): void {
   if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
     throw new Error(`Invalid issue number: ${issueNumber}`);
@@ -771,7 +775,7 @@ export async function listChangedTrackedFilesBetween(
     workspacePath,
     "diff",
     "--name-only",
-    "--diff-filter=ACMR",
+    "--diff-filter=ACMRD",
     "-z",
     fromRef,
     toRef,
@@ -781,7 +785,7 @@ export async function listChangedTrackedFilesBetween(
     .split("\0")
     .map((entry) => entry.trim())
     .filter((entry) => entry.length > 0)
-    .map((entry) => normalizeGitPath(entry));
+    .map((entry) => normalizeGitRelativePath(entry));
 }
 
 export async function listTrackedTopLevelEntries(

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -1136,6 +1136,84 @@ test("legacy current-head processed-thread repair proof requires scoped verifier
   );
 });
 
+test("structured current-head repair artifact proves HRCore-style repaired P2 residue without summary wording", () => {
+  const issueNumber = 2377;
+  const prNumber = 399;
+  const headSha = "01642468db1df175a92ec8d332fdf64e7754a3ab";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_hrcore_399_structured_repair",
+    commentId: "PRRC_hrcore_399_structured_repair",
+    path: "web/src/App.tsx",
+    line: 911,
+    severity: "P2",
+    commentBody: "P2: Require termination code fields before submit.",
+    discussionUrl: "https://example.test/pr/399#discussion_r3409030367",
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    codexConnectorAutoMergeEnabled: true,
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "verification",
+    last_failure_signature: `auto-merge-refused:${headSha}:missing_current_head_codex_no_major`,
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI command passed before auto-merging PR #399.",
+      ran_at: "2026-06-14T04:59:01.275Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "npm run verify:pre-pr",
+      failure_class: null,
+      remediation_target: null,
+    },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run verify:pre-pr",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused verifier passed after the source-changing repair.",
+        recorded_at: "2026-06-14T04:58:52.932Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [
+          `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+        ],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-14T05:12:43Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    true,
+  );
+  assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), "ready_to_merge");
+  assert.equal(hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), true);
+});
+
 test("verified current-head repair artifact must cover current unresolved threads", () => {
   const issueNumber = 2376;
   const prNumber = 401;

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -49,6 +49,18 @@ test("run-once turn execution does not import Decision Kernel v2 action decision
   assert.doesNotMatch(source, /mutationAuthority/u);
 });
 
+test("run-once turn execution keeps artifact-only repair paths across same-turn retries", async () => {
+  const source = await fs.readFile(path.join(process.cwd(), "src", "run-once-turn-execution.ts"), "utf8");
+  const accumulatorIndex = source.indexOf("let artifactOnlyChangedFilesAfterPublication: string[] = [];");
+  const loopIndex = source.indexOf("while (true)");
+
+  assert.ok(accumulatorIndex >= 0);
+  assert.ok(loopIndex >= 0);
+  assert.ok(accumulatorIndex < loopIndex);
+  assert.match(source, /rememberArtifactOnlyChangedFilesAfterPublication\(\s*rewrittenTrackedPaths,\s*\)/u);
+  assert.match(source, /rememberArtifactOnlyChangedFilesAfterPublication\(\s*publicationGate\.rewrittenTrackedPaths,\s*\)/u);
+});
+
 function git(cwd: string, ...args: string[]): string {
   return execFileSync("git", ["-C", cwd, ...args], {
     encoding: "utf8",

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -57,8 +57,8 @@ test("run-once turn execution keeps artifact-only repair paths across same-turn 
   assert.ok(accumulatorIndex >= 0);
   assert.ok(loopIndex >= 0);
   assert.ok(accumulatorIndex < loopIndex);
-  assert.match(source, /rememberArtifactOnlyChangedFilesAfterPublication\(\s*rewrittenTrackedPaths,\s*\)/u);
-  assert.match(source, /rememberArtifactOnlyChangedFilesAfterPublication\(\s*publicationGate\.rewrittenTrackedPaths,\s*\)/u);
+  assert.match(source, /rememberArtifactOnlyChangedFilesAfterPublication\(\s*rewrittenTrackedPaths\s*,?\s*\)/u);
+  assert.match(source, /rememberArtifactOnlyChangedFilesAfterPublication\(\s*publicationGate\.rewrittenTrackedPaths\s*,?\s*\)/u);
 });
 
 function git(cwd: string, ...args: string[]): string {

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -914,6 +914,7 @@ export async function executeCodexTurnPhase(
             verifiedNoSourceChangeReviewThreads:
               postPublicationReviewPersistence.verifiedNoSourceChangeReviewThreads,
             reviewThreadsToProcess,
+            changedFilesAfterPublication,
           });
         const preserveStaleNoPrRecoveryTracking =
           pr === null &&

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -351,6 +351,18 @@ export async function executeCodexTurnPhase(
   let sessionLock: LockHandle | null = null;
   const turnStartHeadSha = workspaceStatus.headSha;
   let usedSameTurnPathRepairRetry = false;
+  let artifactOnlyChangedFilesAfterPublication: string[] = [];
+
+  const rememberArtifactOnlyChangedFilesAfterPublication = (
+    filePaths: readonly string[],
+  ) => {
+    artifactOnlyChangedFilesAfterPublication = [
+      ...new Set([
+        ...artifactOnlyChangedFilesAfterPublication,
+        ...filePaths,
+      ]),
+    ];
+  };
 
   try {
     try {
@@ -604,7 +616,6 @@ export async function executeCodexTurnPhase(
             warningContext: "persisting",
             });
         };
-        let artifactOnlyChangedFilesAfterPublication: string[] = [];
         if (
           (workspaceStatus.remoteAhead > 0 ||
             !workspaceStatus.remoteBranchExists) &&
@@ -638,6 +649,10 @@ export async function executeCodexTurnPhase(
                 changedFilesInCurrentTurn.includes(filePath),
               );
             if (sameTurnRepairEligible) {
+              const rewrittenTrackedPaths = [
+                ...(pathHygieneGate.rewrittenJournalPaths ?? []),
+                ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ?? []),
+              ];
               const retryResult = await runSameTurnDurableArtifactRepairRetry({
                 stateStore,
                 state,
@@ -651,10 +666,7 @@ export async function executeCodexTurnPhase(
                 workspacePath,
                 workspaceStatus,
                 defaultBranch: config.defaultBranch,
-                rewrittenTrackedPaths: [
-                  ...(pathHygieneGate.rewrittenJournalPaths ?? []),
-                  ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ?? []),
-                ],
+                rewrittenTrackedPaths,
                 getWorkspaceStatus: getWorkspaceStatusImpl,
                 syncExecutionMetricsRunSummary: syncPathHygieneExecutionMetrics,
               });
@@ -665,6 +677,7 @@ export async function executeCodexTurnPhase(
                   message: retryResult.message,
                 };
               }
+              rememberArtifactOnlyChangedFilesAfterPublication(rewrittenTrackedPaths);
               workspaceStatus = retryResult.workspaceStatus;
               usedSameTurnPathRepairRetry = true;
               continue;
@@ -721,12 +734,7 @@ export async function executeCodexTurnPhase(
               rewrittenTrackedPaths,
             );
           if (presentRewrittenTrackedPaths.length > 0) {
-            artifactOnlyChangedFilesAfterPublication = [
-              ...new Set([
-                ...artifactOnlyChangedFilesAfterPublication,
-                ...presentRewrittenTrackedPaths,
-              ]),
-            ];
+            rememberArtifactOnlyChangedFilesAfterPublication(presentRewrittenTrackedPaths);
             try {
               await commitAndPushTrackedFiles({
                 workspacePath,
@@ -850,6 +858,9 @@ export async function executeCodexTurnPhase(
               message: retryResult.message,
             };
           }
+          rememberArtifactOnlyChangedFilesAfterPublication(
+            publicationGate.rewrittenTrackedPaths,
+          );
           workspaceStatus = retryResult.workspaceStatus;
           usedSameTurnPathRepairRetry = true;
           continue;

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -914,6 +914,7 @@ export async function executeCodexTurnPhase(
             currentPr: pr,
             codexVerificationCommand,
             workspaceStatus,
+            preRunState,
             structuredSummary: structuredResult?.summary,
             postRunState,
             hasVerifiedNoSourceChangeReviewThreadEvidence:
@@ -923,6 +924,7 @@ export async function executeCodexTurnPhase(
             reviewThreadsToProcess,
             changedFilesAfterPublication,
             artifactOnlyChangedFilesAfterPublication,
+            issueJournalRelativePath: config.issueJournalRelativePath,
           });
         const preserveStaleNoPrRecoveryTracking =
           pr === null &&

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -602,8 +602,9 @@ export async function executeCodexTurnPhase(
               args.config.stateFile,
             ),
             warningContext: "persisting",
-          });
+            });
         };
+        let artifactOnlyChangedFilesAfterPublication: string[] = [];
         if (
           (workspaceStatus.remoteAhead > 0 ||
             !workspaceStatus.remoteBranchExists) &&
@@ -720,6 +721,12 @@ export async function executeCodexTurnPhase(
               rewrittenTrackedPaths,
             );
           if (presentRewrittenTrackedPaths.length > 0) {
+            artifactOnlyChangedFilesAfterPublication = [
+              ...new Set([
+                ...artifactOnlyChangedFilesAfterPublication,
+                ...presentRewrittenTrackedPaths,
+              ]),
+            ];
             try {
               await commitAndPushTrackedFiles({
                 workspacePath,
@@ -915,6 +922,7 @@ export async function executeCodexTurnPhase(
               postPublicationReviewPersistence.verifiedNoSourceChangeReviewThreads,
             reviewThreadsToProcess,
             changedFilesAfterPublication,
+            artifactOnlyChangedFilesAfterPublication,
           });
         const preserveStaleNoPrRecoveryTracking =
           pr === null &&

--- a/src/turn-execution-post-publication-review.test.ts
+++ b/src/turn-execution-post-publication-review.test.ts
@@ -41,6 +41,7 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts persists scoped thr
     hasVerifiedNoSourceChangeReviewThreadEvidence: false,
     verifiedNoSourceChangeReviewThreads: [],
     reviewThreadsToProcess: [reviewThread],
+    changedFilesAfterPublication: ["src/review.ts"],
   });
 
   assert.equal(artifacts?.length, 1);
@@ -83,6 +84,7 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts preserves no-source
     hasVerifiedNoSourceChangeReviewThreadEvidence: true,
     verifiedNoSourceChangeReviewThreads: [reviewThread],
     reviewThreadsToProcess: [reviewThread],
+    changedFilesAfterPublication: [],
   });
 
   assert.equal(artifacts?.length, 1);
@@ -90,5 +92,48 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts preserves no-source
   assert.deepEqual(artifacts?.[0]?.processed_review_thread_ids, [`${reviewThread.id}@${headSha}`]);
   assert.deepEqual(artifacts?.[0]?.processed_review_thread_fingerprints, [
     `${reviewThread.id}@${headSha}#comment-no-source-repair`,
+  ]);
+});
+
+test("buildPostPublicationCodexVerificationTimelineArtifacts does not mark unchanged normal turns as current-head repair proof", () => {
+  const headSha = "head-unchanged-normal-repair";
+  const reviewThread = createReviewThread({
+    id: "thread-unchanged-normal-repair",
+    path: "src/review.ts",
+    line: 44,
+    comments: {
+      nodes: [
+        {
+          id: "comment-unchanged-normal-repair",
+          body: "P2: Verify this finding before merge.",
+          createdAt: "2026-06-15T05:23:00Z",
+          url: "https://example.test/pr/406#discussion_r408",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const artifacts = buildPostPublicationCodexVerificationTimelineArtifacts({
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    codexVerificationCommand: "npm test -- src/review.test.ts",
+    workspaceStatus: { headSha },
+    structuredSummary: "Focused verifier passed without source changes.",
+    postRunState: "blocked",
+    hasVerifiedNoSourceChangeReviewThreadEvidence: false,
+    verifiedNoSourceChangeReviewThreads: [],
+    reviewThreadsToProcess: [reviewThread],
+    changedFilesAfterPublication: [],
+  });
+
+  assert.equal(artifacts?.length, 1);
+  assert.equal(artifacts?.[0]?.repair_targets, undefined);
+  assert.deepEqual(artifacts?.[0]?.processed_review_thread_ids, [`${reviewThread.id}@${headSha}`]);
+  assert.deepEqual(artifacts?.[0]?.processed_review_thread_fingerprints, [
+    `${reviewThread.id}@${headSha}#comment-unchanged-normal-repair`,
   ]);
 });

--- a/src/turn-execution-post-publication-review.test.ts
+++ b/src/turn-execution-post-publication-review.test.ts
@@ -35,13 +35,14 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts persists scoped thr
     record: createRecord({ timeline_artifacts: [] }),
     currentPr: createPullRequest({ headRefOid: headSha }),
     codexVerificationCommand: "npm test -- src/review.test.ts",
-    workspaceStatus: { headSha },
+    workspaceStatus: { headSha, hasUncommittedChanges: false },
     structuredSummary: "Focused verifier passed without relying on summary wording.",
     postRunState: "blocked",
     hasVerifiedNoSourceChangeReviewThreadEvidence: false,
     verifiedNoSourceChangeReviewThreads: [],
     reviewThreadsToProcess: [reviewThread],
     changedFilesAfterPublication: ["src/review.ts"],
+    artifactOnlyChangedFilesAfterPublication: [],
   });
 
   assert.equal(artifacts?.length, 1);
@@ -78,13 +79,14 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts preserves no-source
     record: createRecord({ timeline_artifacts: [] }),
     currentPr: createPullRequest({ headRefOid: headSha }),
     codexVerificationCommand: "npm test -- src/review.test.ts",
-    workspaceStatus: { headSha },
+    workspaceStatus: { headSha, hasUncommittedChanges: false },
     structuredSummary: "Focused no-source verifier passed.",
     postRunState: "blocked",
     hasVerifiedNoSourceChangeReviewThreadEvidence: true,
     verifiedNoSourceChangeReviewThreads: [reviewThread],
     reviewThreadsToProcess: [reviewThread],
     changedFilesAfterPublication: [],
+    artifactOnlyChangedFilesAfterPublication: [],
   });
 
   assert.equal(artifacts?.length, 1);
@@ -121,13 +123,14 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts does not mark uncha
     record: createRecord({ timeline_artifacts: [] }),
     currentPr: createPullRequest({ headRefOid: headSha }),
     codexVerificationCommand: "npm test -- src/review.test.ts",
-    workspaceStatus: { headSha },
+    workspaceStatus: { headSha, hasUncommittedChanges: false },
     structuredSummary: "Focused verifier passed without source changes.",
     postRunState: "blocked",
     hasVerifiedNoSourceChangeReviewThreadEvidence: false,
     verifiedNoSourceChangeReviewThreads: [],
     reviewThreadsToProcess: [reviewThread],
     changedFilesAfterPublication: [],
+    artifactOnlyChangedFilesAfterPublication: [],
   });
 
   assert.equal(artifacts?.length, 1);
@@ -136,4 +139,89 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts does not mark uncha
   assert.deepEqual(artifacts?.[0]?.processed_review_thread_fingerprints, [
     `${reviewThread.id}@${headSha}#comment-unchanged-normal-repair`,
   ]);
+});
+
+test("buildPostPublicationCodexVerificationTimelineArtifacts ignores artifact-only changes for current-head repair proof", () => {
+  const headSha = "head-artifact-only-repair";
+  const reviewThread = createReviewThread({
+    id: "thread-artifact-only-repair",
+    path: "src/review.ts",
+    line: 45,
+    comments: {
+      nodes: [
+        {
+          id: "comment-artifact-only-repair",
+          body: "P2: Verify this finding before merge.",
+          createdAt: "2026-06-15T05:24:00Z",
+          url: "https://example.test/pr/406#discussion_r409",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const artifacts = buildPostPublicationCodexVerificationTimelineArtifacts({
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    codexVerificationCommand: "npm test -- src/review.test.ts",
+    workspaceStatus: { headSha, hasUncommittedChanges: false },
+    structuredSummary: "Focused verifier passed after artifact normalization.",
+    postRunState: "blocked",
+    hasVerifiedNoSourceChangeReviewThreadEvidence: false,
+    verifiedNoSourceChangeReviewThreads: [],
+    reviewThreadsToProcess: [reviewThread],
+    changedFilesAfterPublication: [
+      ".codex-supervisor/issues/2377/issue-journal.md",
+      "docs/generated-summary.md",
+    ],
+    artifactOnlyChangedFilesAfterPublication: ["docs/generated-summary.md"],
+  });
+
+  assert.equal(artifacts?.length, 1);
+  assert.equal(artifacts?.[0]?.repair_targets, undefined);
+  assert.deepEqual(artifacts?.[0]?.processed_review_thread_ids, [`${reviewThread.id}@${headSha}`]);
+});
+
+test("buildPostPublicationCodexVerificationTimelineArtifacts requires a clean workspace for current-head repair proof", () => {
+  const headSha = "head-dirty-workspace-repair";
+  const reviewThread = createReviewThread({
+    id: "thread-dirty-workspace-repair",
+    path: "src/review.ts",
+    line: 46,
+    comments: {
+      nodes: [
+        {
+          id: "comment-dirty-workspace-repair",
+          body: "P2: Verify this finding before merge.",
+          createdAt: "2026-06-15T05:25:00Z",
+          url: "https://example.test/pr/406#discussion_r410",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const artifacts = buildPostPublicationCodexVerificationTimelineArtifacts({
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    codexVerificationCommand: "npm test -- src/review.test.ts",
+    workspaceStatus: { headSha, hasUncommittedChanges: true },
+    structuredSummary: "Focused verifier passed with dirty workspace.",
+    postRunState: "blocked",
+    hasVerifiedNoSourceChangeReviewThreadEvidence: false,
+    verifiedNoSourceChangeReviewThreads: [],
+    reviewThreadsToProcess: [reviewThread],
+    changedFilesAfterPublication: ["src/review.ts"],
+    artifactOnlyChangedFilesAfterPublication: [],
+  });
+
+  assert.equal(artifacts?.length, 1);
+  assert.equal(artifacts?.[0]?.repair_targets, undefined);
+  assert.deepEqual(artifacts?.[0]?.processed_review_thread_ids, [`${reviewThread.id}@${headSha}`]);
 });

--- a/src/turn-execution-post-publication-review.test.ts
+++ b/src/turn-execution-post-publication-review.test.ts
@@ -36,6 +36,7 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts persists scoped thr
     currentPr: createPullRequest({ headRefOid: headSha }),
     codexVerificationCommand: "npm test -- src/review.test.ts",
     workspaceStatus: { headSha, hasUncommittedChanges: false },
+    preRunState: "addressing_review",
     structuredSummary: "Focused verifier passed without relying on summary wording.",
     postRunState: "blocked",
     hasVerifiedNoSourceChangeReviewThreadEvidence: false,
@@ -80,6 +81,7 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts preserves no-source
     currentPr: createPullRequest({ headRefOid: headSha }),
     codexVerificationCommand: "npm test -- src/review.test.ts",
     workspaceStatus: { headSha, hasUncommittedChanges: false },
+    preRunState: "local_review_fix",
     structuredSummary: "Focused no-source verifier passed.",
     postRunState: "blocked",
     hasVerifiedNoSourceChangeReviewThreadEvidence: true,
@@ -124,6 +126,7 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts does not mark uncha
     currentPr: createPullRequest({ headRefOid: headSha }),
     codexVerificationCommand: "npm test -- src/review.test.ts",
     workspaceStatus: { headSha, hasUncommittedChanges: false },
+    preRunState: "addressing_review",
     structuredSummary: "Focused verifier passed without source changes.",
     postRunState: "blocked",
     hasVerifiedNoSourceChangeReviewThreadEvidence: false,
@@ -168,6 +171,7 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts ignores artifact-on
     currentPr: createPullRequest({ headRefOid: headSha }),
     codexVerificationCommand: "npm test -- src/review.test.ts",
     workspaceStatus: { headSha, hasUncommittedChanges: false },
+    preRunState: "addressing_review",
     structuredSummary: "Focused verifier passed after artifact normalization.",
     postRunState: "blocked",
     hasVerifiedNoSourceChangeReviewThreadEvidence: false,
@@ -212,6 +216,7 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts requires a clean wo
     currentPr: createPullRequest({ headRefOid: headSha }),
     codexVerificationCommand: "npm test -- src/review.test.ts",
     workspaceStatus: { headSha, hasUncommittedChanges: true },
+    preRunState: "addressing_review",
     structuredSummary: "Focused verifier passed with dirty workspace.",
     postRunState: "blocked",
     hasVerifiedNoSourceChangeReviewThreadEvidence: false,
@@ -219,6 +224,91 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts requires a clean wo
     reviewThreadsToProcess: [reviewThread],
     changedFilesAfterPublication: ["src/review.ts"],
     artifactOnlyChangedFilesAfterPublication: [],
+  });
+
+  assert.equal(artifacts?.length, 1);
+  assert.equal(artifacts?.[0]?.repair_targets, undefined);
+  assert.deepEqual(artifacts?.[0]?.processed_review_thread_ids, [`${reviewThread.id}@${headSha}`]);
+});
+
+test("buildPostPublicationCodexVerificationTimelineArtifacts keeps source changes from non-review turns out of current-head repair proof", () => {
+  const headSha = "head-ci-repair-with-review-threads";
+  const reviewThread = createReviewThread({
+    id: "thread-ci-repair-with-review-threads",
+    path: "src/review.ts",
+    line: 47,
+    comments: {
+      nodes: [
+        {
+          id: "comment-ci-repair-with-review-threads",
+          body: "P2: Verify this finding before merge.",
+          createdAt: "2026-06-15T05:26:00Z",
+          url: "https://example.test/pr/406#discussion_r411",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const artifacts = buildPostPublicationCodexVerificationTimelineArtifacts({
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    codexVerificationCommand: "npm test -- src/review.test.ts",
+    workspaceStatus: { headSha, hasUncommittedChanges: false },
+    preRunState: "repairing_ci",
+    structuredSummary: "Focused verifier passed after CI repair.",
+    postRunState: "blocked",
+    hasVerifiedNoSourceChangeReviewThreadEvidence: false,
+    verifiedNoSourceChangeReviewThreads: [],
+    reviewThreadsToProcess: [reviewThread],
+    changedFilesAfterPublication: ["src/unrelated-ci-fix.ts"],
+    artifactOnlyChangedFilesAfterPublication: [],
+  });
+
+  assert.equal(artifacts?.length, 1);
+  assert.equal(artifacts?.[0]?.repair_targets, undefined);
+  assert.deepEqual(artifacts?.[0]?.processed_review_thread_ids, [`${reviewThread.id}@${headSha}`]);
+});
+
+test("buildPostPublicationCodexVerificationTimelineArtifacts honors custom journal paths when filtering repair sources", () => {
+  const headSha = "head-custom-journal-only";
+  const reviewThread = createReviewThread({
+    id: "thread-custom-journal-only",
+    path: "src/review.ts",
+    line: 48,
+    comments: {
+      nodes: [
+        {
+          id: "comment-custom-journal-only",
+          body: "P2: Verify this finding before merge.",
+          createdAt: "2026-06-15T05:27:00Z",
+          url: "https://example.test/pr/406#discussion_r412",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const artifacts = buildPostPublicationCodexVerificationTimelineArtifacts({
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    codexVerificationCommand: "npm test -- src/review.test.ts",
+    workspaceStatus: { headSha, hasUncommittedChanges: false },
+    preRunState: "addressing_review",
+    structuredSummary: "Focused verifier passed after journal update.",
+    postRunState: "blocked",
+    hasVerifiedNoSourceChangeReviewThreadEvidence: false,
+    verifiedNoSourceChangeReviewThreads: [],
+    reviewThreadsToProcess: [reviewThread],
+    changedFilesAfterPublication: [".codex-supervisor/custom-journal.md"],
+    artifactOnlyChangedFilesAfterPublication: [],
+    issueJournalRelativePath: ".codex-supervisor/custom-journal.md",
   });
 
   assert.equal(artifacts?.length, 1);

--- a/src/turn-execution-post-publication-review.test.ts
+++ b/src/turn-execution-post-publication-review.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./current-head-codex-repair-proof";
 import { buildPostPublicationCodexVerificationTimelineArtifacts } from "./turn-execution-post-publication-review";
 import {
   createPullRequest,
@@ -35,7 +36,7 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts persists scoped thr
     currentPr: createPullRequest({ headRefOid: headSha }),
     codexVerificationCommand: "npm test -- src/review.test.ts",
     workspaceStatus: { headSha },
-    structuredSummary: "Focused repair verifier passed.",
+    structuredSummary: "Focused verifier passed without relying on summary wording.",
     postRunState: "blocked",
     hasVerifiedNoSourceChangeReviewThreadEvidence: false,
     verifiedNoSourceChangeReviewThreads: [],
@@ -43,9 +44,51 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts persists scoped thr
   });
 
   assert.equal(artifacts?.length, 1);
-  assert.deepEqual(artifacts?.[0]?.repair_targets, undefined);
+  assert.deepEqual(artifacts?.[0]?.repair_targets, [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET]);
   assert.deepEqual(artifacts?.[0]?.processed_review_thread_ids, [`${reviewThread.id}@${headSha}`]);
   assert.deepEqual(artifacts?.[0]?.processed_review_thread_fingerprints, [
     `${reviewThread.id}@${headSha}#comment-normal-repair`,
+  ]);
+});
+
+test("buildPostPublicationCodexVerificationTimelineArtifacts preserves no-source-change repair targets", () => {
+  const headSha = "head-no-source-repair";
+  const reviewThread = createReviewThread({
+    id: "thread-no-source-repair",
+    path: "src/review.ts",
+    line: 43,
+    comments: {
+      nodes: [
+        {
+          id: "comment-no-source-repair",
+          body: "P2: Verify this already-addressed finding before merge.",
+          createdAt: "2026-06-14T05:23:00Z",
+          url: "https://example.test/pr/406#discussion_r407",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const artifacts = buildPostPublicationCodexVerificationTimelineArtifacts({
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    codexVerificationCommand: "npm test -- src/review.test.ts",
+    workspaceStatus: { headSha },
+    structuredSummary: "Focused no-source verifier passed.",
+    postRunState: "blocked",
+    hasVerifiedNoSourceChangeReviewThreadEvidence: true,
+    verifiedNoSourceChangeReviewThreads: [reviewThread],
+    reviewThreadsToProcess: [reviewThread],
+  });
+
+  assert.equal(artifacts?.length, 1);
+  assert.deepEqual(artifacts?.[0]?.repair_targets, ["verified_no_source_change_review_thread_residue"]);
+  assert.deepEqual(artifacts?.[0]?.processed_review_thread_ids, [`${reviewThread.id}@${headSha}`]);
+  assert.deepEqual(artifacts?.[0]?.processed_review_thread_fingerprints, [
+    `${reviewThread.id}@${headSha}#comment-no-source-repair`,
   ]);
 });

--- a/src/turn-execution-post-publication-review.ts
+++ b/src/turn-execution-post-publication-review.ts
@@ -142,6 +142,7 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   hasVerifiedNoSourceChangeReviewThreadEvidence: boolean;
   verifiedNoSourceChangeReviewThreads: ReviewThread[];
   reviewThreadsToProcess: ReviewThread[];
+  changedFilesAfterPublication: readonly string[];
 }): TimelineArtifact[] | null {
   const currentPrHeadSha = args.currentPr?.headRefOid ?? null;
   const codexTurnVerificationReviewThreads = args.hasVerifiedNoSourceChangeReviewThreadEvidence
@@ -154,9 +155,10 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   const hasCodexTurnVerificationReviewThreadEvidence =
     (codexTurnVerificationReviewThreadIds?.length ?? 0) > 0 ||
     (codexTurnVerificationReviewThreadFingerprints?.length ?? 0) > 0;
+  const hasPublishedRepairChanges = args.changedFilesAfterPublication.length > 0;
   const codexTurnVerificationRepairTargets = args.hasVerifiedNoSourceChangeReviewThreadEvidence
     ? [VERIFIED_NO_SOURCE_CHANGE_REVIEW_THREAD_RESIDUE_TARGET]
-    : hasCodexTurnVerificationReviewThreadEvidence
+    : hasPublishedRepairChanges && hasCodexTurnVerificationReviewThreadEvidence
       ? [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET]
       : undefined;
   const codexTurnVerificationHeadSha =

--- a/src/turn-execution-post-publication-review.ts
+++ b/src/turn-execution-post-publication-review.ts
@@ -65,6 +65,7 @@ function normalizeChangedFilePath(filePath: string): string {
 function changedFilesContainPublishedRepairSource(args: {
   changedFilesAfterPublication: readonly string[];
   artifactOnlyChangedFilesAfterPublication: readonly string[];
+  issueJournalRelativePath?: string;
   workspaceStatus: Pick<WorkspaceStatus, "hasUncommittedChanges">;
 }): boolean {
   if (args.workspaceStatus.hasUncommittedChanges) {
@@ -74,12 +75,15 @@ function changedFilesContainPublishedRepairSource(args: {
   const artifactOnlyPaths = new Set(
     args.artifactOnlyChangedFilesAfterPublication.map(normalizeChangedFilePath),
   );
+  const issueJournalRelativePath = args.issueJournalRelativePath
+    ? normalizeChangedFilePath(args.issueJournalRelativePath)
+    : undefined;
   return args.changedFilesAfterPublication
     .map(normalizeChangedFilePath)
     .some((filePath) =>
       !artifactOnlyPaths.has(filePath) &&
       filePath !== "WORKLOG.md" &&
-      !isIgnoredSupervisorArtifactPath(filePath)
+      !isIgnoredSupervisorArtifactPath(filePath, issueJournalRelativePath)
     );
 }
 
@@ -163,6 +167,7 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   currentPr: GitHubPullRequest | null;
   codexVerificationCommand: string | null;
   workspaceStatus: Pick<WorkspaceStatus, "hasUncommittedChanges" | "headSha">;
+  preRunState: IssueRunRecord["state"];
   structuredSummary: string | null | undefined;
   postRunState: IssueRunRecord["state"];
   hasVerifiedNoSourceChangeReviewThreadEvidence: boolean;
@@ -170,6 +175,7 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   reviewThreadsToProcess: ReviewThread[];
   changedFilesAfterPublication: readonly string[];
   artifactOnlyChangedFilesAfterPublication: readonly string[];
+  issueJournalRelativePath?: string;
 }): TimelineArtifact[] | null {
   const currentPrHeadSha = args.currentPr?.headRefOid ?? null;
   const codexTurnVerificationReviewThreads = args.hasVerifiedNoSourceChangeReviewThreadEvidence
@@ -185,11 +191,14 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   const hasPublishedRepairChanges = changedFilesContainPublishedRepairSource({
     changedFilesAfterPublication: args.changedFilesAfterPublication,
     artifactOnlyChangedFilesAfterPublication: args.artifactOnlyChangedFilesAfterPublication,
+    issueJournalRelativePath: args.issueJournalRelativePath,
     workspaceStatus: args.workspaceStatus,
   });
+  const canEmitSourceChangingReviewRepairTarget =
+    args.preRunState === "addressing_review" && hasPublishedRepairChanges;
   const codexTurnVerificationRepairTargets = args.hasVerifiedNoSourceChangeReviewThreadEvidence
     ? [VERIFIED_NO_SOURCE_CHANGE_REVIEW_THREAD_RESIDUE_TARGET]
-    : hasPublishedRepairChanges && hasCodexTurnVerificationReviewThreadEvidence
+    : canEmitSourceChangingReviewRepairTarget && hasCodexTurnVerificationReviewThreadEvidence
       ? [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET]
       : undefined;
   const codexTurnVerificationHeadSha =

--- a/src/turn-execution-post-publication-review.ts
+++ b/src/turn-execution-post-publication-review.ts
@@ -5,6 +5,7 @@ import {
   processedReviewThreadFingerprintKey,
   processedReviewThreadKey,
 } from "./review-handling";
+import { isIgnoredSupervisorArtifactPath } from "./core/git-workspace-helpers";
 import {
   hasCurrentTurnVerifiedNoSourceChangeReviewThreadEvidence,
   nextProcessedReviewThreadPatch,
@@ -56,6 +57,31 @@ function processedReviewThreadFingerprintsForHead(threads: ReviewThread[], headS
 
 const VERIFIED_NO_SOURCE_CHANGE_REVIEW_THREAD_RESIDUE_TARGET =
   "verified_no_source_change_review_thread_residue";
+
+function normalizeChangedFilePath(filePath: string): string {
+  return filePath.replace(/\\/g, "/").replace(/^(?:\.\/)+/u, "");
+}
+
+function changedFilesContainPublishedRepairSource(args: {
+  changedFilesAfterPublication: readonly string[];
+  artifactOnlyChangedFilesAfterPublication: readonly string[];
+  workspaceStatus: Pick<WorkspaceStatus, "hasUncommittedChanges">;
+}): boolean {
+  if (args.workspaceStatus.hasUncommittedChanges) {
+    return false;
+  }
+
+  const artifactOnlyPaths = new Set(
+    args.artifactOnlyChangedFilesAfterPublication.map(normalizeChangedFilePath),
+  );
+  return args.changedFilesAfterPublication
+    .map(normalizeChangedFilePath)
+    .some((filePath) =>
+      !artifactOnlyPaths.has(filePath) &&
+      filePath !== "WORKLOG.md" &&
+      !isIgnoredSupervisorArtifactPath(filePath)
+    );
+}
 
 export interface PostPublicationReviewPersistence {
   processedReviewThreadPatch: Pick<
@@ -136,13 +162,14 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   record: IssueRunRecord;
   currentPr: GitHubPullRequest | null;
   codexVerificationCommand: string | null;
-  workspaceStatus: Pick<WorkspaceStatus, "headSha">;
+  workspaceStatus: Pick<WorkspaceStatus, "hasUncommittedChanges" | "headSha">;
   structuredSummary: string | null | undefined;
   postRunState: IssueRunRecord["state"];
   hasVerifiedNoSourceChangeReviewThreadEvidence: boolean;
   verifiedNoSourceChangeReviewThreads: ReviewThread[];
   reviewThreadsToProcess: ReviewThread[];
   changedFilesAfterPublication: readonly string[];
+  artifactOnlyChangedFilesAfterPublication: readonly string[];
 }): TimelineArtifact[] | null {
   const currentPrHeadSha = args.currentPr?.headRefOid ?? null;
   const codexTurnVerificationReviewThreads = args.hasVerifiedNoSourceChangeReviewThreadEvidence
@@ -155,7 +182,11 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   const hasCodexTurnVerificationReviewThreadEvidence =
     (codexTurnVerificationReviewThreadIds?.length ?? 0) > 0 ||
     (codexTurnVerificationReviewThreadFingerprints?.length ?? 0) > 0;
-  const hasPublishedRepairChanges = args.changedFilesAfterPublication.length > 0;
+  const hasPublishedRepairChanges = changedFilesContainPublishedRepairSource({
+    changedFilesAfterPublication: args.changedFilesAfterPublication,
+    artifactOnlyChangedFilesAfterPublication: args.artifactOnlyChangedFilesAfterPublication,
+    workspaceStatus: args.workspaceStatus,
+  });
   const codexTurnVerificationRepairTargets = args.hasVerifiedNoSourceChangeReviewThreadEvidence
     ? [VERIFIED_NO_SOURCE_CHANGE_REVIEW_THREAD_RESIDUE_TARGET]
     : hasPublishedRepairChanges && hasCodexTurnVerificationReviewThreadEvidence

--- a/src/turn-execution-post-publication-review.ts
+++ b/src/turn-execution-post-publication-review.ts
@@ -1,4 +1,5 @@
 import type { LocalReviewRepairContext } from "./codex";
+import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./current-head-codex-repair-proof";
 import {
   latestReviewThreadCommentFingerprint,
   processedReviewThreadFingerprintKey,
@@ -52,6 +53,9 @@ function processedReviewThreadFingerprintsForHead(threads: ReviewThread[], headS
       : [];
   });
 }
+
+const VERIFIED_NO_SOURCE_CHANGE_REVIEW_THREAD_RESIDUE_TARGET =
+  "verified_no_source_change_review_thread_residue";
 
 export interface PostPublicationReviewPersistence {
   processedReviewThreadPatch: Pick<
@@ -140,13 +144,9 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   reviewThreadsToProcess: ReviewThread[];
 }): TimelineArtifact[] | null {
   const currentPrHeadSha = args.currentPr?.headRefOid ?? null;
-  const codexTurnVerificationRepairTargets = args.hasVerifiedNoSourceChangeReviewThreadEvidence
-    ? ["verified_no_source_change_review_thread_residue"]
-    : undefined;
-  const codexTurnVerificationReviewThreads =
-    codexTurnVerificationRepairTargets
-      ? args.verifiedNoSourceChangeReviewThreads
-      : args.reviewThreadsToProcess;
+  const codexTurnVerificationReviewThreads = args.hasVerifiedNoSourceChangeReviewThreadEvidence
+    ? args.verifiedNoSourceChangeReviewThreads
+    : args.reviewThreadsToProcess;
   const codexTurnVerificationReviewThreadIds =
     processedReviewThreadIdsForHead(codexTurnVerificationReviewThreads, currentPrHeadSha);
   const codexTurnVerificationReviewThreadFingerprints =
@@ -154,6 +154,11 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   const hasCodexTurnVerificationReviewThreadEvidence =
     (codexTurnVerificationReviewThreadIds?.length ?? 0) > 0 ||
     (codexTurnVerificationReviewThreadFingerprints?.length ?? 0) > 0;
+  const codexTurnVerificationRepairTargets = args.hasVerifiedNoSourceChangeReviewThreadEvidence
+    ? [VERIFIED_NO_SOURCE_CHANGE_REVIEW_THREAD_RESIDUE_TARGET]
+    : hasCodexTurnVerificationReviewThreadEvidence
+      ? [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET]
+      : undefined;
   const codexTurnVerificationHeadSha =
     args.currentPr &&
     args.codexVerificationCommand &&


### PR DESCRIPTION
## Summary
- Persist `verified_current_head_repair_review_thread_residue` on source-changing repair verifier artifacts when scoped review-thread evidence exists.
- Keep no-source-change residue artifacts on their existing repair target.
- Add HRCore-style regression coverage proving structured artifact proof does not depend on free-text summary wording.

## Verification
- `npx tsx --test src/turn-execution-post-publication-review.test.ts src/pull-request-state-policy.test.ts src/supervisor/supervisor-pr-readiness.test.ts`
- `npm run verify:supervisor-pre-pr`

Closes #2377