### PR TITLE
Treat scoped repair artifacts as local verification proof

### DIFF
--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -7,7 +7,11 @@ import {
 import { configuredReviewProviderKinds } from "./core/review-providers";
 import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig, TimelineArtifact } from "./core/types";
 import { hasCodexConnectorStrongRiskWording } from "./external-review/external-review-normalization";
-import { currentHeadLocalCiMissing, hasConfiguredLocalCiCommand } from "./local-ci-policy";
+import {
+  currentHeadLocalVerificationEvidence,
+  hasConfiguredLocalCiCommand,
+  type CurrentHeadLocalVerificationEvidence,
+} from "./local-ci-policy";
 import {
   hasProcessedReviewThread,
   latestReviewThreadCommentFingerprint,
@@ -32,6 +36,8 @@ export type CurrentHeadCodexRepairProofSource =
 export interface CurrentHeadCodexRepairProofProjection {
   source: CurrentHeadCodexRepairProofSource;
   summary: string;
+  localVerificationEvidenceSource: CurrentHeadLocalVerificationEvidence["source"] | null;
+  localVerificationEvidenceSummary: string | null;
   processedThreadEvidenceCount: number;
   currentConfiguredThreadCount: number;
 }
@@ -244,7 +250,6 @@ function projectionSafetyGatesPass(args: {
     configuredReviewProvidersAreCodexOnly(args.config) &&
     checksPresentAndGreen(args.checks) &&
     args.record.last_head_sha === args.pr.headRefOid &&
-    (!hasConfiguredLocalCiCommand(args.config) || !currentHeadLocalCiMissing(args.record, args.pr)) &&
     !humanReviewBlocksProjection(args.config, args.pr, args.reviewThreads) &&
     unresolvedConfiguredBotThreadsAreCodexConnectorOnly(args.config, args.reviewThreads)
   );
@@ -274,10 +279,25 @@ export function projectCurrentHeadCodexRepairProof(args: {
   }
 
   const structuredArtifact = currentHeadVerifiedRepairResidueArtifact(args.record, args.pr, repairResidueThreads);
+  const configuredLocalCiRequired = hasConfiguredLocalCiCommand(args.config);
+  const structuredLocalVerificationEvidence = configuredLocalCiRequired
+    ? currentHeadLocalVerificationEvidence({
+        config: args.config,
+        record: args.record,
+        pr: args.pr,
+        checks: args.checks,
+        scopedTimelineArtifact: structuredArtifact,
+      })
+    : null;
+  if (configuredLocalCiRequired && !structuredLocalVerificationEvidence) {
+    return null;
+  }
   if (structuredArtifact) {
     return {
       source: "structured_artifact",
       summary: structuredArtifact.summary || "verified_current_head_repair_review_thread_residue_artifact",
+      localVerificationEvidenceSource: structuredLocalVerificationEvidence?.source ?? null,
+      localVerificationEvidenceSummary: structuredLocalVerificationEvidence?.summary ?? null,
       processedThreadEvidenceCount: structuredArtifact.processed_review_thread_ids?.length ?? 0,
       currentConfiguredThreadCount: repairResidueThreads.length,
     };
@@ -295,10 +315,24 @@ export function projectCurrentHeadCodexRepairProof(args: {
   if (!currentHeadVerification) {
     return null;
   }
+  const legacyLocalVerificationEvidence = configuredLocalCiRequired
+    ? currentHeadLocalVerificationEvidence({
+        config: args.config,
+        record: args.record,
+        pr: args.pr,
+        checks: args.checks,
+        scopedTimelineArtifact: null,
+      })
+    : null;
+  if (configuredLocalCiRequired && !legacyLocalVerificationEvidence) {
+    return null;
+  }
 
   return {
     source: "legacy_processed_thread_evidence",
     summary: `legacy_processed_thread_evidence:${currentHeadVerification.summary || currentHeadVerification.command || "current_head_codex_turn_verification"}`,
+    localVerificationEvidenceSource: legacyLocalVerificationEvidence?.source ?? null,
+    localVerificationEvidenceSummary: legacyLocalVerificationEvidence?.summary ?? null,
     processedThreadEvidenceCount,
     currentConfiguredThreadCount: repairResidueThreads.length,
   };

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -90,7 +90,15 @@ function currentHeadVerifiedRepairResidueArtifact(
   pr: Pick<GitHubPullRequest, "headRefOid">,
   currentThreads?: ReviewThread[],
 ): TimelineArtifact | null {
-  return (record.timeline_artifacts ?? []).find(
+  return currentHeadVerifiedRepairResidueArtifacts(record, pr, currentThreads)[0] ?? null;
+}
+
+function currentHeadVerifiedRepairResidueArtifacts(
+  record: Pick<IssueRunRecord, "timeline_artifacts">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  currentThreads?: ReviewThread[],
+): TimelineArtifact[] {
+  return (record.timeline_artifacts ?? []).filter(
     (artifact) =>
       artifact.type === "verification_result" &&
       artifact.outcome === "passed" &&
@@ -98,7 +106,7 @@ function currentHeadVerifiedRepairResidueArtifact(
       artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
       artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0 &&
       (!currentThreads || repairArtifactCoversCurrentThreads(artifact, pr, currentThreads)),
-  ) ?? null;
+  );
 }
 
 function artifactHeadScopedProcessedThreadEvidenceCount(
@@ -278,29 +286,52 @@ export function projectCurrentHeadCodexRepairProof(args: {
     return null;
   }
 
-  const structuredArtifact = currentHeadVerifiedRepairResidueArtifact(args.record, args.pr, repairResidueThreads);
   const configuredLocalCiRequired = hasConfiguredLocalCiCommand(args.config);
-  const structuredLocalVerificationEvidence = configuredLocalCiRequired
+  const structuredProof = currentHeadVerifiedRepairResidueArtifacts(args.record, args.pr, repairResidueThreads)
+    .map((structuredArtifact) => {
+      const localVerificationEvidence = configuredLocalCiRequired
+        ? currentHeadLocalVerificationEvidence({
+            config: args.config,
+            record: args.record,
+            pr: args.pr,
+            checks: args.checks,
+            scopedTimelineArtifact: structuredArtifact,
+          })
+        : null;
+      if (configuredLocalCiRequired && !localVerificationEvidence) {
+        return null;
+      }
+      return {
+        structuredArtifact,
+        localVerificationEvidence,
+      };
+    })
+    .find((proof): proof is {
+      structuredArtifact: TimelineArtifact;
+      localVerificationEvidence: CurrentHeadLocalVerificationEvidence | null;
+    } => proof !== null);
+  if (structuredProof) {
+    return {
+      source: "structured_artifact",
+      summary: structuredProof.structuredArtifact.summary || "verified_current_head_repair_review_thread_residue_artifact",
+      localVerificationEvidenceSource: structuredProof.localVerificationEvidence?.source ?? null,
+      localVerificationEvidenceSummary: structuredProof.localVerificationEvidence?.summary ?? null,
+      processedThreadEvidenceCount: structuredProof.structuredArtifact.processed_review_thread_ids?.length ?? 0,
+      currentConfiguredThreadCount: repairResidueThreads.length,
+    };
+  }
+
+  const unscopedLocalVerificationEvidence = configuredLocalCiRequired
     ? currentHeadLocalVerificationEvidence({
         config: args.config,
         record: args.record,
         pr: args.pr,
         checks: args.checks,
-        scopedTimelineArtifact: structuredArtifact,
+        scopedTimelineArtifact: null,
       })
     : null;
-  if (configuredLocalCiRequired && !structuredLocalVerificationEvidence) {
+  if (configuredLocalCiRequired && !unscopedLocalVerificationEvidence) {
     return null;
-  }
-  if (structuredArtifact) {
-    return {
-      source: "structured_artifact",
-      summary: structuredArtifact.summary || "verified_current_head_repair_review_thread_residue_artifact",
-      localVerificationEvidenceSource: structuredLocalVerificationEvidence?.source ?? null,
-      localVerificationEvidenceSummary: structuredLocalVerificationEvidence?.summary ?? null,
-      processedThreadEvidenceCount: structuredArtifact.processed_review_thread_ids?.length ?? 0,
-      currentConfiguredThreadCount: repairResidueThreads.length,
-    };
   }
 
   const processedThreadEvidenceCount = headScopedProcessedThreadEvidenceCount(args.record, args.pr);
@@ -315,24 +346,11 @@ export function projectCurrentHeadCodexRepairProof(args: {
   if (!currentHeadVerification) {
     return null;
   }
-  const legacyLocalVerificationEvidence = configuredLocalCiRequired
-    ? currentHeadLocalVerificationEvidence({
-        config: args.config,
-        record: args.record,
-        pr: args.pr,
-        checks: args.checks,
-        scopedTimelineArtifact: null,
-      })
-    : null;
-  if (configuredLocalCiRequired && !legacyLocalVerificationEvidence) {
-    return null;
-  }
-
   return {
     source: "legacy_processed_thread_evidence",
     summary: `legacy_processed_thread_evidence:${currentHeadVerification.summary || currentHeadVerification.command || "current_head_codex_turn_verification"}`,
-    localVerificationEvidenceSource: legacyLocalVerificationEvidence?.source ?? null,
-    localVerificationEvidenceSummary: legacyLocalVerificationEvidence?.summary ?? null,
+    localVerificationEvidenceSource: unscopedLocalVerificationEvidence?.source ?? null,
+    localVerificationEvidenceSummary: unscopedLocalVerificationEvidence?.summary ?? null,
     processedThreadEvidenceCount,
     currentConfiguredThreadCount: repairResidueThreads.length,
   };

--- a/src/local-ci-policy.ts
+++ b/src/local-ci-policy.ts
@@ -76,7 +76,7 @@ export interface CurrentHeadLocalVerificationEvidence {
 }
 
 export function currentHeadLocalVerificationEvidence(args: {
-  config: Pick<SupervisorConfig, "reviewBotLogins" | "configuredReviewProviders">;
+  config: Pick<SupervisorConfig, "localCiCommand" | "reviewBotLogins" | "configuredReviewProviders">;
   record: Pick<IssueRunRecord, "latest_local_ci_result">;
   pr: Pick<GitHubPullRequest, "headRefOid">;
   checks: Pick<PullRequestCheck, "bucket" | "name" | "workflow">[];
@@ -89,8 +89,18 @@ export function currentHeadLocalVerificationEvidence(args: {
       summary: latestLocalCi.summary || latestLocalCi.command || "current_head_local_ci_passed",
     };
   }
+  if (latestLocalCi?.head_sha === args.pr.headRefOid) {
+    return null;
+  }
 
   if (!args.scopedTimelineArtifact) {
+    return null;
+  }
+  const configuredLocalCiCommand = displayLocalCiCommand(args.config.localCiCommand ?? undefined);
+  if (
+    !configuredLocalCiCommand ||
+    args.scopedTimelineArtifact.command?.trim() !== configuredLocalCiCommand
+  ) {
     return null;
   }
 

--- a/src/local-ci-policy.ts
+++ b/src/local-ci-policy.ts
@@ -1,5 +1,10 @@
 import { displayLocalCiCommand } from "./core/config";
-import { GitHubPullRequest, IssueRunRecord, SupervisorConfig } from "./core/types";
+import {
+  configuredReviewBotLogins,
+  configuredReviewProviderKinds,
+  normalizeReviewProviderLogin,
+} from "./core/review-providers";
+import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, SupervisorConfig, TimelineArtifact } from "./core/types";
 
 export type LocalCiConfiguredState = Pick<SupervisorConfig, "localCiCommand"> & {
   localCiCommand?: SupervisorConfig["localCiCommand"] | null;
@@ -16,4 +21,96 @@ export function hasCurrentHeadLocalCiSuccess(record: IssueRunRecord, pr: GitHubP
 
 export function currentHeadLocalCiMissing(record: IssueRunRecord, pr: GitHubPullRequest): boolean {
   return !hasCurrentHeadLocalCiSuccess(record, pr);
+}
+
+function allChecksPassing(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
+  return checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
+}
+
+function isConfiguredReviewBotCheck(
+  config: Pick<SupervisorConfig, "reviewBotLogins" | "configuredReviewProviders">,
+  check: Pick<PullRequestCheck, "name" | "workflow">,
+): boolean {
+  const configuredBotLogins = configuredReviewBotLogins(config);
+  const configuredProviderKinds = configuredReviewProviderKinds(config);
+  const labels = [check.name, check.workflow].flatMap((label) => {
+    const normalized = label?.trim().toLowerCase();
+    return normalized ? [normalized] : [];
+  });
+
+  return labels.some((label) => {
+    const login = normalizeReviewProviderLogin(label);
+    if (login && configuredBotLogins.includes(login)) {
+      return true;
+    }
+    if (configuredBotLogins.some((configuredLogin) => label.includes(configuredLogin))) {
+      return true;
+    }
+    if (configuredProviderKinds.includes("codex") && label.includes("codex") && (label.includes("connector") || label.includes("review"))) {
+      return true;
+    }
+    if (configuredProviderKinds.includes("coderabbit") && label.includes("coderabbit")) {
+      return true;
+    }
+    return configuredProviderKinds.includes("copilot") && label.includes("copilot") && label.includes("review");
+  });
+}
+
+export function currentHeadPassingNonReviewChecks(
+  config: Pick<SupervisorConfig, "reviewBotLogins" | "configuredReviewProviders">,
+  checks: Pick<PullRequestCheck, "bucket" | "name" | "workflow">[],
+): Pick<PullRequestCheck, "bucket" | "name" | "workflow">[] {
+  if (!allChecksPassing(checks)) {
+    return [];
+  }
+  return checks.filter((check) => check.bucket === "pass" && !isConfiguredReviewBotCheck(config, check));
+}
+
+export type CurrentHeadLocalVerificationEvidenceSource =
+  | "latest_local_ci_result"
+  | "scoped_repair_timeline_artifact_with_non_review_checks";
+
+export interface CurrentHeadLocalVerificationEvidence {
+  source: CurrentHeadLocalVerificationEvidenceSource;
+  summary: string;
+}
+
+export function currentHeadLocalVerificationEvidence(args: {
+  config: Pick<SupervisorConfig, "reviewBotLogins" | "configuredReviewProviders">;
+  record: Pick<IssueRunRecord, "latest_local_ci_result">;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  checks: Pick<PullRequestCheck, "bucket" | "name" | "workflow">[];
+  scopedTimelineArtifact?: Pick<TimelineArtifact, "summary" | "command"> | null;
+}): CurrentHeadLocalVerificationEvidence | null {
+  const latestLocalCi = args.record.latest_local_ci_result;
+  if (latestLocalCi?.outcome === "passed" && latestLocalCi.head_sha === args.pr.headRefOid) {
+    return {
+      source: "latest_local_ci_result",
+      summary: latestLocalCi.summary || latestLocalCi.command || "current_head_local_ci_passed",
+    };
+  }
+
+  if (!args.scopedTimelineArtifact) {
+    return null;
+  }
+
+  const nonReviewChecks = currentHeadPassingNonReviewChecks(args.config, args.checks);
+  if (nonReviewChecks.length === 0) {
+    return null;
+  }
+
+  const checkNames = nonReviewChecks
+    .map((check) => check.name?.trim())
+    .filter((name): name is string => Boolean(name))
+    .slice(0, 3)
+    .join(",");
+  const checkSummary = checkNames ? `current_head_checks_passed:${checkNames}` : "current_head_checks_passed";
+  const artifactSummary =
+    args.scopedTimelineArtifact.summary ||
+    args.scopedTimelineArtifact.command ||
+    "current_head_scoped_repair_verification_passed";
+  return {
+    source: "scoped_repair_timeline_artifact_with_non_review_checks",
+    summary: `${artifactSummary};${checkSummary}`,
+  };
 }

--- a/src/local-ci-policy.ts
+++ b/src/local-ci-policy.ts
@@ -46,13 +46,17 @@ function isConfiguredReviewBotCheck(
     if (configuredBotLogins.some((configuredLogin) => label.includes(configuredLogin))) {
       return true;
     }
-    if (configuredProviderKinds.includes("codex") && label.includes("codex") && (label.includes("connector") || label.includes("review"))) {
+    if (
+      configuredProviderKinds.includes("codex") &&
+      label.includes("codex") &&
+      (label === "codex" || label.includes("connector") || label.includes("review"))
+    ) {
       return true;
     }
     if (configuredProviderKinds.includes("coderabbit") && label.includes("coderabbit")) {
       return true;
     }
-    return configuredProviderKinds.includes("copilot") && label.includes("copilot") && label.includes("review");
+    return configuredProviderKinds.includes("copilot") && label.includes("copilot") && (label === "copilot" || label.includes("review"));
   });
 }
 

--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -2341,10 +2341,19 @@ test("handlePostTurnPullRequestTransitionsPhase merges later same-head verified 
   const artifact = result.record.timeline_artifacts?.find(
     (candidate) =>
       candidate.head_sha === headSha &&
+      candidate.gate === "workspace_preparation" &&
+      candidate.command === null &&
       candidate.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true,
+  );
+  const originalVerificationArtifact = result.record.timeline_artifacts?.find(
+    (candidate) =>
+      candidate.head_sha === headSha &&
+      candidate.gate === "codex_turn" &&
+      candidate.command === "npm test -- src/post-turn-pull-request.test.ts",
   );
   assert.deepEqual(replyCalls.map((call) => call.threadId), ["thread-codex-repair-new"]);
   assert.deepEqual(resolveCalls, ["thread-codex-repair-new"]);
+  assert.equal(originalVerificationArtifact?.command, "npm test -- src/post-turn-pull-request.test.ts");
   assert.deepEqual(artifact?.processed_review_thread_ids?.sort(), [
     `thread-codex-repair-new@${headSha}`,
     `thread-codex-repair-old@${headSha}`,

--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -2364,6 +2364,130 @@ test("handlePostTurnPullRequestTransitionsPhase merges later same-head verified 
   ]);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase preserves oldest scoped local proof when timeline is full", async () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+    localCiCommand: "npm run verify:pre-pr",
+  });
+  const issue = createIssue({ title: "Preserve oldest scoped local proof" });
+  const headSha = "head-1990";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber: issue.number,
+    prNumber: 1990,
+    headSha,
+    threadId: "thread-codex-repair-local-proof",
+    commentId: "comment-codex-repair-local-proof",
+    path: "src/review.ts",
+    line: 8,
+    severity: "P2",
+    commentBody: "P2: Verify the repair residue before merge.",
+    discussionUrl: "https://example.test/pr/1990#discussion_r1990",
+  });
+  const pr = createPullRequest(scenario.pullRequestPatch);
+  const proofArtifact = {
+    type: "verification_result" as const,
+    gate: "codex_turn" as const,
+    command: "npm run verify:pre-pr",
+    head_sha: headSha,
+    outcome: "passed" as const,
+    remediation_target: null,
+    next_action: "continue" as const,
+    summary: "Configured local CI passed after the current-head repair.",
+    recorded_at: "2026-05-15T00:18:00Z",
+    repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+    processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [
+      `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+    ],
+  };
+  const fillerArtifacts = Array.from({ length: 19 }, (_, index) => ({
+    type: "verification_result" as const,
+    gate: "workspace_preparation" as const,
+    command: null,
+    head_sha: `old-head-${index}`,
+    outcome: "passed" as const,
+    remediation_target: null,
+    next_action: "continue" as const,
+    summary: `Older unrelated artifact ${index}.`,
+    recorded_at: `2026-05-15T00:${String(index).padStart(2, "0")}:00Z`,
+  }));
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        ...scenario.recordPatch,
+        latest_local_ci_result: null,
+        timeline_artifacts: [proofArtifact, ...fillerArtifacts],
+      }),
+    },
+  };
+  const replyCalls: Array<{ threadId: string; body: string }> = [];
+  const resolveCalls: string[] = [];
+  let snapshotLoads = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      replyToReviewThread: async (threadId: string, body: string) => {
+        replyCalls.push({ threadId, body });
+      },
+      resolveReviewThread: async (threadId: string) => {
+        resolveCalls.push(threadId);
+      },
+    }),
+    context: createPostTurnContext({
+      state,
+      record: state.issues["102"]!,
+      issue,
+      pr,
+      workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    }),
+    derivePullRequestLifecycleSnapshot: (recordForState, _pr, _checks, currentReviewThreads) =>
+      createLifecycleSnapshot(recordForState, currentReviewThreads.length === 0 ? "waiting_ci" : "blocked", {
+        failureContext: currentReviewThreads.length === 0 ? null : scenario.staleReviewFailureContext,
+      }),
+    applyFailureSignature: (_record, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    blockedReasonFromReviewState: (_record, _pr, _checks, currentReviewThreads) =>
+      currentReviewThreads.length === 0 ? null : "stale_review_bot",
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    runLocalCiCommand: async () => undefined,
+    runWorkstationLocalPathGate: async () => ({
+      ok: true,
+      failureContext: null,
+    }),
+    loadOpenPullRequestSnapshot: async () => {
+      snapshotLoads += 1;
+      return {
+        pr,
+        checks: scenario.passingChecks,
+        reviewThreads: snapshotLoads <= 2 ? [scenario.reviewThread] : [],
+      };
+    },
+  });
+
+  const retainedProofArtifact = result.record.timeline_artifacts?.find(
+    (candidate) =>
+      candidate.head_sha === headSha &&
+      candidate.gate === "codex_turn" &&
+      candidate.command === "npm run verify:pre-pr" &&
+      candidate.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true,
+  );
+  assert.deepEqual(replyCalls.map((call) => call.threadId), ["thread-codex-repair-local-proof"]);
+  assert.deepEqual(resolveCalls, ["thread-codex-repair-local-proof"]);
+  assert.equal(result.record.timeline_artifacts?.length, 20);
+  assert.equal(retainedProofArtifact?.command, "npm run verify:pre-pr");
+  assert.deepEqual(retainedProofArtifact?.processed_review_thread_ids, [`${scenario.reviewThread.id}@${headSha}`]);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase resolves mechanically verified P2 repair residue without no-major signal", async () => {
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -48,6 +48,7 @@ import { applyTrackedPrLifecycleState } from "./post-turn-pull-request-lifecycle
 import { maybePromoteDraftPullRequestToReady } from "./post-turn-ready-promotion";
 import { effectiveConfiguredBotReviewThreadsForState } from "./pull-request-state-codex-residue-policy";
 import { getWorkspaceStatus } from "./core/workspace";
+import { projectCurrentHeadCodexRepairProof } from "./current-head-codex-repair-proof";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 
@@ -542,11 +543,22 @@ export async function handlePostTurnPullRequestTransitionsPhase(
   if (record.state === "blocked" && record.last_failure_context?.signature?.startsWith("codex-connector-review-request-failed:")) {
     effectiveFailureContext = record.last_failure_context;
   }
+  const currentHeadRepairProof = projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr: postReady.pr,
+    checks: postReady.checks,
+    reviewThreads: postReady.reviewThreads,
+  });
+  const localCiSatisfiedByRepairProof =
+    currentHeadRepairProof?.localVerificationEvidenceSource ===
+    "scoped_repair_timeline_artifact_with_non_review_checks";
   if (
     record.state === "ready_to_merge" &&
     !postReady.pr.isDraft &&
     hasConfiguredLocalCiCommand(config) &&
     currentHeadLocalCiMissing(record, postReady.pr) &&
+    !localCiSatisfiedByRepairProof &&
     !options.dryRun
   ) {
     const currentHeadLocalCiGate = await runTrackedPrCurrentHeadLocalCiGate({

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -8,7 +8,7 @@ import {
   syncCopilotReviewTimeoutState,
   syncMergeLatencyVisibility,
 } from "./pull-request-state";
-import { GitHubPullRequest, IssueRunRecord, SupervisorConfig } from "./core/types";
+import { GitHubPullRequest, IssueRunRecord, PullRequestCheck, SupervisorConfig } from "./core/types";
 import {
   createConfig,
   createPullRequest,
@@ -1141,7 +1141,7 @@ test("legacy current-head processed-thread repair proof requires scoped verifier
   );
 });
 
-test("structured current-head repair artifact proves HRCore-style repaired P2 residue without summary wording", () => {
+test("structured current-head repair artifact proves HRCore-style repaired P2 residue without latest local CI result", () => {
   const issueNumber = 2377;
   const prNumber = 399;
   const headSha = "01642468db1df175a92ec8d332fdf64e7754a3ab";
@@ -1168,16 +1168,7 @@ test("structured current-head repair artifact proves HRCore-style repaired P2 re
     ...scenario.recordPatch,
     blocked_reason: "verification",
     last_failure_signature: `auto-merge-refused:${headSha}:missing_current_head_codex_no_major`,
-    latest_local_ci_result: {
-      outcome: "passed",
-      summary: "Configured local CI command passed before auto-merging PR #399.",
-      ran_at: "2026-06-14T04:59:01.275Z",
-      head_sha: headSha,
-      execution_mode: "shell",
-      command: "npm run verify:pre-pr",
-      failure_class: null,
-      remediation_target: null,
-    },
+    latest_local_ci_result: null,
     timeline_artifacts: [
       {
         type: "verification_result",
@@ -1217,6 +1208,79 @@ test("structured current-head repair artifact proves HRCore-style repaired P2 re
   );
   assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), "ready_to_merge");
   assert.equal(hasConfiguredProviderSuccess(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), true);
+  assert.deepEqual(effectiveConfiguredBotReviewThreadsForState(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), []);
+});
+
+test("structured current-head repair artifact still requires green non-review checks when latest local CI result is absent", () => {
+  const issueNumber = 2381;
+  const prNumber = 402;
+  const headSha = "e4642468db1df175a92ec8d332fdf64e7754a3cd";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_hrcore_402_review_check_only",
+    commentId: "PRRC_hrcore_402_review_check_only",
+    path: "web/src/App.tsx",
+    line: 812,
+    severity: "P2",
+    commentBody: "P2: Require termination code fields before submit.",
+    discussionUrl: "https://example.test/pr/402#discussion_r3409030367",
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    codexConnectorAutoMergeEnabled: true,
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "verification",
+    last_failure_signature: `auto-merge-refused:${headSha}:missing_current_head_codex_no_major`,
+    latest_local_ci_result: null,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run verify:pre-pr",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused verifier passed after the source-changing repair.",
+        recorded_at: "2026-06-14T04:58:52.932Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [
+          `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+        ],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-14T05:12:43Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+  const reviewOnlyChecks: PullRequestCheck[] = [
+    { name: "Codex Review", state: "SUCCESS", bucket: "pass", workflow: "Codex Connector Review" },
+  ];
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: reviewOnlyChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    false,
+  );
+  assert.notEqual(inferStateFromPullRequest(config, record, pr, reviewOnlyChecks, [scenario.reviewThread]), "ready_to_merge");
+  assert.equal(hasConfiguredProviderSuccess(config, record, pr, reviewOnlyChecks, [scenario.reviewThread]), false);
 });
 
 test("record-level stale metadata proof does not suppress current-head Codex P2 repair progress", () => {

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -1283,6 +1283,151 @@ test("structured current-head repair artifact still requires green non-review ch
   assert.equal(hasConfiguredProviderSuccess(config, record, pr, reviewOnlyChecks, [scenario.reviewThread]), false);
 });
 
+test("structured current-head repair artifact must run the configured local CI command", () => {
+  const issueNumber = 2381;
+  const prNumber = 402;
+  const headSha = "f4642468db1df175a92ec8d332fdf64e7754a3ce";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_hrcore_402_wrong_local_ci_command",
+    commentId: "PRRC_hrcore_402_wrong_local_ci_command",
+    path: "web/src/App.tsx",
+    line: 812,
+    severity: "P2",
+    commentBody: "P2: Require termination code fields before submit.",
+    discussionUrl: "https://example.test/pr/402#discussion_r3409030368",
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    codexConnectorAutoMergeEnabled: true,
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "verification",
+    last_failure_signature: `auto-merge-refused:${headSha}:missing_current_head_codex_no_major`,
+    latest_local_ci_result: null,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm test -- src/focused.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused verifier passed after the source-changing repair.",
+        recorded_at: "2026-06-14T04:58:52.932Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [
+          `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+        ],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-14T05:12:43Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    false,
+  );
+  assert.notEqual(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), "ready_to_merge");
+});
+
+test("structured current-head repair artifact does not override failed current-head local CI", () => {
+  const issueNumber = 2381;
+  const prNumber = 402;
+  const headSha = "a5642468db1df175a92ec8d332fdf64e7754a3cf";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_hrcore_402_failed_local_ci",
+    commentId: "PRRC_hrcore_402_failed_local_ci",
+    path: "web/src/App.tsx",
+    line: 812,
+    severity: "P2",
+    commentBody: "P2: Require termination code fields before submit.",
+    discussionUrl: "https://example.test/pr/402#discussion_r3409030369",
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    codexConnectorAutoMergeEnabled: true,
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "verification",
+    last_failure_signature: `auto-merge-refused:${headSha}:missing_current_head_codex_no_major`,
+    latest_local_ci_result: {
+      outcome: "failed",
+      summary: "Configured local CI command failed before auto-merging PR #402.",
+      ran_at: "2026-06-14T04:59:01.275Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "npm run verify:pre-pr",
+      failure_class: null,
+      remediation_target: null,
+    },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run verify:pre-pr",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused verifier passed after the source-changing repair.",
+        recorded_at: "2026-06-14T04:58:52.932Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [
+          `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+        ],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-14T05:12:43Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    false,
+  );
+  assert.notEqual(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), "ready_to_merge");
+});
+
 test("record-level stale metadata proof does not suppress current-head Codex P2 repair progress", () => {
   const issueNumber = 2379;
   const prNumber = 399;

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -1268,6 +1268,9 @@ test("structured current-head repair artifact still requires green non-review ch
   const reviewOnlyChecks: PullRequestCheck[] = [
     { name: "Codex Review", state: "SUCCESS", bucket: "pass", workflow: "Codex Connector Review" },
   ];
+  const bareCodexReviewOnlyChecks: PullRequestCheck[] = [
+    { name: "Codex", state: "SUCCESS", bucket: "pass", workflow: "Codex" },
+  ];
 
   assert.equal(
     hasVerifiedCurrentHeadRepairReviewMetadataResidue({
@@ -1281,6 +1284,21 @@ test("structured current-head repair artifact still requires green non-review ch
   );
   assert.notEqual(inferStateFromPullRequest(config, record, pr, reviewOnlyChecks, [scenario.reviewThread]), "ready_to_merge");
   assert.equal(hasConfiguredProviderSuccess(config, record, pr, reviewOnlyChecks, [scenario.reviewThread]), false);
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: bareCodexReviewOnlyChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    false,
+  );
+  assert.notEqual(
+    inferStateFromPullRequest(config, record, pr, bareCodexReviewOnlyChecks, [scenario.reviewThread]),
+    "ready_to_merge",
+  );
+  assert.equal(hasConfiguredProviderSuccess(config, record, pr, bareCodexReviewOnlyChecks, [scenario.reviewThread]), false);
 });
 
 test("structured current-head repair artifact must run the configured local CI command", () => {

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -1428,6 +1428,83 @@ test("structured current-head repair artifact does not override failed current-h
   assert.notEqual(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), "ready_to_merge");
 });
 
+test("structured current-head repair artifact searches past earlier non-local-CI scoped artifacts", () => {
+  const issueNumber = 2381;
+  const prNumber = 402;
+  const headSha = "b6642468db1df175a92ec8d332fdf64e7754a3d0";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_hrcore_402_later_local_ci_artifact",
+    commentId: "PRRC_hrcore_402_later_local_ci_artifact",
+    path: "web/src/App.tsx",
+    line: 812,
+    severity: "P2",
+    commentBody: "P2: Require termination code fields before submit.",
+    discussionUrl: "https://example.test/pr/402#discussion_r3409030370",
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    codexConnectorAutoMergeEnabled: true,
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const commonArtifact = {
+    type: "verification_result" as const,
+    gate: "codex_turn" as const,
+    head_sha: headSha,
+    outcome: "passed" as const,
+    remediation_target: null,
+    next_action: "continue" as const,
+    recorded_at: "2026-06-14T04:58:52.932Z",
+    repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+    processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [
+      `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+    ],
+  };
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "verification",
+    last_failure_signature: `auto-merge-refused:${headSha}:missing_current_head_codex_no_major`,
+    latest_local_ci_result: null,
+    timeline_artifacts: [
+      {
+        ...commonArtifact,
+        command: "npm test -- src/focused.test.ts",
+        summary: "Focused verifier passed after the source-changing repair.",
+      },
+      {
+        ...commonArtifact,
+        command: "npm run verify:pre-pr",
+        summary: "Configured local CI passed after the source-changing repair.",
+        recorded_at: "2026-06-14T04:59:52.932Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-14T05:12:43Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    true,
+  );
+  assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), "ready_to_merge");
+});
+
 test("record-level stale metadata proof does not suppress current-head Codex P2 repair progress", () => {
   const issueNumber = 2379;
   const prNumber = 399;

--- a/src/stale-configured-bot-auto-handle.ts
+++ b/src/stale-configured-bot-auto-handle.ts
@@ -4,6 +4,7 @@ import { promisify } from "node:util";
 import type { GitHubClient } from "./github";
 import type { IssueJournalSync } from "./run-once-issue-preparation";
 import type { StateStore } from "./core/state-store";
+import { displayLocalCiCommand } from "./core/config";
 import type {
   FailureContext,
   GitHubPullRequest,
@@ -202,6 +203,19 @@ function isAutoResolvedCurrentHeadVerifiedRepairResidueArtifact(
   );
 }
 
+function isConfiguredLocalCiCurrentHeadVerifiedRepairResidueArtifact(
+  config: SupervisorConfig,
+  artifact: TimelineArtifact,
+  headSha: string,
+): boolean {
+  const configuredLocalCiCommand = displayLocalCiCommand(config.localCiCommand ?? undefined);
+  return (
+    configuredLocalCiCommand !== null &&
+    isCurrentHeadVerifiedRepairResidueArtifact(artifact, headSha) &&
+    artifact.command?.trim() === configuredLocalCiCommand
+  );
+}
+
 function appendBoundedUniqueStrings(
   existing: readonly string[] | null | undefined,
   next: readonly string[] | null | undefined,
@@ -220,7 +234,13 @@ function mergeVerifiedCurrentHeadRepairResidueArtifact(
   }
 
   return {
-    ...next,
+    ...existing,
+    summary: next.summary,
+    recorded_at: next.recorded_at,
+    outcome: next.outcome,
+    next_action: next.next_action,
+    remediation_target: next.remediation_target,
+    repair_targets: appendBoundedUniqueStrings(existing.repair_targets, next.repair_targets),
     processed_review_thread_ids: appendBoundedUniqueStrings(
       existing.processed_review_thread_ids,
       next.processed_review_thread_ids,
@@ -342,15 +362,23 @@ export async function handleStaleConfiguredBotReviewRemediation(args: {
       verificationEvidenceSummary: staleReviewBotRemediation.verificationEvidenceSummary,
     });
     if (artifact) {
-      const existingArtifact = (repliedRecord.timeline_artifacts ?? []).find((candidate) =>
-        isAutoResolvedCurrentHeadVerifiedRepairResidueArtifact(candidate, args.pr.headRefOid),
-      ) ?? null;
+      const existingArtifact =
+        (repliedRecord.timeline_artifacts ?? []).find((candidate) =>
+          isConfiguredLocalCiCurrentHeadVerifiedRepairResidueArtifact(args.config, candidate, args.pr.headRefOid),
+        ) ??
+        (repliedRecord.timeline_artifacts ?? []).find((candidate) =>
+          isAutoResolvedCurrentHeadVerifiedRepairResidueArtifact(candidate, args.pr.headRefOid),
+        ) ??
+        null;
       const mergedArtifact = mergeVerifiedCurrentHeadRepairResidueArtifact(existingArtifact, artifact);
       repliedRecord = args.stateStore.touch(repliedRecord, {
         timeline_artifacts: upsertTimelineArtifact(
           repliedRecord,
           mergedArtifact,
-          (candidate) => isAutoResolvedCurrentHeadVerifiedRepairResidueArtifact(candidate, args.pr.headRefOid),
+          (candidate) =>
+            existingArtifact
+              ? candidate === existingArtifact
+              : isAutoResolvedCurrentHeadVerifiedRepairResidueArtifact(candidate, args.pr.headRefOid),
         ),
       });
       args.state.issues[String(repliedRecord.issue_number)] = repliedRecord;

--- a/src/stale-configured-bot-auto-handle.ts
+++ b/src/stale-configured-bot-auto-handle.ts
@@ -191,6 +191,17 @@ function isCurrentHeadVerifiedRepairResidueArtifact(
   );
 }
 
+function isAutoResolvedCurrentHeadVerifiedRepairResidueArtifact(
+  artifact: TimelineArtifact,
+  headSha: string,
+): boolean {
+  return (
+    isCurrentHeadVerifiedRepairResidueArtifact(artifact, headSha) &&
+    artifact.gate === "workspace_preparation" &&
+    artifact.command === null
+  );
+}
+
 function appendBoundedUniqueStrings(
   existing: readonly string[] | null | undefined,
   next: readonly string[] | null | undefined,
@@ -332,14 +343,14 @@ export async function handleStaleConfiguredBotReviewRemediation(args: {
     });
     if (artifact) {
       const existingArtifact = (repliedRecord.timeline_artifacts ?? []).find((candidate) =>
-        isCurrentHeadVerifiedRepairResidueArtifact(candidate, args.pr.headRefOid),
+        isAutoResolvedCurrentHeadVerifiedRepairResidueArtifact(candidate, args.pr.headRefOid),
       ) ?? null;
       const mergedArtifact = mergeVerifiedCurrentHeadRepairResidueArtifact(existingArtifact, artifact);
       repliedRecord = args.stateStore.touch(repliedRecord, {
         timeline_artifacts: upsertTimelineArtifact(
           repliedRecord,
           mergedArtifact,
-          (candidate) => isCurrentHeadVerifiedRepairResidueArtifact(candidate, args.pr.headRefOid),
+          (candidate) => isAutoResolvedCurrentHeadVerifiedRepairResidueArtifact(candidate, args.pr.headRefOid),
         ),
       });
       args.state.issues[String(repliedRecord.issue_number)] = repliedRecord;

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -5,7 +5,11 @@ import {
   CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
   createCodexConnectorTrackedReviewResidueScenario,
 } from "../codex-connector-tracked-pr-test-helpers";
-import { buildStaleReviewBotRemediation, buildStaleReviewBotThreadDiagnostics } from "./stale-review-bot-remediation";
+import {
+  buildStaleReviewBotRemediation,
+  buildStaleReviewBotThreadDiagnostics,
+  VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
+} from "./stale-review-bot-remediation";
 import {
   classifyStaleReviewBotAutoRepairSuppressionPolicy,
   classifyStaleReviewBotRemediationPolicy,
@@ -935,6 +939,75 @@ test("buildStaleReviewBotRemediation classifies explicit P2 repair evidence with
   assert.equal(remediation?.codexCurrentHeadReviewState, "missing");
   assert.equal(remediation?.missingProbeReason, null);
   assert.equal(remediation?.verificationEvidenceSummary, "Focused current-head repair verifier passed.");
+});
+
+test("buildStaleReviewBotRemediation surfaces scoped repair artifact plus non-review checks as local proof", () => {
+  const issueNumber = 2381;
+  const prNumber = 402;
+  const headSha = "e584c41883b831ab6b85bf3467a66a5c01fd49fd";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_hrcore_402_local_proof_artifact",
+    commentId: "PRRC_hrcore_402_local_proof_artifact",
+    path: "web/src/App.tsx",
+    line: 911,
+    severity: "P2",
+    commentBody: "P2: Require termination code fields before submit.",
+    discussionUrl: "https://example.test/pr/402#discussion_r402",
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "npm run verify:pre-pr",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "verification",
+    last_failure_signature: `auto-merge-refused:${headSha}:missing_current_head_codex_no_major`,
+    latest_local_ci_result: null,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run verify:pre-pr",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused verifier passed after the current-head repair.",
+        recorded_at: "2026-06-14T04:58:52.932Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [
+          `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+        ],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-14T05:12:43Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotCurrentHeadStatusState: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+  });
+
+  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
+  assert.equal(remediation?.missingProbeReason, null);
+  assert.match(
+    remediation?.verificationEvidenceSummary ?? "",
+    /^Focused verifier passed after the current-head repair.;local_verification=Focused verifier passed after the current-head repair.;current_head_checks_passed:build$/,
+  );
 });
 
 test("buildStaleReviewBotRemediation surfaces legacy current-head repair proof source", () => {

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -24,12 +24,9 @@ import {
   nonActionableConfiguredBotReviewThreads,
   pendingBotReviewThreads,
 } from "../review-thread-reporting";
-import {
-  configuredReviewBotLogins,
-  configuredReviewProviderKinds,
-  normalizeReviewProviderLogin,
-} from "../core/review-providers";
+import { configuredReviewProviderKinds } from "../core/review-providers";
 import { projectCurrentHeadCodexRepairProof } from "../current-head-codex-repair-proof";
+import { currentHeadPassingNonReviewChecks } from "../local-ci-policy";
 import {
   STALE_REVIEW_BOT_MANUAL_NEXT_STEP,
   VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
@@ -130,45 +127,6 @@ function codeCiState(
 
 function allChecksPassing(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
   return checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
-}
-
-function isConfiguredReviewBotCheck(
-  config: Pick<SupervisorConfig, "reviewBotLogins" | "configuredReviewProviders">,
-  check: Pick<PullRequestCheck, "name" | "workflow">,
-): boolean {
-  const configuredBotLogins = configuredReviewBotLogins(config);
-  const configuredProviderKinds = configuredReviewProviderKinds(config);
-  const labels = [check.name, check.workflow].flatMap((label) => {
-    const normalized = label?.trim().toLowerCase();
-    return normalized ? [normalized] : [];
-  });
-
-  return labels.some((label) => {
-    const login = normalizeReviewProviderLogin(label);
-    if (login && configuredBotLogins.includes(login)) {
-      return true;
-    }
-    if (configuredBotLogins.some((configuredLogin) => label.includes(configuredLogin))) {
-      return true;
-    }
-    if (configuredProviderKinds.includes("codex") && label.includes("codex") && (label.includes("connector") || label.includes("review"))) {
-      return true;
-    }
-    if (configuredProviderKinds.includes("coderabbit") && label.includes("coderabbit")) {
-      return true;
-    }
-    return configuredProviderKinds.includes("copilot") && label.includes("copilot") && label.includes("review");
-  });
-}
-
-function currentHeadPassingNonReviewChecks(
-  config: Pick<SupervisorConfig, "reviewBotLogins" | "configuredReviewProviders">,
-  checks: Pick<PullRequestCheck, "bucket" | "name" | "workflow">[],
-): Pick<PullRequestCheck, "bucket" | "name" | "workflow">[] {
-  if (!allChecksPassing(checks)) {
-    return [];
-  }
-  return checks.filter((check) => check.bucket === "pass" && !isConfiguredReviewBotCheck(config, check));
 }
 
 function hasFailingChecks(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
@@ -347,7 +305,14 @@ export function currentHeadVerifiedRepairResidueArtifactEvidenceSummary(args: {
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
 }): string | null {
-  return projectCurrentHeadCodexRepairProof(args)?.summary ?? null;
+  const proof = projectCurrentHeadCodexRepairProof(args);
+  if (!proof) {
+    return null;
+  }
+  if (proof.localVerificationEvidenceSource === "scoped_repair_timeline_artifact_with_non_review_checks") {
+    return `${proof.summary};local_verification=${proof.localVerificationEvidenceSummary}`;
+  }
+  return proof.summary;
 }
 
 function hasCurrentHeadNoSourceChangeCodexTurnVerification(

--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -19,6 +19,7 @@ import {
   executionReadyBody,
   git,
 } from "./supervisor-test-helpers";
+import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./stale-review-bot-remediation";
 
 function runnableCodexIssueBody(summary: string): string {
   return `${executionReadyBody(summary)}
@@ -481,6 +482,122 @@ test("handlePostTurnMergeAndCompletion treats verified current-head repair resid
     merged.last_auto_merge_guard_context?.details.join("\\n") ?? "",
     /codex_repair_proof_source=legacy_processed_thread_evidence/,
   );
+});
+
+test("handlePostTurnMergeAndCompletion honors scoped local proof in the final auto-merge guard", async () => {
+  const fixture = await createSupervisorFixture();
+  const issueNumber = 2381;
+  const branch = branchName(fixture.config, issueNumber);
+  const config = createConfig({
+    ...fixture.config,
+    codexConnectorAutoMergeEnabled: true,
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotSettledWaitSeconds: 0,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+    localCiCommand: "npm run verify:pre-pr",
+  });
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Merge scoped local proof",
+    body: runnableCodexIssueBody("Merge scoped local proof."),
+    createdAt: "2026-06-14T00:00:00Z",
+    updatedAt: "2026-06-14T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const headSha = "head-scoped-local-proof";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber: 4020,
+    headSha,
+    branch,
+    threadId: "thread-scoped-local-proof",
+    commentId: "comment-scoped-local-proof",
+    path: "src/review-policy.ts",
+    line: 14,
+    severity: "P2",
+    commentBody: "P2: Verify this current-head repair before merge.",
+    discussionUrl: "https://example.test/pr/4020#discussion_scoped_local_proof",
+  });
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    reviewDecision: "CHANGES_REQUESTED",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotOnlyChangesRequestedReview: true,
+    configuredBotCurrentHeadObservedAt: "2026-06-14T00:17:00Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        ...scenario.recordPatch,
+        issue_number: issueNumber,
+        state: "ready_to_merge",
+        branch,
+        blocked_reason: null,
+        last_error: null,
+        latest_local_ci_result: null,
+        timeline_artifacts: [
+          {
+            type: "verification_result",
+            gate: "codex_turn",
+            command: "npm run verify:pre-pr",
+            head_sha: headSha,
+            outcome: "passed",
+            remediation_target: null,
+            next_action: "continue",
+            summary: "Configured local CI passed after the current-head repair.",
+            recorded_at: "2026-06-14T00:18:00Z",
+            repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+            processed_review_thread_ids: [`${scenario.reviewThread.id}@${headSha}`],
+            processed_review_thread_fingerprints: [
+              `${scenario.reviewThread.id}@${headSha}#${scenario.reviewThread.comments.nodes[0]?.id}`,
+            ],
+          },
+        ],
+      }),
+    },
+  };
+  const comments: Array<{ issueNumber: number; body: string }> = [];
+  const autoMergeCalls: Array<{ prNumber: number; headSha: string }> = [];
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { loadOpenPullRequestSnapshot: (prNumber: number) => Promise<unknown> }).loadOpenPullRequestSnapshot = async (
+    prNumber: number,
+  ) => {
+    assert.equal(prNumber, 4020);
+    return { pr, checks: scenario.passingChecks, reviewThreads: [scenario.reviewThread] };
+  };
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    addIssueComment: async (commentIssueNumber: number, body: string) => {
+      comments.push({ issueNumber: commentIssueNumber, body });
+    },
+    enableAutoMerge: async (prNumber: number, mergeHeadSha: string) => {
+      autoMergeCalls.push({ prNumber, headSha: mergeHeadSha });
+    },
+  };
+
+  const merged = await (
+    supervisor as unknown as {
+      handlePostTurnMergeAndCompletion: (
+        state: SupervisorStateFile,
+        issue: GitHubIssue,
+        record: ReturnType<typeof createRecord>,
+        pr: GitHubPullRequest,
+        options: { dryRun: boolean },
+      ) => Promise<ReturnType<typeof createRecord>>;
+    }
+  ).handlePostTurnMergeAndCompletion(state, issue, state.issues[String(issueNumber)]!, pr, { dryRun: false });
+
+  assert.equal(merged.state, "merging");
+  assert.equal(merged.blocked_reason, null);
+  assert.deepEqual(autoMergeCalls, [{ prNumber: 4020, headSha }]);
+  assert.equal(comments.length, 1);
+  assert.match(comments[0]?.body ?? "", /Final auto-merge guard passed for head/);
+  assert.match(merged.last_auto_merge_guard_context?.details.join("\\n") ?? "", /local_ci=scoped_repair_proof/);
+  assert.doesNotMatch(merged.last_failure_signature ?? "", /missing_current_head_local_ci_success/);
 });
 
 test("handlePostTurnMergeAndCompletion does not auto-merge high-severity verified repair residue without Codex no-major", async () => {

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -290,7 +290,11 @@ function finalAutoMergeGuard(args: {
   });
   const localCiResult = record.latest_local_ci_result ?? null;
   const localCiConfigured = hasConfiguredLocalCiCommand(config);
-  const localCiMissing = localCiConfigured && currentHeadLocalCiMissing(record, currentPr);
+  const localCiSatisfiedByRepairProof =
+    verifiedCurrentHeadRepairProof?.localVerificationEvidenceSource ===
+    "scoped_repair_timeline_artifact_with_non_review_checks";
+  const localCiMissing =
+    localCiConfigured && currentHeadLocalCiMissing(record, currentPr) && !localCiSatisfiedByRepairProof;
   const evidenceDetails = [
     `auto_merge_path=${autoMergePath}`,
     `head_sha=${currentPr.headRefOid}`,
@@ -306,7 +310,7 @@ function finalAutoMergeGuard(args: {
     `human_blockers=${effectiveHumanBlockers}`,
     `review_decision=${currentPr.reviewDecision ?? "none"}`,
     localCiConfigured
-      ? `local_ci=${localCiResult?.outcome ?? "missing"} head_sha=${localCiResult?.head_sha ?? "none"}`
+      ? `local_ci=${localCiSatisfiedByRepairProof ? "scoped_repair_proof" : localCiResult?.outcome ?? "missing"} head_sha=${localCiResult?.head_sha ?? "none"}`
       : "local_ci=not_configured",
   ];
 


### PR DESCRIPTION
## Summary

Closes #2381.

This changes current-head Codex repair-residue projection so repos with a configured local CI command are no longer limited to `latest_local_ci_result` as the only acceptable local verification proof. A narrowly scoped `verification_result` timeline artifact can now satisfy the local verification requirement when it is tied to the current head, marks `verified_current_head_repair_review_thread_residue`, covers the unresolved review-thread ids/fingerprints, and current-head non-review checks are green.

## Changes

- Centralized current-head non-review check filtering in `local-ci-policy` so stale-review diagnostics and repair projection share the same provider-exclusion logic.
- Added `currentHeadLocalVerificationEvidence` with two accepted sources:
  - `latest_local_ci_result`
  - `scoped_repair_timeline_artifact_with_non_review_checks`
- Moved the local verification gate into `projectCurrentHeadCodexRepairProof`, after scoped repair artifact validation, so generic `codex_turn` artifacts remain insufficient.
- Surfaced the selected local verification evidence in stale-review-bot remediation summaries for operator diagnostics.
- Added regressions for the HRCore-style case where `latest_local_ci_result` is absent but scoped repair evidence and green non-review checks exist, plus a fail-closed review-check-only case.

## Verification

- `npx tsx --test src/pull-request-state-policy.test.ts src/supervisor/stale-review-bot-remediation.test.ts src/recovery-blocked-issue-reconciliation.test.ts`
- `npx tsx src/index.ts replay-corpus`
- `git diff --check`
- `npm run verify:supervisor-pre-pr`
