### PR TITLE
[codex] Add thread-scoped repair proof

### DIFF
--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -1,5 +1,6 @@
 import {
   codexConnectorMustFixReviewThreads,
+  commitShasEqualForComparison,
   hasCodexConnectorFindingReviewComment,
   latestCodexConnectorReviewComment,
   latestCodexConnectorPSeverity,
@@ -31,6 +32,7 @@ export const VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET =
 
 export type CurrentHeadCodexRepairProofSource =
   | "structured_artifact"
+  | "thread_scoped_verification_artifact"
   | "legacy_processed_thread_evidence";
 
 export interface CurrentHeadCodexRepairProofProjection {
@@ -83,6 +85,24 @@ function currentHeadCodexTurnVerificationArtifact(
       artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") !== true &&
       repairArtifactCoversCurrentThreads(artifact, pr, currentThreads),
   ) ?? null;
+}
+
+function currentHeadThreadScopedVerificationArtifacts(
+  record: Pick<IssueRunRecord, "timeline_artifacts">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  currentThreads: ReviewThread[],
+): TimelineArtifact[] {
+  return (record.timeline_artifacts ?? []).filter(
+    (artifact) =>
+      artifact.type === "verification_result" &&
+      artifact.gate === "codex_turn" &&
+      artifact.outcome === "passed" &&
+      artifact.head_sha === pr.headRefOid &&
+      artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") !== true &&
+      artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) !== true &&
+      artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0 &&
+      repairArtifactCoversCurrentThreads(artifact, pr, currentThreads),
+  );
 }
 
 function currentHeadVerifiedRepairResidueArtifact(
@@ -139,7 +159,7 @@ function repairArtifactCoversCurrentThreads(
         processedReviewThreadFingerprintKey(thread.id, pr.headRefOid, latestFingerprint),
       )
     ) {
-      return true;
+      return latestReviewThreadCommentPredatesArtifact(thread, artifact);
     }
     if (!processedThreadIds.includes(headScopedKey)) {
       return false;
@@ -234,6 +254,69 @@ function isCurrentHeadNoMajorMergeGuardFailure(
   );
 }
 
