### PR TITLE
[codex] Ensure current-head Codex P2 residue repairs progress

### DIFF
--- a/replay-corpus/cases/codex-current-head-success-unresolved-must-fix/expected/replay-result.json
+++ b/replay-corpus/cases/codex-current-head-success-unresolved-must-fix/expected/replay-result.json
@@ -1,6 +1,6 @@
 {
   "nextState": "blocked",
   "shouldRunCodex": false,
-  "blockedReason": "stale_review_bot",
+  "blockedReason": "manual_review",
   "failureSignature": "stalled-bot:thread-simulator-denylist|stalled-bot:thread-production-workflow|stalled-bot:thread-ad-hoc-exec|stalled-bot:thread-authoritative-claims|stalled-bot:thread-production-exclusion-default"
 }

--- a/replay-corpus/cases/phase0-aegisops-repeated-codex-feedback-terminal/expected/replay-result.json
+++ b/replay-corpus/cases/phase0-aegisops-repeated-codex-feedback-terminal/expected/replay-result.json
@@ -1,6 +1,6 @@
 {
   "nextState": "blocked",
   "shouldRunCodex": false,
-  "blockedReason": "stale_review_bot",
+  "blockedReason": "manual_review",
   "failureSignature": "stalled-bot:thread-production-source-denylist"
 }

--- a/replay-corpus/cases/phase5-aegisops-external-handoff-review-ci-merge/expected/replay-result.json
+++ b/replay-corpus/cases/phase5-aegisops-external-handoff-review-ci-merge/expected/replay-result.json
@@ -1,6 +1,6 @@
 {
   "nextState": "blocked",
   "shouldRunCodex": false,
-  "blockedReason": "stale_review_bot",
+  "blockedReason": "manual_review",
   "failureSignature": "stalled-bot:thread-production-source-denylist"
 }

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -239,8 +239,8 @@ function projectionSafetyGatesPass(args: {
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
 }): boolean {
+  // Auto-resolution opt-in gates the write action; this proof also drives manual-resolution state.
   return (
-    args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true &&
     configuredReviewProvidersAreCodexOnly(args.config) &&
     checksPresentAndGreen(args.checks) &&
     args.record.last_head_sha === args.pr.headRefOid &&

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -38,6 +38,8 @@ import {
 import {
   buildStaleReviewBotRemediation,
   isProvenStaleReviewMetadataClassification,
+  isVerifiedStaleResidueClassification,
+  type StaleReviewBotRemediationDto,
 } from "./supervisor/stale-review-bot-remediation";
 import { projectCurrentHeadCodexRepairProof } from "./current-head-codex-repair-proof";
 import {
@@ -82,6 +84,11 @@ function allowJournalOnlyConfiguredBotThreadException(
 
   const unresolvedConfiguredBotThreads = configuredBotReviewThreads(config, reviewThreads);
   return unresolvedConfiguredBotThreads.length > 0 && unresolvedConfiguredBotThreads.every(isIssueJournalThreadPath);
+}
+
+function configuredReviewProvidersAreCodexOnly(config: SupervisorConfig): boolean {
+  const providerKinds = configuredReviewProviderKinds(config);
+  return providerKinds.length > 0 && providerKinds.every((kind) => kind === "codex");
 }
 
 function effectiveConfiguredBotReviewThreads(
@@ -244,11 +251,15 @@ function recordForCodexStaleReviewMetadataClassification(args: {
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
 }): IssueRunRecord | null {
-  if (args.record.blocked_reason === "stale_review_bot" || args.record.blocked_reason === "manual_review") {
-    return args.record;
+  if (
+    args.record.blocked_reason !== null &&
+    args.record.blocked_reason !== "stale_review_bot" &&
+    args.record.blocked_reason !== "manual_review"
+  ) {
+    return null;
   }
 
-  if (args.record.blocked_reason !== null || !configuredReviewProviderKinds(args.config).includes("codex")) {
+  if (!configuredReviewProviderKinds(args.config).includes("codex")) {
     return null;
   }
 
@@ -269,7 +280,38 @@ function recordForCodexStaleReviewMetadataClassification(args: {
     return null;
   }
 
-  if (!currentConfiguredThreads.every(hasCodexConnectorFindingReviewComment)) {
+  const recordForClassification = {
+    ...args.record,
+    blocked_reason: "stale_review_bot" as const,
+  };
+  const allCurrentConfiguredThreadsAreCodexFindings = currentConfiguredThreads.every(
+    hasCodexConnectorFindingReviewComment,
+  );
+
+  if (codexConnectorMustFixReviewThreads(currentConfiguredThreads).length > 0) {
+    if (!allCurrentConfiguredThreadsAreCodexFindings) {
+      return null;
+    }
+    const remediation = buildStaleReviewBotRemediation({
+      config: args.config,
+      record: recordForClassification,
+      pr: args.pr,
+      checks: args.checks,
+      reviewThreads: args.reviewThreads,
+    });
+    if (
+      remediation &&
+      verifiedMustFixStaleResidueHasScopedProof({
+        ...args,
+        classification: remediation.classification,
+      })
+    ) {
+      return recordForClassification;
+    }
+    return null;
+  }
+
+  if (!allCurrentConfiguredThreadsAreCodexFindings) {
     return null;
   }
 
@@ -277,10 +319,26 @@ function recordForCodexStaleReviewMetadataClassification(args: {
     return null;
   }
 
-  return {
-    ...args.record,
-    blocked_reason: "stale_review_bot",
-  };
+  return recordForClassification;
+}
+
+function verifiedMustFixStaleResidueHasScopedProof(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  classification: StaleReviewBotRemediationDto["classification"];
+}): boolean {
+  if (!isVerifiedStaleResidueClassification(args.classification)) {
+    return false;
+  }
+
+  if (args.classification === "verified_current_head_repair_pending_thread_resolution") {
+    return projectCurrentHeadCodexRepairProof(args) !== null;
+  }
+
+  return true;
 }
 
 export function hasProvenCodexConnectorStaleReviewMetadata(args: {
@@ -473,6 +531,13 @@ export function hasConfiguredProviderSuccess(
       checks,
       reviewThreads,
     })
+  ) {
+    return true;
+  }
+
+  if (
+    configuredReviewProvidersAreCodexOnly(config) &&
+    hasProvenCodexConnectorStaleReviewMetadata({ config, record, pr, checks, reviewThreads })
   ) {
     return true;
   }

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -502,11 +502,16 @@ test("inferStateFromPullRequest advances past proven Codex Connector stale metad
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
     humanReviewBlocksMerge: true,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
   });
   const record = createRecord({
     ...scenario.recordPatch,
     copilot_review_timed_out_at: null,
     copilot_review_timeout_action: null,
+    timeline_artifacts: (scenario.recordPatch.timeline_artifacts ?? []).map((artifact) => ({
+      ...artifact,
+      repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+    })),
   });
   const pr = createPullRequest({
     ...scenario.pullRequestPatch,
@@ -523,7 +528,7 @@ test("inferStateFromPullRequest advances past proven Codex Connector stale metad
   );
 });
 
-test("inferStateFromPullRequest keeps recovered Codex stale metadata residue merge-ready", () => {
+test("inferStateFromPullRequest reroutes recovered Codex stale metadata residue when current-head P2 lacks scoped proof", () => {
   const issueNumber = 2098;
   const prNumber = 118;
   const headSha = "9ba6e1cf234dd5630a2ee527cd575bebd02fbeec";
@@ -573,11 +578,11 @@ test("inferStateFromPullRequest keeps recovered Codex stale metadata residue mer
 
   assert.equal(
     inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
-    "ready_to_merge",
+    "addressing_review",
   );
   assert.equal(
     blockedReasonFromReviewState(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
-    null,
+    "manual_review",
   );
 });
 
@@ -1212,6 +1217,511 @@ test("structured current-head repair artifact proves HRCore-style repaired P2 re
   );
   assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), "ready_to_merge");
   assert.equal(hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), true);
+});
+
+test("record-level stale metadata proof does not suppress current-head Codex P2 repair progress", () => {
+  const issueNumber = 2379;
+  const prNumber = 399;
+  const headSha = "01642468db1df175a92ec8d332fdf64e7754a3ab";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_hrcore_399_progress_repair",
+    commentId: "PRRC_hrcore_399_progress_repair",
+    path: "web/src/App.tsx",
+    line: 911,
+    severity: "P2",
+    commentBody: "P2: Require termination code fields before submit.",
+    discussionUrl: "https://example.test/pr/399#discussion_r3409030367",
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    codexConnectorAutoMergeEnabled: true,
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    state: "ready_to_merge",
+    blocked_reason: null,
+    last_failure_signature: `auto-merge-refused:${headSha}:missing_current_head_codex_no_major`,
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI command passed before auto-merging PR #399.",
+      ran_at: "2026-06-14T04:59:01.275Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "npm run verify:pre-pr",
+      failure_class: null,
+      remediation_target: null,
+    },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run verify:pre-pr",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Verified current head addresses the review findings.",
+        recorded_at: "2026-06-14T04:58:52.932Z",
+      },
+    ],
+  });
+  const reviewThread = createReviewThread({
+    ...scenario.reviewThread,
+    comments: {
+      nodes: [
+        ...scenario.reviewThread.comments.nodes,
+        {
+          id: "PRRC_hrcore_399_operator_ack",
+          body:
+            "The supervisor reprocessed this configured-bot finding on the current head and classified it as stale. Leaving thread resolution to a human operator.",
+          createdAt: "2026-06-14T04:59:30Z",
+          url: "https://example.test/pr/399#discussion_r3409030500",
+          author: {
+            login: "TommyKammy",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-14T05:12:43Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [reviewThread],
+    }),
+    false,
+  );
+  assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [reviewThread]), "addressing_review");
+  assert.equal(hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, [reviewThread]), false);
+});
+
+test("verified no-source current-head P2 residue remains configured-provider success", () => {
+  const issueNumber = 2380;
+  const prNumber = 400;
+  const headSha = "b5c4f67verifiednosourcep2";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_verified_no_source_p2",
+    commentId: "PRRC_verified_no_source_p2",
+    path: "src/pull-request-state-codex-residue-policy.ts",
+    line: 273,
+    severity: "P2",
+    commentBody: "P2: Re-check this current-head finding without changing source.",
+    discussionUrl: "https://example.test/pr/400#discussion_r2380",
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-06-15T01:00:00Z",
+      observedAt: "2026-06-15T01:05:00Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    codexConnectorAutoMergeEnabled: true,
+    verifiedNoSourceChangeReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    state: "ready_to_merge",
+    blocked_reason: null,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npx tsx --test src/pull-request-state-policy.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Verified the current-head P2 finding required no source change.",
+        recorded_at: "2026-06-15T01:06:00Z",
+        repair_targets: ["verified_no_source_change_review_thread_residue"],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [`${scenario.reviewThread.id}@${headSha}#PRRC_verified_no_source_p2`],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  assert.equal(
+    hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
+    true,
+  );
+  assert.deepEqual(
+    effectiveConfiguredBotReviewThreadsForState(config, record, pr, scenario.passingChecks, [
+      scenario.reviewThread,
+    ]),
+    [],
+  );
+  assert.equal(
+    inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
+    "ready_to_merge",
+  );
+});
+
+test("verified repair current-head P2 residue remains configured-provider success", () => {
+  const issueNumber = 2380;
+  const prNumber = 403;
+  const headSha = "b5c4f67verifiedrepairp2";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_verified_repair_p2",
+    commentId: "PRRC_verified_repair_p2",
+    path: "src/pull-request-state-codex-residue-policy.ts",
+    line: 296,
+    severity: "P2",
+    commentBody: "P2: Re-check this current-head repair residue before merge.",
+    discussionUrl: "https://example.test/pr/403#discussion_r2380",
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-06-15T01:00:00Z",
+      observedAt: "2026-06-15T01:05:00Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    codexConnectorAutoMergeEnabled: true,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: false,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    state: "ready_to_merge",
+    blocked_reason: null,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npx tsx --test src/pull-request-state-policy.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head repair verifier passed.",
+        recorded_at: "2026-06-15T01:06:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [`${scenario.reviewThread.id}@${headSha}#PRRC_verified_repair_p2`],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    true,
+  );
+  assert.equal(
+    currentHeadRepairProofSatisfiesConfiguredProviderSignal({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    true,
+  );
+  assert.equal(
+    hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
+    true,
+  );
+  assert.deepEqual(
+    effectiveConfiguredBotReviewThreadsForState(config, record, pr, scenario.passingChecks, [
+      scenario.reviewThread,
+    ]),
+    [],
+  );
+  assert.equal(
+    inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
+    "ready_to_merge",
+  );
+});
+
+test("unscoped verified repair classification does not clear current-head P2 residue", () => {
+  const issueNumber = 2380;
+  const prNumber = 404;
+  const headSha = "b5c4f67unscopedrepair";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_unscoped_repair_p2",
+    commentId: "PRRC_unscoped_repair_p2",
+    path: "src/pull-request-state-codex-residue-policy.ts",
+    line: 297,
+    severity: "P2",
+    commentBody: "P2: Do not clear this current-head repair residue without scoped proof.",
+    discussionUrl: "https://example.test/pr/404#discussion_r2380",
+    verifiedRepair: {
+      summary: "Generic current-head verifier passed without scoped repair residue proof.",
+      ranAt: "2026-06-15T01:06:00Z",
+      command: "npx tsx --test src/pull-request-state-policy.test.ts",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-06-15T01:00:00Z",
+      observedAt: "2026-06-15T01:05:00Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    codexConnectorAutoMergeEnabled: true,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    state: "ready_to_merge",
+    blocked_reason: null,
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  assert.equal(
+    hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
+    false,
+  );
+  assert.deepEqual(
+    effectiveConfiguredBotReviewThreadsForState(config, record, pr, scenario.passingChecks, [
+      scenario.reviewThread,
+    ]).map((thread) => thread.id),
+    [scenario.reviewThread.id],
+  );
+  assert.equal(
+    inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
+    "addressing_review",
+  );
+});
+
+test("verified no-source Codex P2 proof does not clear mixed-provider configured threads", () => {
+  const issueNumber = 2380;
+  const prNumber = 401;
+  const headSha = "b5c4f67mixedprovider";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_verified_no_source_mixed_codex",
+    commentId: "PRRC_verified_no_source_mixed_codex",
+    path: "src/pull-request-state-codex-residue-policy.ts",
+    line: 284,
+    severity: "P2",
+    commentBody: "P2: Re-check this current-head Codex finding without changing source.",
+    discussionUrl: "https://example.test/pr/401#discussion_codex",
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-06-15T01:00:00Z",
+      observedAt: "2026-06-15T01:05:00Z",
+    },
+  });
+  const coderabbitThread = createReviewThread({
+    id: "PRRT_verified_no_source_mixed_coderabbit",
+    path: "src/review-thread-reporting.ts",
+    line: 411,
+    comments: {
+      nodes: [
+        {
+          id: "PRRC_verified_no_source_mixed_coderabbit",
+          body: "P2: Keep this non-Codex configured-bot finding blocked.",
+          createdAt: "2026-06-15T01:04:00Z",
+          url: "https://example.test/pr/401#discussion_coderabbit",
+          author: {
+            login: "coderabbitai[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN, "coderabbitai[bot]"],
+    codexConnectorAutoMergeEnabled: true,
+    verifiedNoSourceChangeReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    state: "ready_to_merge",
+    blocked_reason: null,
+    processed_review_thread_ids: [
+      ...(scenario.recordPatch.processed_review_thread_ids ?? []),
+      `${coderabbitThread.id}@${headSha}`,
+    ],
+    processed_review_thread_fingerprints: [
+      ...(scenario.recordPatch.processed_review_thread_fingerprints ?? []),
+      `${coderabbitThread.id}@${headSha}#PRRC_verified_no_source_mixed_coderabbit`,
+    ],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npx tsx --test src/pull-request-state-policy.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Verified the current-head Codex P2 finding required no source change.",
+        recorded_at: "2026-06-15T01:06:00Z",
+        repair_targets: ["verified_no_source_change_review_thread_residue"],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [`${scenario.reviewThread.id}@${headSha}#PRRC_verified_no_source_mixed_codex`],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    number: prNumber,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+  const reviewThreads = [scenario.reviewThread, coderabbitThread];
+
+  assert.equal(hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, reviewThreads), false);
+  assert.deepEqual(
+    effectiveConfiguredBotReviewThreadsForState(config, record, pr, scenario.passingChecks, reviewThreads).map(
+      (thread) => thread.id,
+    ),
+    [scenario.reviewThread.id, coderabbitThread.id],
+  );
+});
+
+test("verified Codex P2 proof does not satisfy mixed-provider review success by itself", () => {
+  const issueNumber = 2380;
+  const prNumber = 405;
+  const headSha = "b5c4f67mixednosignal";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_mixed_provider_codex_only",
+    commentId: "PRRC_mixed_provider_codex_only",
+    path: "src/pull-request-state-codex-residue-policy.ts",
+    line: 508,
+    severity: "P2",
+    commentBody: "P2: Do not let Codex-only proof satisfy every configured provider.",
+    discussionUrl: "https://example.test/pr/405#discussion_codex",
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-06-15T01:00:00Z",
+      observedAt: "2026-06-15T01:05:00Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN, "coderabbitai[bot]"],
+    codexConnectorAutoMergeEnabled: true,
+    verifiedNoSourceChangeReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    state: "ready_to_merge",
+    blocked_reason: null,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npx tsx --test src/pull-request-state-policy.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Verified the current-head Codex P2 finding required no source change.",
+        recorded_at: "2026-06-15T01:06:00Z",
+        repair_targets: ["verified_no_source_change_review_thread_residue"],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [`${scenario.reviewThread.id}@${headSha}#PRRC_mixed_provider_codex_only`],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  assert.equal(
+    hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
+    false,
+  );
+});
+
+test("already-blocked current-head Codex P2 without scoped proof is not proven stale metadata", () => {
+  const issueNumber = 2380;
+  const prNumber = 402;
+  const headSha = "b5c4f67blockedp2";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_already_blocked_p2",
+    commentId: "PRRC_already_blocked_p2",
+    path: "src/pull-request-state-codex-residue-policy.ts",
+    line: 277,
+    severity: "P2",
+    commentBody: "P2: Do not reuse generic processed-thread evidence as stale metadata proof.",
+    discussionUrl: "https://example.test/pr/402#discussion_r2380",
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-06-15T01:00:00Z",
+      observedAt: "2026-06-15T01:05:00Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    codexConnectorAutoMergeEnabled: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    state: "blocked",
+    blocked_reason: "stale_review_bot",
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run verify:pre-pr",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Generic verification passed on the current head.",
+        recorded_at: "2026-06-15T01:06:00Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotTopLevelReviewStrength: "blocking",
+  });
+
+  assert.equal(hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), false);
+  assert.deepEqual(
+    effectiveConfiguredBotReviewThreadsForState(config, record, pr, scenario.passingChecks, [
+      scenario.reviewThread,
+    ]).map((thread) => thread.id),
+    [scenario.reviewThread.id],
+  );
 });
 
 test("verified current-head repair artifact must cover current unresolved threads", () => {

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -4283,6 +4283,166 @@ test("reconcileRecoverableBlockedIssueStates allows same-head tracked PR recover
   ]);
 });
 
+test("reconcileRecoverableBlockedIssueStates advances current-head Codex P2 residue into review repair", async () => {
+  const issueNumber = 392;
+  const prNumber = 399;
+  const headSha = "01642468db1df175a92ec8d332fdf64e7754a3ab";
+  const threadId = "PRRT_hrcore_399_progress_repair";
+  const commentId = "PRRC_hrcore_399_progress_repair";
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    humanReviewBlocksMerge: true,
+    codexConnectorAutoMergeEnabled: true,
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    activeIssueNumber: issueNumber,
+    issues: [
+      createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch: `codex/issue-${issueNumber}`,
+        pr_number: prNumber,
+        last_head_sha: headSha,
+        attempt_count: 4,
+        implementation_attempt_count: 1,
+        repair_attempt_count: 0,
+        blocked_reason: "verification",
+        last_error: "Auto-merge refused because current-head Codex must-fix findings remain.",
+        last_failure_signature: `auto-merge-refused:${headSha}:missing_current_head_codex_no_major`,
+        repeated_failure_signature_count: 1,
+        processed_review_thread_ids: [`${threadId}@${headSha}`],
+        processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
+        latest_local_ci_result: {
+          outcome: "passed",
+          summary: "Configured local CI command passed before auto-merging PR #399.",
+          ran_at: "2026-06-14T04:59:01.275Z",
+          head_sha: headSha,
+          execution_mode: "shell",
+          command: "npm run verify:pre-pr",
+          failure_class: null,
+          remediation_target: null,
+        },
+        timeline_artifacts: [
+          {
+            type: "verification_result",
+            gate: "codex_turn",
+            command: "npm run verify:pre-pr",
+            head_sha: headSha,
+            outcome: "passed",
+            remediation_target: null,
+            next_action: "continue",
+            summary: "Verified current head addresses the review findings.",
+            recorded_at: "2026-06-14T04:58:52.932Z",
+          },
+        ],
+      }),
+    ],
+  });
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Implement HRCore WebUI approval flow",
+    updatedAt: "2026-06-14T05:14:00Z",
+  });
+  const pr = createPullRequest({
+    number: prNumber,
+    title: "Implement HRCore WebUI approval flow",
+    headRefName: `codex/issue-${issueNumber}`,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-14T04:59:01.275Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-14T05:12:43Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+  const reviewThread = createReviewThread({
+    id: threadId,
+    isResolved: false,
+    isOutdated: false,
+    path: "web/src/App.tsx",
+    line: 911,
+    comments: {
+      nodes: [
+        {
+          id: commentId,
+          body: "P2: Require termination code fields before submit.",
+          createdAt: "2026-06-14T04:48:23Z",
+          url: "https://example.test/pr/399#discussion_r3409030367",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+        {
+          id: "PRRC_hrcore_399_operator_ack",
+          body:
+            "The supervisor reprocessed this configured-bot finding on the current head and classified it as stale. Leaving thread resolution to a human operator.",
+          createdAt: "2026-06-14T04:59:30Z",
+          url: "https://example.test/pr/399#discussion_r3409030500",
+          author: {
+            login: "TommyKammy",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
+  let saveCalls = 0;
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "verify-pre-pr", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [reviewThread],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-06-15T00:25:00Z",
+        };
+      },
+      async save(): Promise<void> {
+        saveCalls += 1;
+      },
+    },
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues[String(issueNumber)];
+  assert.equal(updated.state, "addressing_review");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_failure_signature, null);
+  assert.equal(updated.repeated_failure_signature_count, 0);
+  assert.equal(updated.repair_attempt_count, 0);
+  assert.equal(updated.last_head_sha, headSha);
+  assert.match(
+    updated.last_recovery_reason ?? "",
+    /tracked_pr_lifecycle_recovered: resumed issue #392 from blocked to addressing_review using fresh tracked PR #399 facts/,
+  );
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    `tracked_pr_lifecycle_recovered: resumed issue #${issueNumber} from blocked to addressing_review using fresh tracked PR #${prNumber} facts at head ${headSha}`,
+  ]);
+});
+
 test("reconcileRecoverableBlockedIssueStates keeps same-head draft tracked PRs blocked when the verification gate still fails", async () => {
   const config = createConfig({
     localCiCommand: "npm run verify:paths",

--- a/src/review-thread-reporting.ts
+++ b/src/review-thread-reporting.ts
@@ -1,4 +1,4 @@
-import { hasProcessedReviewThread } from "./review-handling";
+import { hasProcessedReviewThread, reviewLoopRetryBudgetExhaustedForThread } from "./review-handling";
 import { configuredReviewBotLogins, normalizeReviewProviderLogin } from "./core/review-providers";
 import { FailureContext, GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "./core/types";
 import { nowIso } from "./core/utils";
@@ -13,6 +13,7 @@ import {
 import {
   codexConnectorMustFixReviewThreads,
   isSoftenedCodexConnectorP3Thread,
+  latestCodexConnectorReviewCommentFingerprint,
   latestCodexConnectorPSeverity,
 } from "./codex-connector-review-policy";
 
@@ -354,6 +355,10 @@ export function staleConfiguredBotReviewThreads(
     return [];
   }
 
+  if (codexConnectorMustFixReviewThreads(configuredThreads).length > 0) {
+    return [];
+  }
+
   if (pendingBotReviewThreads(config, record, pr, configuredThreads).length > 0) {
     return [];
   }
@@ -363,6 +368,63 @@ export function staleConfiguredBotReviewThreads(
   }
 
   return configuredThreads;
+}
+
+export function stalledConfiguredBotReviewThreads(
+  config: SupervisorConfig,
+  record: Pick<
+    IssueRunRecord,
+    | "processed_review_thread_ids"
+    | "processed_review_thread_fingerprints"
+    | "last_head_sha"
+    | "review_follow_up_head_sha"
+    | "review_follow_up_remaining"
+    | "last_tracked_pr_repeat_failure_decision"
+    | "review_loop_retry_state"
+  >,
+  pr: Pick<
+    GitHubPullRequest,
+    | "number"
+    | "headRefOid"
+    | "configuredBotCurrentHeadObservedAt"
+    | "configuredBotCurrentHeadStatusState"
+    | "configuredBotTopLevelReviewStrength"
+  >,
+  reviewThreads: ReviewThread[],
+): ReviewThread[] {
+  const staleThreads = staleConfiguredBotReviewThreads(config, record, pr, reviewThreads);
+  if (staleThreads.length > 0) {
+    return staleThreads;
+  }
+
+  const configuredThreads = hasExplicitCurrentHeadNoActionableConfiguredBotSignal(pr)
+    ? configuredBotReviewThreads(config, reviewThreads)
+    : actionableConfiguredBotReviewThreads(config, reviewThreads);
+  const mustFixThreads = codexConnectorMustFixReviewThreads(configuredThreads);
+  if (mustFixThreads.length === 0 || pendingBotReviewThreads(config, record, pr, configuredThreads).length > 0) {
+    return [];
+  }
+
+  const exhaustedMustFixThreads = mustFixThreads.filter((thread) =>
+    reviewLoopRetryBudgetExhaustedForThread(
+      record,
+      pr,
+      thread,
+      1,
+      latestCodexConnectorReviewCommentFingerprint(thread),
+    ),
+  );
+  if (exhaustedMustFixThreads.length === mustFixThreads.length) {
+    return exhaustedMustFixThreads;
+  }
+
+  const legacyRepeatStopExhausted =
+    record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
+    mustFixThreads.every((thread) =>
+      hasProcessedReviewThread(record, pr, thread) ||
+      hasProcessedReviewThread(record, pr, thread, latestCodexConnectorReviewCommentFingerprint(thread)),
+    );
+  return legacyRepeatStopExhausted ? mustFixThreads : [];
 }
 
 export function nonActionableConfiguredBotReviewThreads(

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -205,7 +205,9 @@ export function isProvenStaleReviewMetadataClassification(
   );
 }
 
-function isVerifiedStaleResidueClassification(classification: StaleReviewBotRemediationDto["classification"]): boolean {
+export function isVerifiedStaleResidueClassification(
+  classification: StaleReviewBotRemediationDto["classification"],
+): boolean {
   return (
     classification === "verified_no_source_change_pending_thread_resolution" ||
     classification === "verified_current_head_repair_pending_thread_resolution"

--- a/src/supervisor/supervisor-failure-context.test.ts
+++ b/src/supervisor/supervisor-failure-context.test.ts
@@ -268,6 +268,105 @@ test("inferFailureContext returns automated review blocker context", () => {
   assert.equal(context?.summary, "1 unresolved automated review thread(s) remain.");
 });
 
+test("inferFailureContext preserves stalled diagnostics for exhausted current-head Codex P2", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    humanReviewBlocksMerge: false,
+  });
+  const pr = createPullRequest({
+    number: 44,
+    headRefOid: "head123",
+    reviewDecision: null,
+    configuredBotCurrentHeadObservedAt: "2026-06-15T01:00:00Z",
+    configuredBotCurrentHeadStatusState: null,
+  });
+  const record = createRecord({
+    pr_number: 44,
+    last_head_sha: "head123",
+    processed_review_thread_ids: ["thread-p2@head123"],
+    processed_review_thread_fingerprints: ["thread-p2@head123#comment-p2"],
+    review_loop_retry_state: [
+      {
+        fingerprint: "pr=44|head=head123|thread=thread-p2|comment=comment-p2",
+        pr_number: 44,
+        head_sha: "head123",
+        thread_id: "thread-p2",
+        latest_comment_fingerprint: "comment-p2",
+        attempts: 1,
+        first_attempted_at: "2026-06-15T01:03:00Z",
+        last_attempted_at: "2026-06-15T01:03:00Z",
+      },
+    ],
+  });
+  const reviewThread = createReviewThread({
+    id: "thread-p2",
+    comments: {
+      nodes: [
+        {
+          id: "comment-p2",
+          body: "P2: Keep exhausted current-head findings visible in diagnostics.",
+          createdAt: "2026-06-15T01:02:00Z",
+          url: "https://example.test/pr/44#discussion_p2",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const context = inferFailureContext(config, record, pr, [], [reviewThread]);
+
+  assert.equal(context?.category, "manual");
+  assert.equal(context?.signature, "stalled-bot:thread-p2");
+  assert.match(context?.details[0] ?? "", /processed_on_current_head=yes/);
+});
+
+test("inferFailureContext preserves stalled diagnostics for legacy repeat-stop Codex P2", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    humanReviewBlocksMerge: false,
+  });
+  const pr = createPullRequest({
+    number: 44,
+    headRefOid: "head123",
+    reviewDecision: null,
+    configuredBotCurrentHeadObservedAt: "2026-06-15T01:00:00Z",
+    configuredBotCurrentHeadStatusState: null,
+  });
+  const record = createRecord({
+    pr_number: 44,
+    last_head_sha: "head123",
+    processed_review_thread_ids: ["thread-legacy-p2@head123"],
+    processed_review_thread_fingerprints: ["thread-legacy-p2@head123#comment-legacy-p2"],
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+  });
+  const reviewThread = createReviewThread({
+    id: "thread-legacy-p2",
+    comments: {
+      nodes: [
+        {
+          id: "comment-legacy-p2",
+          body: "P2: Keep legacy repeat-stop findings visible in diagnostics.",
+          createdAt: "2026-06-15T01:02:00Z",
+          url: "https://example.test/pr/44#discussion_legacy_p2",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const context = inferFailureContext(config, record, pr, [], [reviewThread]);
+
+  assert.equal(context?.category, "manual");
+  assert.equal(context?.signature, "stalled-bot:thread-legacy-p2");
+  assert.match(context?.details[0] ?? "", /processed_on_current_head=yes/);
+});
+
 test("inferFailureContext returns local review blocker context", () => {
   const config = createConfig({
     localReviewPolicy: "block_ready",

--- a/src/supervisor/supervisor-failure-context.ts
+++ b/src/supervisor/supervisor-failure-context.ts
@@ -19,7 +19,7 @@ import {
   manualReviewThreads,
   nonActionableConfiguredBotReviewThreads,
   pendingBotReviewThreads,
-  staleConfiguredBotReviewThreads,
+  stalledConfiguredBotReviewThreads,
 } from "../review-thread-reporting";
 import {
   localReviewBlocksMerge,
@@ -88,7 +88,7 @@ export function inferFailureContext(
       }
 
       const stalledBotReviewContext = buildStalledBotReviewFailureContext(
-        staleConfiguredBotReviewThreads(config, record, pr, effectiveConfiguredBotThreads),
+        stalledConfiguredBotReviewThreads(config, record, pr, effectiveConfiguredBotThreads),
         configuredBotReviewFollowUpState(config, record, pr, effectiveConfiguredBotThreads) === "exhausted"
           ? "exhausted_follow_up"
           : "no_progress",
@@ -143,7 +143,7 @@ export function inferFailureContext(
     }
 
     const stalledBotReviewContext = buildStalledBotReviewFailureContext(
-      staleConfiguredBotReviewThreads(config, record, pr, effectiveConfiguredBotThreads),
+      stalledConfiguredBotReviewThreads(config, record, pr, effectiveConfiguredBotThreads),
       configuredBotReviewFollowUpState(config, record, pr, effectiveConfiguredBotThreads) === "exhausted"
         ? "exhausted_follow_up"
         : "no_progress",


### PR DESCRIPTION
Fixes #2379

## Summary
This change keeps current-head Codex Connector must-fix review residue on the repair path instead of allowing it to be reclassified as stale review metadata.

## Root cause
Record-level processed-thread evidence could synthesize stale metadata proof even when the current PR head still had unresolved non-outdated Codex Connector P2 findings and no structured current-head repair proof. A parallel stale configured-bot helper could also classify those current-head must-fix threads as stale_review_bot after a no-actionable provider signal, which let the supervisor oscillate between lifecycle recovery and verification blocking instead of entering the existing repair lane.

## Changes
- Fail closed for Codex stale metadata classification when current unresolved configured-bot threads include must-fix findings, including already-blocked stale/manual records.
- Preserve verified current-head P2 residue as configured-provider success only when it has scoped no-source or scoped repair residue proof.
- Keep mixed-provider configured-bot requirements out of Codex-only proof and provider-success shortcuts.
- Align stale configured-bot review thread reporting so current-head Codex P1/P2 residue is not treated as stale review-bot work for state classification.
- Keep exhausted current-head Codex P2 threads visible in manual-stop diagnostics with stalled-bot signatures, including legacy stop_no_progress repeat stops.
- Add HRCore-style regression coverage proving current-head P2 residue with only generic processed-thread evidence returns to addressing_review, the existing repair execution entry point.
- Update replay corpus expectations so unresolved must-fix cases block as manual_review while retaining stalled-bot signatures when automation is exhausted.

## Verification
- npx tsx src/index.ts replay-corpus
- npx tsx --test src/pull-request-state-policy.test.ts src/recovery-tracked-pr-reconciliation.test.ts src/recovery-blocked-issue-reconciliation.test.ts src/supervisor/supervisor-recovery-reconciliation.test.ts src/run-once-issue-selection.test.ts src/supervisor/supervisor-failure-context.test.ts src/review-thread-reporting.test.ts src/supervisor/stale-review-bot-remediation.test.ts
- npm run verify:supervisor-pre-pr