+function validTimestamp(value: string | null | undefined): string | null {
+  if (!value || Number.isNaN(Date.parse(value))) {
+    return null;
+  }
+  return value;
+}
+
+function currentHeadNoMajorSupportSummary(
+  record: Pick<
+    IssueRunRecord,
+    "codex_connector_review_requested_observed_at" | "codex_connector_review_requested_head_sha"
+  >,
+  pr: Pick<
+    GitHubPullRequest,
+    | "headRefOid"
+    | "codexConnectorReviewRequestedAt"
+    | "codexConnectorReviewRequestedHeadSha"
+    | "configuredBotCurrentHeadObservedAt"
+    | "configuredBotCurrentHeadObservationSource"
+  >,
+): string | null {
+  if (pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment") {
+    return null;
+  }
+  const observedAt = validTimestamp(pr.configuredBotCurrentHeadObservedAt);
+  if (!observedAt) {
+    return null;
+  }
+  const requestedAt =
+    validTimestamp(record.codex_connector_review_requested_observed_at) ??
+    validTimestamp(pr.codexConnectorReviewRequestedAt);
+  const requestedHeadSha =
+    record.codex_connector_review_requested_head_sha ?? pr.codexConnectorReviewRequestedHeadSha;
+  if (!requestedAt || !commitShasEqualForComparison(requestedHeadSha, pr.headRefOid)) {
+    return null;
+  }
+  if (Date.parse(observedAt) < Date.parse(requestedAt)) {
+    return null;
+  }
+  return "codex_pr_success_comment_after_current_head_request";
+}
+
+function formatThreadScopedVerificationSummary(args: {
+  artifact: TimelineArtifact;
+  localVerificationEvidence: CurrentHeadLocalVerificationEvidence | null;
+  noMajorSupport: string | null;
+}): string {
+  const artifactSummary =
+    args.artifact.summary ||
+    args.artifact.command ||
+    "current_head_thread_scoped_verification_passed";
+  const details = [`thread_scoped_current_head_verification_artifact:${artifactSummary}`];
+  if (args.localVerificationEvidence) {
+    details.push(
+      `local_verification=${args.localVerificationEvidence.source}:${args.localVerificationEvidence.summary}`,
+    );
+  }
+  if (args.noMajorSupport) {
+    details.push(`codex_no_major_support=${args.noMajorSupport}`);
+  }
+  return details.join(";");
+}
+
 function humanReviewBlocksProjection(
   config: SupervisorConfig,
   pr: GitHubPullRequest,
@@ -317,6 +400,48 @@ export function projectCurrentHeadCodexRepairProof(args: {
       localVerificationEvidenceSource: structuredProof.localVerificationEvidence?.source ?? null,
       localVerificationEvidenceSummary: structuredProof.localVerificationEvidence?.summary ?? null,
       processedThreadEvidenceCount: structuredProof.structuredArtifact.processed_review_thread_ids?.length ?? 0,
+      currentConfiguredThreadCount: repairResidueThreads.length,
+    };
+  }
+
+  const noMajorSupport = currentHeadNoMajorSupportSummary(args.record, args.pr);
+  const threadScopedProof = noMajorSupport
+    ? currentHeadThreadScopedVerificationArtifacts(args.record, args.pr, repairResidueThreads)
+        .map((artifact) => {
+          const localVerificationEvidence = configuredLocalCiRequired
+            ? currentHeadLocalVerificationEvidence({
+                config: args.config,
+                record: args.record,
+                pr: args.pr,
+                checks: args.checks,
+                scopedTimelineArtifact: artifact,
+              })
+            : null;
+          if (configuredLocalCiRequired && !localVerificationEvidence) {
+            return null;
+          }
+          return {
+            artifact,
+            localVerificationEvidence,
+          };
+        })
+        .find((proof): proof is {
+          artifact: TimelineArtifact;
+          localVerificationEvidence: CurrentHeadLocalVerificationEvidence | null;
+        } => proof !== null)
+    : null;
+  if (threadScopedProof) {
+    return {
+      source: "thread_scoped_verification_artifact",
+      summary: formatThreadScopedVerificationSummary({
+        artifact: threadScopedProof.artifact,
+        localVerificationEvidence: threadScopedProof.localVerificationEvidence,
+        noMajorSupport,
+      }),
+      localVerificationEvidenceSource: threadScopedProof.localVerificationEvidence?.source ?? null,
+      localVerificationEvidenceSummary: threadScopedProof.localVerificationEvidence?.summary ?? null,
+      processedThreadEvidenceCount:
+        threadScopedProof.artifact.processed_review_thread_ids?.length ?? 0,
       currentConfiguredThreadCount: repairResidueThreads.length,
     };
   }

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -26,7 +26,10 @@ import {
   hasConfiguredProviderSuccess,
   hasVerifiedCurrentHeadRepairReviewMetadataResidue,
 } from "./pull-request-state-codex-residue-policy";
-import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./supervisor/stale-review-bot-remediation";
+import {
+  currentHeadVerifiedRepairResidueArtifactEvidenceSummary,
+  VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
+} from "./supervisor/stale-review-bot-remediation";
 
 test("inferStateFromPullRequest routes actionable high local-review retry into local_review_fix", () => {
   const config = createConfig({
@@ -668,6 +671,167 @@ test("verified current-head repair residue evidence can replace Codex no-major e
   assert.equal(inferGitHubWaitStep(config, record, pr, scenario.passingChecks, []), null);
 });
 
+test("thread-scoped current-head verification artifact proves repaired Codex P2 residue", () => {
+  const issueNumber = 2383;
+  const prNumber = 44;
+  const headSha = "3cc6bf7f17a37a7bd2e766a40d856fd7ccc0f2cc";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_veridoc_scope_binding",
+    commentId: "PRRC_veridoc_scope_binding",
+    path: "core/validate/automatic.py",
+    line: 78,
+    severity: "P2",
+    commentBody: "P2: Do not let confidence review skip scope binding.",
+    discussionUrl: "https://example.test/pr/44#discussion_r3452786352",
+    verifiedRepair: {
+      summary: "Focused low-confidence scope-binding verifier passed.",
+      ranAt: "2026-06-22T14:18:00Z",
+      command: "python3 -m pytest tests/test_automatic_validation.py",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-06-22T14:11:32Z",
+      observedAt: "2026-06-22T14:15:07Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    codexConnectorAutoMergeEnabled: true,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "stale_review_bot",
+  });
+  const pr = createPullRequest(scenario.pullRequestPatch);
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    true,
+  );
+  assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), "ready_to_merge");
+  assert.deepEqual(
+    effectiveConfiguredBotReviewThreadsForState(config, record, pr, scenario.passingChecks, [scenario.reviewThread]),
+    [],
+  );
+  assert.match(
+    currentHeadVerifiedRepairResidueArtifactEvidenceSummary({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }) ?? "",
+    /thread_scoped_current_head_verification_artifact:Focused low-confidence scope-binding verifier passed.;codex_no_major_support=codex_pr_success_comment_after_current_head_request/u,
+  );
+});
+
+test("same-head no-major comment without thread-scoped verification does not prove Codex P2 residue", () => {
+  const issueNumber = 2383;
+  const prNumber = 44;
+  const headSha = "3cc6bf7f17a37a7bd2e766a40d856fd7ccc0f2cc";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_veridoc_no_proof",
+    commentId: "PRRC_veridoc_no_proof",
+    path: "core/validate/automatic.py",
+    line: 78,
+    severity: "P2",
+    commentBody: "P2: Do not let confidence review skip scope binding.",
+    discussionUrl: "https://example.test/pr/44#discussion_r3452786352",
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-06-22T14:11:32Z",
+      observedAt: "2026-06-22T14:15:07Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    codexConnectorAutoMergeEnabled: true,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "stale_review_bot",
+  });
+  const pr = createPullRequest(scenario.pullRequestPatch);
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    false,
+  );
+  assert.notEqual(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), "ready_to_merge");
+});
+
+test("thread-scoped verification artifact must postdate the latest Codex thread comment", () => {
+  const issueNumber = 2383;
+  const prNumber = 44;
+  const headSha = "3cc6bf7f17a37a7bd2e766a40d856fd7ccc0f2cc";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_veridoc_stale_proof",
+    commentId: "PRRC_veridoc_stale_proof",
+    path: "core/validate/automatic.py",
+    line: 78,
+    severity: "P2",
+    commentBody: "P2: Do not let confidence review skip scope binding.",
+    discussionUrl: "https://example.test/pr/44#discussion_r3452786352",
+    verifiedRepair: {
+      summary: "Focused verifier ran before the review thread was updated.",
+      ranAt: "2026-05-15T00:01:00Z",
+      command: "python3 -m pytest tests/test_automatic_validation.py",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-06-22T14:11:32Z",
+      observedAt: "2026-06-22T14:15:07Z",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    codexConnectorAutoMergeEnabled: true,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    ...scenario.recordPatch,
+    blocked_reason: "stale_review_bot",
+  });
+  const pr = createPullRequest(scenario.pullRequestPatch);
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenario.passingChecks,
+      reviewThreads: [scenario.reviewThread],
+    }),
+    false,
+  );
+  assert.notEqual(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, [scenario.reviewThread]), "ready_to_merge");
+});
+
 test("legacy current-head processed-thread repair proof can replace Codex no-major evidence", () => {
   const issueNumber = 2375;
   const prNumber = 399;
@@ -803,6 +967,7 @@ test("legacy current-head processed-thread repair proof can replace Codex no-maj
       record: createRecord({
         ...record,
         latest_local_ci_result: null,
+        timeline_artifacts: [],
       }),
       pr,
       checks: scenario.passingChecks,
@@ -1012,6 +1177,7 @@ test("legacy current-head processed-thread repair proof requires current-head no
     ...scenario.recordPatch,
     blocked_reason: "verification",
     last_failure_signature: `auto-merge-refused:${oldHeadSha}:missing_current_head_codex_no_major`,
+    timeline_artifacts: [],
     last_failure_context: {
       category: "blocked",
       summary: "Old auto-merge guard refusal should not prove the current head.",

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -203,7 +203,7 @@ test("buildStaleReviewBotRemediation classifies same-head Codex no-major comment
   );
   assert.match(
     remediation?.verificationEvidenceSummary ?? "",
-    /Focused mutation lock verifier passed on the current head.;codex_pr_success_comment_after_current_head_request/,
+    /thread_scoped_current_head_verification_artifact:Focused mutation lock verifier passed on the current head.;codex_no_major_support=codex_pr_success_comment_after_current_head_request/u,
   );
   assert.equal(diagnostics?.currentHeadSuccess, "yes");
 });

--- a/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
@@ -1615,7 +1615,7 @@ test("status --why surfaces verified Codex residue remediation for manual_review
 
   assert.match(
     status,
-    /^stale_review_bot_remediation issue=#143 pr=#147 reason=stale_review_bot code_ci=green current_head_sha=68401b26947918f0ce2280a9526ab68298b1a25c processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/147#discussion_r147 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=verify-pre-pr_passed_with_96_tests\.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+    /^stale_review_bot_remediation issue=#143 pr=#147 reason=stale_review_bot code_ci=green current_head_sha=68401b26947918f0ce2280a9526ab68298b1a25c processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/147#discussion_r147 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=thread_scoped_current_head_verification_artifact:verify-pre-pr_passed_with_96_tests\.;codex_no_major_support=codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
   );
   assert.match(status, /^operator_action action=resolve_stale_review_bot source=stale_review_bot_remediation /m);
   assert.doesNotMatch(status, /run-once --config \.\.\. --dry-run/);

--- a/src/supervisor/supervisor-diagnostics-explain-stale-review-bot.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain-stale-review-bot.test.ts
@@ -836,7 +836,7 @@ test("explain distinguishes Codex verified current-head repair residue from no-s
 
   assert.match(
     explanation,
-    /^stale_review_bot_remediation issue=#199 pr=#399 reason=stale_review_bot code_ci=green current_head_sha=head-199 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/399#discussion_r399 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+    /^stale_review_bot_remediation issue=#199 pr=#399 reason=stale_review_bot code_ci=green current_head_sha=head-199 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/399#discussion_r399 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=thread_scoped_current_head_verification_artifact:Focused_verifier_passed_after_the_repair_commit\.;codex_no_major_support=codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
   );
   assert.doesNotMatch(explanation, /classification=verified_no_source_change_pending_thread_resolution/);
 });

--- a/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
@@ -746,7 +746,7 @@ test("status --why uses the shared stale review-bot presenter for active verifie
 
   assert.match(
     status,
-    /^stale_review_bot_remediation issue=#400 pr=#500 reason=stale_review_bot code_ci=green current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/500#discussion_r400 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+    /^stale_review_bot_remediation issue=#400 pr=#500 reason=stale_review_bot code_ci=green current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f4 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/500#discussion_r400 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=thread_scoped_current_head_verification_artifact:Focused_verifier_passed_after_the_repair_commit\.;codex_no_major_support=codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
   );
   assert.doesNotMatch(
     status,


### PR DESCRIPTION
## Summary

Implements #2383 by adding a conservative thread-scoped current-head verification proof path for unresolved Codex Connector P2 review residue.

## What changed

- Added a new `thread_scoped_verification_artifact` current-head repair proof source.
- Accepts focused `codex_turn` verification artifacts only when they:
  - are for the current PR head,
  - cover the current unresolved thread id/fingerprint,
  - postdate the latest thread comment,
  - pass the existing green-check and configured-provider safety gates,
  - satisfy configured local CI identity when `localCiCommand` is set,
  - have same-head Codex no-major support as corroboration.
- Kept no-major comments non-authoritative by themselves.
- Added regression coverage for the VeriDoc-shaped case and fail-closed cases.

## Validation

- `npx tsx --test src/pull-request-state-policy.test.ts src/supervisor/stale-review-bot-remediation.test.ts src/operator-actions.test.ts`
- `npx tsx --test src/post-turn-pull-request-codex-connector.test.ts src/supervisor/supervisor-pr-readiness.test.ts`
- `npx tsx src/index.ts replay-corpus`
- `npm run verify:supervisor-pre-pr`
- `node dist/index.js issue-lint 2383 --config supervisor.config.codex.json`
- `git diff --check`
