### PR TITLE
[codex] Route still-valid Codex review threads back to repair

### DIFF
--- a/src/codex-connector-valid-review-repair-selection.ts
+++ b/src/codex-connector-valid-review-repair-selection.ts
@@ -1,0 +1,79 @@
+import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "./core/types";
+import { configuredReviewProviderKinds } from "./core/review-providers";
+import { manualReviewThreads } from "./review-thread-reporting";
+import { buildCodexConnectorStillValidReviewRepairTargets } from "./codex-connector-valid-review-repair";
+
+function allChecksGreen(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
+  return checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
+}
+
+function prAllowsRepair(pr: Pick<GitHubPullRequest, "state" | "isDraft" | "mergeStateStatus" | "mergeable">): boolean {
+  return pr.state === "OPEN" && !pr.isDraft && pr.mergeStateStatus !== "DIRTY" && pr.mergeable !== "CONFLICTING";
+}
+
+export function shouldReenterCodexConnectorValidReviewRepair(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): boolean {
+  return (
+    args.record.pr_number === args.pr.number &&
+    configuredReviewProviderKinds(args.config).includes("codex") &&
+    prAllowsRepair(args.pr) &&
+    allChecksGreen(args.checks) &&
+    (!args.config.humanReviewBlocksMerge || manualReviewThreads(args.config, args.reviewThreads).length === 0) &&
+    buildCodexConnectorStillValidReviewRepairTargets({
+      record: args.record,
+      pr: args.pr,
+      reviewThreads: args.reviewThreads,
+    }).length > 0
+  );
+}
+
+export async function shouldSelectCodexConnectorValidReviewRepair(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord | undefined;
+  getPullRequestIfExists?: (
+    prNumber: number,
+    options?: { purpose?: "status" | "action" },
+  ) => Promise<GitHubPullRequest | null>;
+  getChecks?: (prNumber: number) => Promise<PullRequestCheck[]>;
+  getUnresolvedReviewThreads?: (prNumber: number) => Promise<ReviewThread[]>;
+}): Promise<boolean> {
+  const { config, record } = args;
+  if (
+    !record ||
+    record.state !== "blocked" ||
+    (record.blocked_reason !== "manual_review" && record.blocked_reason !== "stale_review_bot") ||
+    record.pr_number === null ||
+    !configuredReviewProviderKinds(config).includes("codex") ||
+    !args.getPullRequestIfExists ||
+    !args.getChecks ||
+    !args.getUnresolvedReviewThreads
+  ) {
+    return false;
+  }
+
+  try {
+    const pr = await args.getPullRequestIfExists(record.pr_number, { purpose: "status" });
+    if (!pr || pr.headRefName !== record.branch) {
+      return false;
+    }
+
+    const [checks, reviewThreads] = await Promise.all([
+      args.getChecks(pr.number),
+      args.getUnresolvedReviewThreads(pr.number),
+    ]);
+    return shouldReenterCodexConnectorValidReviewRepair({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+    });
+  } catch {
+    return false;
+  }
+}

--- a/src/codex-connector-valid-review-repair-selection.ts
+++ b/src/codex-connector-valid-review-repair-selection.ts
@@ -4,7 +4,7 @@ import { manualReviewThreads } from "./review-thread-reporting";
 import { buildCodexConnectorStillValidReviewRepairTargets } from "./codex-connector-valid-review-repair";
 
 function allChecksGreen(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
-  return checks.length > 0 && checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
+  return checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
 }
 
 function prAllowsRepair(pr: Pick<GitHubPullRequest, "state" | "isDraft" | "mergeStateStatus" | "mergeable">): boolean {

--- a/src/codex-connector-valid-review-repair.ts
+++ b/src/codex-connector-valid-review-repair.ts
@@ -36,22 +36,23 @@ function timelineArtifactCoversReviewThread(args: {
   const processedThreadIds = args.artifact.processed_review_thread_ids ?? [];
   const processedThreadFingerprints = args.artifact.processed_review_thread_fingerprints ?? [];
   const headScopedThreadId = processedReviewThreadKey(args.thread.id, args.pr.headRefOid);
-  const latestCommentFingerprint =
-    latestCodexConnectorReviewCommentFingerprint(args.thread as ReviewThread) ??
-    latestReviewThreadCommentFingerprint(args.thread);
-  if (
-    latestCommentFingerprint &&
-    processedThreadFingerprints.includes(
-      processedReviewThreadFingerprintKey(args.thread.id, args.pr.headRefOid, latestCommentFingerprint),
-    )
-  ) {
+  const latestCommentFingerprints = [
+    latestCodexConnectorReviewCommentFingerprint(args.thread as ReviewThread),
+    latestReviewThreadCommentFingerprint(args.thread),
+  ].filter((fingerprint): fingerprint is string => Boolean(fingerprint));
+  const acceptedFingerprintKeys = new Set(
+    latestCommentFingerprints.map((fingerprint) =>
+      processedReviewThreadFingerprintKey(args.thread.id, args.pr.headRefOid, fingerprint),
+    ),
+  );
+  if (processedThreadFingerprints.some((fingerprint) => acceptedFingerprintKeys.has(fingerprint))) {
     return true;
   }
 
   if (!processedThreadIds.includes(headScopedThreadId)) {
     return false;
   }
-  if (!latestCommentFingerprint) {
+  if (latestCommentFingerprints.length === 0) {
     return true;
   }
 
@@ -93,6 +94,7 @@ function isLaterConvergedRepairProof(args: {
     isCurrentHeadCodexTurnArtifact(args) &&
     args.artifact.outcome === "passed" &&
     (
+      (args.artifact.repair_targets?.length ?? 0) === 0 ||
       args.artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true ||
       args.artifact.repair_targets?.includes(VERIFIED_NO_SOURCE_CHANGE_REVIEW_THREAD_RESIDUE_TARGET) === true
     )

--- a/src/codex-connector-valid-review-repair.ts
+++ b/src/codex-connector-valid-review-repair.ts
@@ -1,0 +1,121 @@
+import type { GitHubPullRequest, IssueRunRecord, ReviewThread, TimelineArtifact } from "./core/types";
+import {
+  latestReviewThreadCommentFingerprint,
+  processedReviewThreadFingerprintKey,
+  processedReviewThreadKey,
+} from "./review-handling";
+import {
+  codexConnectorMustFixReviewThreads,
+  latestCodexConnectorPSeverity,
+  latestCodexConnectorReviewComment,
+  latestCodexConnectorReviewCommentFingerprint,
+  latestCodexConnectorReviewCommentNode,
+} from "./codex-connector-review-policy";
+
+export const STILL_VALID_REVIEW_THREAD_REPAIR_TARGET =
+  "still_valid_review_thread_repair";
+
+export interface CodexConnectorValidReviewRepairTarget {
+  threadId: string;
+  path: string;
+  line: string;
+  severity: string;
+  url: string | null;
+  summary: string;
+  evidenceSummary: string;
+}
+
+function timelineArtifactCoversReviewThread(args: {
+  artifact: TimelineArtifact;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  thread: Pick<ReviewThread, "id" | "comments">;
+}): boolean {
+  const processedThreadIds = args.artifact.processed_review_thread_ids ?? [];
+  const processedThreadFingerprints = args.artifact.processed_review_thread_fingerprints ?? [];
+  const headScopedThreadId = processedReviewThreadKey(args.thread.id, args.pr.headRefOid);
+  if (processedThreadIds.includes(headScopedThreadId)) {
+    return true;
+  }
+
+  const latestCommentFingerprint =
+    latestCodexConnectorReviewCommentFingerprint(args.thread as ReviewThread) ??
+    latestReviewThreadCommentFingerprint(args.thread);
+  if (!latestCommentFingerprint) {
+    return false;
+  }
+
+  return processedThreadFingerprints.includes(
+    processedReviewThreadFingerprintKey(args.thread.id, args.pr.headRefOid, latestCommentFingerprint),
+  );
+}
+
+export function failedStillValidReviewThreadProbeArtifact(args: {
+  record: Pick<IssueRunRecord, "timeline_artifacts">;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  thread: ReviewThread;
+}): TimelineArtifact | null {
+  return [...(args.record.timeline_artifacts ?? [])].reverse().find((artifact) =>
+    artifact.type === "verification_result" &&
+    artifact.gate === "codex_turn" &&
+    artifact.outcome === "failed" &&
+    artifact.head_sha === args.pr.headRefOid &&
+    artifact.repair_targets?.includes(STILL_VALID_REVIEW_THREAD_REPAIR_TARGET) === true &&
+    timelineArtifactCoversReviewThread({ artifact, pr: args.pr, thread: args.thread }),
+  ) ?? null;
+}
+
+export function codexConnectorStillValidReviewRepairThreads(args: {
+  record: Pick<IssueRunRecord, "timeline_artifacts">;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  reviewThreads: ReviewThread[];
+}): ReviewThread[] {
+  return codexConnectorMustFixReviewThreads(args.reviewThreads).filter((thread) =>
+    failedStillValidReviewThreadProbeArtifact({
+      record: args.record,
+      pr: args.pr,
+      thread,
+    }) !== null,
+  );
+}
+
+function normalizeSummaryText(value: string): string {
+  return value
+    .replace(/```[\s\S]*?```/gu, " ")
+    .replace(/<[^>]+>/gu, " ")
+    .replace(/!\[[^\]]*\]\([^)]+\)/gu, " ")
+    .replace(/\s+/gu, " ")
+    .trim();
+}
+
+function summarizeReviewThread(thread: ReviewThread): string {
+  const body = latestCodexConnectorReviewComment(thread)?.body ?? "";
+  const normalized = normalizeSummaryText(body);
+  if (normalized.length === 0) {
+    return "review details available at source link";
+  }
+  return normalized.length > 180 ? `${normalized.slice(0, 177)}...` : normalized;
+}
+
+export function buildCodexConnectorStillValidReviewRepairTargets(args: {
+  record: Pick<IssueRunRecord, "timeline_artifacts">;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  reviewThreads: ReviewThread[];
+}): CodexConnectorValidReviewRepairTarget[] {
+  return codexConnectorStillValidReviewRepairThreads(args).map((thread) => {
+    const evidence = failedStillValidReviewThreadProbeArtifact({
+      record: args.record,
+      pr: args.pr,
+      thread,
+    });
+    const latestCodexComment = latestCodexConnectorReviewCommentNode(thread);
+    return {
+      threadId: thread.id,
+      path: thread.path ?? "unknown",
+      line: thread.line === null ? "?" : String(thread.line),
+      severity: latestCodexConnectorPSeverity(thread) ?? "unknown",
+      url: latestCodexComment?.url ?? thread.comments.nodes[thread.comments.nodes.length - 1]?.url ?? null,
+      summary: summarizeReviewThread(thread),
+      evidenceSummary: evidence?.summary ?? "thread-scoped verification failed on the current head",
+    };
+  });
+}

--- a/src/codex-connector-valid-review-repair.ts
+++ b/src/codex-connector-valid-review-repair.ts
@@ -1,4 +1,5 @@
 import type { GitHubPullRequest, IssueRunRecord, ReviewThread, TimelineArtifact } from "./core/types";
+import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./current-head-codex-repair-proof";
 import {
   latestReviewThreadCommentFingerprint,
   processedReviewThreadFingerprintKey,
@@ -14,6 +15,8 @@ import {
 
 export const STILL_VALID_REVIEW_THREAD_REPAIR_TARGET =
   "still_valid_review_thread_repair";
+const VERIFIED_NO_SOURCE_CHANGE_REVIEW_THREAD_RESIDUE_TARGET =
+  "verified_no_source_change_review_thread_residue";
 
 export interface CodexConnectorValidReviewRepairTarget {
   threadId: string;
@@ -33,19 +36,66 @@ function timelineArtifactCoversReviewThread(args: {
   const processedThreadIds = args.artifact.processed_review_thread_ids ?? [];
   const processedThreadFingerprints = args.artifact.processed_review_thread_fingerprints ?? [];
   const headScopedThreadId = processedReviewThreadKey(args.thread.id, args.pr.headRefOid);
-  if (processedThreadIds.includes(headScopedThreadId)) {
-    return true;
-  }
-
   const latestCommentFingerprint =
     latestCodexConnectorReviewCommentFingerprint(args.thread as ReviewThread) ??
     latestReviewThreadCommentFingerprint(args.thread);
-  if (!latestCommentFingerprint) {
-    return false;
+  if (
+    latestCommentFingerprint &&
+    processedThreadFingerprints.includes(
+      processedReviewThreadFingerprintKey(args.thread.id, args.pr.headRefOid, latestCommentFingerprint),
+    )
+  ) {
+    return true;
   }
 
-  return processedThreadFingerprints.includes(
-    processedReviewThreadFingerprintKey(args.thread.id, args.pr.headRefOid, latestCommentFingerprint),
+  if (!processedThreadIds.includes(headScopedThreadId)) {
+    return false;
+  }
+  if (!latestCommentFingerprint) {
+    return true;
+  }
+
+  const threadFingerprintPrefix = `${headScopedThreadId}#`;
+  return !processedThreadFingerprints.some((key) => key.startsWith(threadFingerprintPrefix));
+}
+
+function isCurrentHeadCodexTurnArtifact(args: {
+  artifact: TimelineArtifact;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  thread: ReviewThread;
+}): boolean {
+  return (
+    args.artifact.type === "verification_result" &&
+    args.artifact.gate === "codex_turn" &&
+    args.artifact.head_sha === args.pr.headRefOid &&
+    timelineArtifactCoversReviewThread(args)
+  );
+}
+
+function isStillValidRepairProbeFailure(args: {
+  artifact: TimelineArtifact;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  thread: ReviewThread;
+}): boolean {
+  return (
+    isCurrentHeadCodexTurnArtifact(args) &&
+    args.artifact.outcome === "failed" &&
+    args.artifact.repair_targets?.includes(STILL_VALID_REVIEW_THREAD_REPAIR_TARGET) === true
+  );
+}
+
+function isLaterConvergedRepairProof(args: {
+  artifact: TimelineArtifact;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  thread: ReviewThread;
+}): boolean {
+  return (
+    isCurrentHeadCodexTurnArtifact(args) &&
+    args.artifact.outcome === "passed" &&
+    (
+      args.artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true ||
+      args.artifact.repair_targets?.includes(VERIFIED_NO_SOURCE_CHANGE_REVIEW_THREAD_RESIDUE_TARGET) === true
+    )
   );
 }
 
@@ -54,14 +104,15 @@ export function failedStillValidReviewThreadProbeArtifact(args: {
   pr: Pick<GitHubPullRequest, "headRefOid">;
   thread: ReviewThread;
 }): TimelineArtifact | null {
-  return [...(args.record.timeline_artifacts ?? [])].reverse().find((artifact) =>
-    artifact.type === "verification_result" &&
-    artifact.gate === "codex_turn" &&
-    artifact.outcome === "failed" &&
-    artifact.head_sha === args.pr.headRefOid &&
-    artifact.repair_targets?.includes(STILL_VALID_REVIEW_THREAD_REPAIR_TARGET) === true &&
-    timelineArtifactCoversReviewThread({ artifact, pr: args.pr, thread: args.thread }),
-  ) ?? null;
+  for (const artifact of [...(args.record.timeline_artifacts ?? [])].reverse()) {
+    if (isLaterConvergedRepairProof({ artifact, pr: args.pr, thread: args.thread })) {
+      return null;
+    }
+    if (isStillValidRepairProbeFailure({ artifact, pr: args.pr, thread: args.thread })) {
+      return artifact;
+    }
+  }
+  return null;
 }
 
 export function codexConnectorStillValidReviewRepairThreads(args: {

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -30,6 +30,7 @@ import {
   currentHeadVerifiedRepairResidueArtifactEvidenceSummary,
   VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
 } from "./supervisor/stale-review-bot-remediation";
+import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "./codex-connector-valid-review-repair";
 
 test("inferStateFromPullRequest routes actionable high local-review retry into local_review_fix", () => {
   const config = createConfig({
@@ -3722,6 +3723,77 @@ test("inferStateFromPullRequest blocks exhausted Codex Connector must-fix thread
   ];
 
   assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "blocked");
+});
+
+test("inferStateFromPullRequest re-enters review repair for exhausted Codex thread with failed still-valid probe", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: false,
+  });
+  const record = createRecord({
+    state: "pr_open",
+    pr_number: 44,
+    last_head_sha: "head123",
+    processed_review_thread_ids: ["thread-1@head123"],
+    processed_review_thread_fingerprints: ["thread-1@head123#comment-codex"],
+    review_loop_retry_state: [
+      {
+        fingerprint: "pr=44|head=head123|thread=thread-1|comment=comment-codex",
+        pr_number: 44,
+        head_sha: "head123",
+        thread_id: "thread-1",
+        latest_comment_fingerprint: "comment-codex",
+        attempts: 1,
+        first_attempted_at: "2026-06-07T01:00:00Z",
+        last_attempted_at: "2026-06-07T01:00:00Z",
+      },
+    ],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python -m pytest tests/test_audit_log.py -k query_code",
+        head_sha: "head123",
+        outcome: "failed",
+        remediation_target: null,
+        next_action: "repair still-valid review thread",
+        summary: "Focused query-code redaction probe still reproduces.",
+        recorded_at: "2026-06-07T01:30:00Z",
+        repair_targets: [STILL_VALID_REVIEW_THREAD_REPAIR_TARGET],
+        processed_review_thread_ids: ["thread-1@head123"],
+        processed_review_thread_fingerprints: ["thread-1@head123#comment-codex"],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    number: 44,
+    headRefOid: "head123",
+    reviewDecision: null,
+    configuredBotTopLevelReviewStrength: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-1",
+      comments: {
+        nodes: [
+          {
+            id: "comment-codex",
+            body: "P2: Redact query-only credential names such as ?code=...",
+            createdAt: "2026-06-07T01:05:00Z",
+            url: "https://example.test/pr/44#discussion_r1",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), reviewThreads), "addressing_review");
 });
 
 test("inferStateFromPullRequest blocks exhausted Codex Connector repairs even with nonblocking human threads", () => {

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -19,6 +19,7 @@ import {
   codexConnectorMustFixReviewThreads,
   latestCodexConnectorReviewCommentFingerprint,
 } from "./codex-connector-review-policy";
+import { shouldReenterCodexConnectorValidReviewRepair } from "./codex-connector-valid-review-repair-selection";
 import {
   actionableConfiguredBotReviewThreads,
   configuredBotReviewFollowUpState,
@@ -368,6 +369,13 @@ export function inferStateFromPullRequest(
     checks,
     reviewThreads,
   );
+  const stillValidCodexRepairAvailable = shouldReenterCodexConnectorValidReviewRepair({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+  });
 
   if (pr.mergedAt || pr.state === "MERGED") {
     return "done";
@@ -390,6 +398,10 @@ export function inferStateFromPullRequest(
   }
 
   if (pr.reviewDecision === "CHANGES_REQUESTED" && !botReviewDecisionResidueSatisfied) {
+    if (stillValidCodexRepairAvailable) {
+      return "addressing_review";
+    }
+
     if (
       processedCodexConnectorMustFixThreadsExhaustedRepeatBudget({
         config,
@@ -491,6 +503,7 @@ export function inferStateFromPullRequest(
   }
 
   if (
+    stillValidCodexRepairAvailable ||
     codexConnectorMustFixThreads.length > 0 &&
     !codexConnectorMustFixThreadsExhausted &&
     !checkSummary.hasFailing &&

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -20,6 +20,7 @@ import {
   buildRequirementsBlockerIssueComment,
   syncRequirementsBlockerIssueComment,
 } from "./requirements-blocker-issue-comment";
+import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "./codex-connector-valid-review-repair";
 
 test("run-once issue selection does not consume external orchestration handoff authority", async () => {
   const source = await fs.readFile(path.join(process.cwd(), "src", "run-once-issue-selection.ts"), "utf8");
@@ -1211,6 +1212,155 @@ test("resolveRunnableIssueContext selects stale-review-bot tracked PR when Codex
       await result.issueLock.release();
     }
   }
+});
+
+test("resolveRunnableIssueContext selects still-valid Codex review repair with bound GitHub methods", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    humanReviewBlocksMerge: false,
+  });
+  const issueNumber = 2385;
+  const prNumber = 2386;
+  const branch = "codex/issue-2385";
+  const headSha = "head-2385-current";
+  const threadId = "thread-query-code";
+  const commentId = "comment-query-code";
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Continue still-valid Codex repair",
+    body: executionReadyBody("Continue repair for a still-valid unresolved Codex Connector thread."),
+    createdAt: "2026-06-22T00:00:00Z",
+    updatedAt: "2026-06-22T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    labels: [],
+    state: "OPEN",
+  };
+  const record = createRecord(issueNumber, {
+    state: "blocked",
+    branch,
+    pr_number: prNumber,
+    blocked_reason: "manual_review",
+    last_head_sha: headSha,
+    processed_review_thread_ids: [`${threadId}@${headSha}`],
+    processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
+    review_loop_retry_state: [
+      {
+        fingerprint: `pr=${prNumber}|head=${headSha}|thread=${threadId}|comment=${commentId}`,
+        pr_number: prNumber,
+        head_sha: headSha,
+        thread_id: threadId,
+        latest_comment_fingerprint: commentId,
+        attempts: 1,
+        first_attempted_at: "2026-06-22T21:00:00Z",
+        last_attempted_at: "2026-06-22T21:00:00Z",
+      },
+    ],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python -m pytest tests/test_audit_log.py -k query_code",
+        head_sha: headSha,
+        outcome: "failed",
+        remediation_target: null,
+        next_action: "repair_still_valid_review_thread",
+        summary: "Focused query-code redaction probe still reproduces.",
+        recorded_at: "2026-06-22T21:05:00Z",
+        repair_targets: [STILL_VALID_REVIEW_THREAD_REPAIR_TARGET],
+        processed_review_thread_ids: [`${threadId}@${headSha}`],
+        processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
+      },
+    ],
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: record,
+    },
+  };
+  const pr: GitHubPullRequest = {
+    number: prNumber,
+    title: "Tracked PR",
+    url: `https://example.test/pr/${prNumber}`,
+    state: "OPEN",
+    createdAt: "2026-06-22T00:00:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: branch,
+    headRefOid: headSha,
+    mergedAt: null,
+    currentHeadCiGreenAt: "2026-06-22T20:40:44Z",
+    configuredBotLatestReviewedCommitSha: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-22T20:53:59Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    codexConnectorReviewRequestedAt: null,
+    codexConnectorReviewRequestedHeadSha: null,
+  };
+  const checks: PullRequestCheck[] = [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }];
+  const reviewThreads: ReviewThread[] = [
+    {
+      id: threadId,
+      isResolved: false,
+      isOutdated: false,
+      path: "core/llm/conversion_plan.py",
+      line: 699,
+      comments: {
+        nodes: [
+          {
+            id: commentId,
+            body: "P2: Redact query-only credential names such as ?code=...",
+            createdAt: "2026-06-22T20:50:00Z",
+            url: `https://example.test/pr/${prNumber}#discussion_r1`,
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    },
+  ];
+  const github = {
+    pr,
+    checks,
+    reviewThreads,
+    listCandidateIssues: async () => [issue],
+    getIssue: async () => issue,
+    getPullRequestIfExists: async function(this: { pr: GitHubPullRequest }, prNumberToFetch: number) {
+      assert.equal(this.pr.number, prNumberToFetch);
+      return this.pr;
+    },
+    getChecks: async function(this: { checks: PullRequestCheck[] }) {
+      return this.checks;
+    },
+    getUnresolvedReviewThreads: async function(this: { reviewThreads: ReviewThread[] }) {
+      return this.reviewThreads;
+    },
+  };
+  const savedStates: SupervisorStateFile[] = [];
+
+  const result = await resolveRunnableIssueContext({
+    github,
+    config,
+    stateStore: createTouchStateStore(savedStates),
+    state,
+    currentRecord: null,
+    acquireIssueLock: async () => ({
+      acquired: true,
+      release: async () => {},
+    }),
+    ensureRecordJournalContext: async (selectedRecord) => ({
+      workspace: selectedRecord.workspace,
+      journal_path: selectedRecord.journal_path,
+    }),
+  });
+
+  assert.equal(typeof result, "object");
+  assert.equal((result as { kind: string }).kind, "ready");
+  assert.equal((result as { record: IssueRunRecord }).record.issue_number, issueNumber);
 });
 
 test("resolveRunnableIssueContext selects stale review-commit residue without timeout metadata", async () => {

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -525,9 +525,15 @@ async function selectIssueRecord(
         !(await shouldSelectCodexConnectorValidReviewRepair({
           config,
           record: existing,
-          getPullRequestIfExists: github.getPullRequestIfExists,
-          getChecks: github.getChecks,
-          getUnresolvedReviewThreads: github.getUnresolvedReviewThreads,
+          getPullRequestIfExists: github.getPullRequestIfExists
+            ? (prNumber, options) => github.getPullRequestIfExists!(prNumber, options)
+            : undefined,
+          getChecks: github.getChecks
+            ? (prNumber) => github.getChecks!(prNumber)
+            : undefined,
+          getUnresolvedReviewThreads: github.getUnresolvedReviewThreads
+            ? (prNumber) => github.getUnresolvedReviewThreads!(prNumber)
+            : undefined,
         })) &&
         !(isAutonomousExecutionTrustBlockedRecord(existing) && trustDecision.allowed)
       ) {

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -47,6 +47,7 @@ import {
 } from "./supervisor/supervisor-events";
 import { findLatestBlockedPreservedPartialWorkIncident } from "./supervisor/supervisor-preserved-partial-work";
 import { codexConnectorReviewRequestAction } from "./codex-connector-review-request-decision";
+import { shouldSelectCodexConnectorValidReviewRepair } from "./codex-connector-valid-review-repair-selection";
 import { configuredBotReviewThreads, manualReviewThreads } from "./review-thread-reporting";
 import { mergeConflictDetected, summarizeChecks } from "./supervisor/supervisor-reporting";
 
@@ -139,8 +140,7 @@ function shouldFetchDirectTrackedPrRecoveryIssue(
     record.state === "blocked" &&
     (record.blocked_reason === "manual_review" || record.blocked_reason === "stale_review_bot") &&
     record.pr_number !== null &&
-    configuredReviewProviderKinds(config).includes("codex") &&
-    config.configuredBotCurrentHeadSignalTimeoutAction === "request_review_comment"
+    configuredReviewProviderKinds(config).includes("codex")
   );
 }
 
@@ -522,6 +522,13 @@ async function selectIssueRecord(
       if (
         !isEligibleForSelection(existing, config) &&
         !(await shouldSelectCodexConnectorReviewRequestRecovery(github, config, existing)) &&
+        !(await shouldSelectCodexConnectorValidReviewRepair({
+          config,
+          record: existing,
+          getPullRequestIfExists: github.getPullRequestIfExists,
+          getChecks: github.getChecks,
+          getUnresolvedReviewThreads: github.getUnresolvedReviewThreads,
+        })) &&
         !(isAutonomousExecutionTrustBlockedRecord(existing) && trustDecision.allowed)
       ) {
         continue;

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -68,6 +68,7 @@ import {
 import { issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
 import { applyCodexTurnPublicationGate } from "./turn-execution-publication-gate";
 import {
+  explicitFailedCodexTurnVerificationCommand,
   explicitPassingCodexTurnVerificationCommand,
 } from "./run-once-turn-verification-evidence";
 import {
@@ -877,6 +878,8 @@ export async function executeCodexTurnPhase(
 
         const codexVerificationCommand =
           explicitPassingCodexTurnVerificationCommand(structuredResult?.tests);
+        const failedCodexVerificationCommand =
+          explicitFailedCodexTurnVerificationCommand(structuredResult?.tests);
         const changedFilesAfterPublication =
           workspaceStatus.headSha === turnStartHeadSha
             ? []
@@ -924,6 +927,7 @@ export async function executeCodexTurnPhase(
             record,
             currentPr: pr,
             codexVerificationCommand,
+            failedCodexVerificationCommand,
             workspaceStatus,
             preRunState,
             structuredSummary: structuredResult?.summary,

--- a/src/run-once-turn-verification-evidence.ts
+++ b/src/run-once-turn-verification-evidence.ts
@@ -72,6 +72,12 @@ function hasExplicitNegativeCodexTurnVerificationOutcome(value: string): boolean
   );
 }
 
+function hasExplicitFailedCodexTurnVerificationOutcome(value: string): boolean {
+  return /(?:^|\s)(?:failed|failure|error|timeout|blocked)(?=$|[\s:.,;])/i.test(
+    value,
+  );
+}
+
 export function explicitPassingCodexTurnVerificationCommand(
   tests: string | null | undefined,
 ): string | null {
@@ -88,8 +94,30 @@ export function explicitPassingCodexTurnVerificationCommand(
   return value;
 }
 
+export function explicitFailedCodexTurnVerificationCommand(
+  tests: string | null | undefined,
+): string | null {
+  const value = tests?.trim();
+  if (!value) {
+    return null;
+  }
+  if (!hasExplicitCodexTurnVerificationCommandEvidence(value)) {
+    return null;
+  }
+  if (!hasExplicitFailedCodexTurnVerificationOutcome(value)) {
+    return null;
+  }
+  return value;
+}
+
 export function conciseCodexVerificationSummary(summary: string | null | undefined): string {
   const value = summary?.trim();
   return truncate(value && value.length > 0 ? value : "Codex turn verification passed.", 500) ??
     "Codex turn verification passed.";
+}
+
+export function conciseFailedCodexVerificationSummary(summary: string | null | undefined): string {
+  const value = summary?.trim();
+  return truncate(value && value.length > 0 ? value : "Codex turn verification failed.", 500) ??
+    "Codex turn verification failed.";
 }

--- a/src/supervisor/stale-review-bot-diagnostics-presenter.ts
+++ b/src/supervisor/stale-review-bot-diagnostics-presenter.ts
@@ -4,6 +4,7 @@ import {
   type StaleReviewBotRemediationDto,
   type StaleReviewBotThreadDiagnosticsDto,
 } from "./stale-review-bot-remediation";
+import type { CodexConnectorValidReviewRepairTarget } from "../codex-connector-valid-review-repair";
 import { GitHubPullRequest, PullRequestCheck } from "../core/types";
 
 export function githubPullRequestAllowsMergeReadyAction(
@@ -99,6 +100,25 @@ export function formatStaleReviewBotThreadDiagnosticsLine(
   ].join(" ");
 }
 
+export function formatStaleReviewBotRepairTargetLine(
+  diagnostics: Pick<StaleReviewBotThreadDiagnosticsDto, "issueNumber" | "prNumber">,
+  target: CodexConnectorValidReviewRepairTarget,
+): string {
+  return [
+    "stale_review_bot_repair_target",
+    `issue=#${diagnostics.issueNumber}`,
+    `pr=${diagnostics.prNumber === null ? "none" : `#${diagnostics.prNumber}`}`,
+    `thread=${formatStaleReviewBotTokenValue(target.threadId)}`,
+    `file=${formatStaleReviewBotTokenValue(target.path)}`,
+    `line=${formatStaleReviewBotTokenValue(target.line)}`,
+    `severity=${formatStaleReviewBotTokenValue(target.severity)}`,
+    `url=${target.url ? formatStaleReviewBotTokenValue(target.url) : "none"}`,
+    `evidence=${formatStaleReviewBotTokenValue(target.evidenceSummary).replace(/\s+/gu, "_")}`,
+    `summary=${formatStaleReviewBotTokenValue(target.summary).replace(/\s+/gu, "_")}`,
+    "next_action=repair_still_valid_review_thread",
+  ].join(" ");
+}
+
 export function formatStaleReviewBotTerminalStopLine(args: {
   remediation: StaleReviewBotRemediationDto;
   diagnostics: StaleReviewBotThreadDiagnosticsDto;
@@ -122,7 +142,9 @@ export function formatStaleReviewBotTerminalStopLine(args: {
       ? "retry_budget_exhausted"
       : "metadata_only_review_thread_resolution_pending";
   const nextAction =
-    diagnostics.repeatStopExhausted === "yes"
+    (diagnostics.validRepairTargets ?? []).length > 0
+      ? "repair_still_valid_review_thread"
+      : diagnostics.repeatStopExhausted === "yes"
       ? "manual_review_thread_handling"
       : remediation.classification === "metadata_only_missing_current_head_review"
         ? "request_current_head_review"

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -10,6 +10,7 @@ import {
   buildStaleReviewBotThreadDiagnostics,
   VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
 } from "./stale-review-bot-remediation";
+import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "../codex-connector-valid-review-repair";
 import {
   classifyStaleReviewBotAutoRepairSuppressionPolicy,
   classifyStaleReviewBotRemediationPolicy,
@@ -1999,6 +2000,153 @@ test("buildStaleReviewBotRemediation ignores unprocessed outdated Codex threads 
   assert.equal(remediation?.classification, "unknown_needs_operator");
   assert.equal(remediation?.codexCurrentHeadReviewState, "observed");
   assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
+test("buildStaleReviewBotThreadDiagnostics separates still-valid repair targets from unknown mixed residue", () => {
+  const issueNumber = 2385;
+  const prNumber = 45;
+  const headSha = "190f9fd34d4ffc4534c1927e91c7a53ae17535d5";
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const stillValidThread = createReviewThread({
+    id: "thread-query-code",
+    path: "core/llm/conversion_plan.py",
+    line: 699,
+    comments: {
+      nodes: [
+        {
+          id: "comment-query-code",
+          body: "P2: Redact query-only credential names such as ?key=... or ?code=...",
+          createdAt: "2026-06-22T20:50:00Z",
+          url: "https://example.test/pr/45#discussion_r3455261710",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const unknownThread = createReviewThread({
+    id: "thread-schema-value",
+    path: "core/llm/conversion_plan.py",
+    line: 565,
+    comments: {
+      nodes: [
+        {
+          id: "comment-schema-value",
+          body: "P2: Reject non-string schema value literals too.",
+          createdAt: "2026-06-22T20:49:00Z",
+          url: "https://example.test/pr/45#discussion_r3455261682",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const record = createRecord({
+    issue_number: issueNumber,
+    state: "blocked",
+    pr_number: prNumber,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    processed_review_thread_ids: [`${stillValidThread.id}@${headSha}`, `${unknownThread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [
+      `${stillValidThread.id}@${headSha}#comment-query-code`,
+      `${unknownThread.id}@${headSha}#comment-schema-value`,
+    ],
+    review_loop_retry_state: [
+      {
+        fingerprint: `pr=${prNumber}|head=${headSha}|thread=${stillValidThread.id}|comment=comment-query-code`,
+        pr_number: prNumber,
+        head_sha: headSha,
+        thread_id: stillValidThread.id,
+        latest_comment_fingerprint: "comment-query-code",
+        attempts: 1,
+        first_attempted_at: "2026-06-22T21:00:00Z",
+        last_attempted_at: "2026-06-22T21:00:00Z",
+      },
+      {
+        fingerprint: `pr=${prNumber}|head=${headSha}|thread=${unknownThread.id}|comment=comment-schema-value`,
+        pr_number: prNumber,
+        head_sha: headSha,
+        thread_id: unknownThread.id,
+        latest_comment_fingerprint: "comment-schema-value",
+        attempts: 1,
+        first_attempted_at: "2026-06-22T21:00:00Z",
+        last_attempted_at: "2026-06-22T21:00:00Z",
+      },
+    ],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python -m pytest tests/test_llm_conversion_plan.py -k query_code",
+        head_sha: headSha,
+        outcome: "failed",
+        remediation_target: null,
+        next_action: "repair still-valid review thread",
+        summary: "query_params code probe still leaks.",
+        recorded_at: "2026-06-22T21:05:00Z",
+        repair_targets: [STILL_VALID_REVIEW_THREAD_REPAIR_TARGET],
+        processed_review_thread_ids: [`${stillValidThread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [`${stillValidThread.id}@${headSha}#comment-query-code`],
+      },
+    ],
+    last_failure_context: {
+      category: "manual",
+      summary: "Mixed current-head Codex residue remains unresolved.",
+      signature: `stalled-bot:${stillValidThread.id}|stalled-bot:${unknownThread.id}`,
+      command: null,
+      details: [
+        `reviewer=${CODEX_CONNECTOR_REVIEW_BOT_LOGIN} file=${stillValidThread.path} line=${stillValidThread.line} p_severity=P2 processed_on_current_head=yes`,
+        `reviewer=${CODEX_CONNECTOR_REVIEW_BOT_LOGIN} file=${unknownThread.path} line=${unknownThread.line} p_severity=P2 processed_on_current_head=yes`,
+      ],
+      url: "https://example.test/pr/45#discussion_r3455261710",
+      updated_at: "2026-06-22T21:10:00Z",
+    },
+    codex_connector_review_requested_observed_at: "2026-06-22T20:49:10Z",
+    codex_connector_review_requested_head_sha: headSha,
+  });
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-22T20:40:44Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-22T20:53:59Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+  const checks = [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass" as const, workflow: "CI" }];
+  const reviewThreads = [stillValidThread, unknownThread];
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+  });
+  const diagnostics = buildStaleReviewBotThreadDiagnostics({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads,
+    remediation,
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(diagnostics?.actionableMustFixThreads, 2);
+  assert.equal(diagnostics?.missingVerificationEvidenceThreads, 1);
+  assert.equal(diagnostics?.repeatStopExhausted, "yes");
+  assert.equal(diagnostics?.validRepairTargets?.length, 1);
+  assert.equal(diagnostics?.validRepairTargets?.[0]?.threadId, "thread-query-code");
+  assert.equal(diagnostics?.validRepairTargets?.[0]?.path, "core/llm/conversion_plan.py");
+  assert.equal(diagnostics?.validRepairTargets?.[0]?.severity, "P2");
 });
 
 test("buildStaleReviewBotThreadDiagnostics does not report repeat-stop suppression when Codex current-head request is pending", () => {

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -28,6 +28,10 @@ import { configuredReviewProviderKinds } from "../core/review-providers";
 import { projectCurrentHeadCodexRepairProof } from "../current-head-codex-repair-proof";
 import { currentHeadPassingNonReviewChecks } from "../local-ci-policy";
 import {
+  buildCodexConnectorStillValidReviewRepairTargets,
+  type CodexConnectorValidReviewRepairTarget,
+} from "../codex-connector-valid-review-repair";
+import {
   STALE_REVIEW_BOT_MANUAL_NEXT_STEP,
   VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
   VERIFIED_CURRENT_HEAD_REPAIR_MANUAL_NEXT_STEP,
@@ -77,6 +81,7 @@ export interface StaleReviewBotThreadDiagnosticsDto {
   missingVerificationEvidenceThreads: number;
   repeatStopExhausted: "yes" | "no";
   autoRepairSuppressedReason: StaleReviewBotAutoRepairSuppressedReason;
+  validRepairTargets?: CodexConnectorValidReviewRepairTarget[];
 }
 
 type RepositoryFileContents = Record<string, string | null | undefined>;
@@ -1100,7 +1105,17 @@ export function buildStaleReviewBotThreadDiagnostics(args: {
   const verifiedStaleResidueThreads = isVerifiedResidue
     ? unresolvedConfiguredThreads.length
     : 0;
-  const missingVerificationEvidenceThreads = remediation.missingProbeReason ? Math.max(actionableMustFixThreads.length, 1) : 0;
+  const validRepairTargets =
+    config && args.pr
+      ? buildCodexConnectorStillValidReviewRepairTargets({
+          record: args.record,
+          pr: args.pr,
+          reviewThreads: actionableMustFixThreads,
+        })
+      : [];
+  const missingVerificationEvidenceThreads = remediation.missingProbeReason
+    ? Math.max(actionableMustFixThreads.length - validRepairTargets.length, validRepairTargets.length > 0 ? 0 : 1)
+    : 0;
 
   return {
     issueNumber: args.record.issue_number,
@@ -1121,5 +1136,6 @@ export function buildStaleReviewBotThreadDiagnostics(args: {
       actionableMustFixThreads,
       repeatStopExhausted,
     }),
+    validRepairTargets,
   };
 }

--- a/src/supervisor/supervisor-active-detailed-status-presenters.ts
+++ b/src/supervisor/supervisor-active-detailed-status-presenters.ts
@@ -32,6 +32,7 @@ import {
 } from "./stale-review-bot-remediation";
 import {
   formatStaleReviewBotRemediationLine,
+  formatStaleReviewBotRepairTargetLine,
   formatStaleReviewBotTerminalStopLine,
   formatStaleReviewBotThreadDiagnosticsLine,
 } from "./stale-review-bot-diagnostics-presenter";
@@ -192,6 +193,9 @@ export function buildActiveStaleReviewBotDiagnosticLines(
     });
     if (diagnostics) {
       lines.push(formatStaleReviewBotThreadDiagnosticsLine(diagnostics));
+      for (const target of diagnostics.validRepairTargets ?? []) {
+        lines.push(formatStaleReviewBotRepairTargetLine(diagnostics, target));
+      }
       const terminalStopLine = formatStaleReviewBotTerminalStopLine({
         remediation,
         diagnostics,

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -12,6 +12,7 @@ import {
 } from "./stale-review-bot-remediation";
 import {
   formatStaleReviewBotRemediationLine,
+  formatStaleReviewBotRepairTargetLine,
   formatStaleReviewBotTerminalStopLine,
   formatStaleReviewBotThreadDiagnosticsLine,
 } from "./stale-review-bot-diagnostics-presenter";
@@ -204,6 +205,9 @@ export function buildInactiveDetailedStatusLines(
     });
     if (diagnostics) {
       lines.push(formatStaleReviewBotThreadDiagnosticsLine(diagnostics));
+      for (const target of diagnostics.validRepairTargets ?? []) {
+        lines.push(formatStaleReviewBotRepairTargetLine(diagnostics, target));
+      }
       const terminalStopLine = formatStaleReviewBotTerminalStopLine({
         remediation: staleReviewBotRemediation,
         diagnostics,

--- a/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts
@@ -25,6 +25,7 @@ import {
 } from "./supervisor-diagnostics-status-scenarios";
 import {
   formatStaleReviewMetadataConvergenceDiagnostic,
+  formatStaleReviewBotRepairTargetLine,
   formatStaleReviewBotTerminalStopLine,
 } from "./stale-review-bot-diagnostics-presenter";
 import {
@@ -39,6 +40,24 @@ import {
   clearCurrentReconciliationPhase,
   writeCurrentReconciliationPhase,
 } from "./supervisor-reconciliation-phase";
+
+test("formatStaleReviewBotRepairTargetLine surfaces still-valid thread repair details", () => {
+  assert.equal(
+    formatStaleReviewBotRepairTargetLine(
+      { issueNumber: 2385, prNumber: 45 },
+      {
+        threadId: "thread-query-code",
+        path: "core/llm/conversion_plan.py",
+        line: "699",
+        severity: "P2",
+        url: "https://example.test/pr/45#discussion_r3455261710",
+        evidenceSummary: "query_params code probe still leaks.",
+        summary: "P2: Redact query-only credential names such as ?key=... or ?code=...",
+      },
+    ),
+    "stale_review_bot_repair_target issue=#2385 pr=#45 thread=thread-query-code file=core/llm/conversion_plan.py line=699 severity=P2 url=https://example.test/pr/45#discussion_r3455261710 evidence=query_params_code_probe_still_leaks. summary=P2:_Redact_query-only_credential_names_such_as_?key=..._or_?code=... next_action=repair_still_valid_review_thread",
+  );
+});
 
 test("renderSupervisorStatusDto maps stale configured-bot remediation to the root operator action", () => {
   const status = renderSupervisorStatusDto({

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -6,6 +6,7 @@ import {
   GitHubIssue,
   SupervisorStateFile,
 } from "../core/types";
+import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "../codex-connector-valid-review-repair";
 import {
   buildIssueExplainDto,
   buildIssueExplainSummary,
@@ -18,6 +19,7 @@ import {
   createConfig,
   createPullRequest,
   createRecord,
+  createReviewThread,
   createSupervisorFixture,
   createSupervisorState,
 } from "./supervisor-test-helpers";
@@ -1520,6 +1522,106 @@ test("buildIssueExplainDto reports local-review-blocked external readiness for d
     dto.externalSignalReadinessSummary,
     "external_signal_readiness status=blocked_by_local_review ci=passing review=local_review_blocked workflows=absent",
   );
+});
+
+test("buildIssueExplainDto marks still-valid Codex review repair targets runnable", async () => {
+  const issueNumber = 1694;
+  const prNumber = 94;
+  const branch = "codex/reopen-issue-1694";
+  const headSha = "head-1694";
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    humanReviewBlocksMerge: false,
+  });
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Continue still-valid Codex repair",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        blocked_reason: "manual_review",
+        branch,
+        pr_number: prNumber,
+        last_head_sha: headSha,
+        processed_review_thread_ids: [`thread-query-code@${headSha}`],
+        processed_review_thread_fingerprints: [`thread-query-code@${headSha}#comment-query-code`],
+        review_loop_retry_state: [
+          {
+            fingerprint: `pr=${prNumber}|head=${headSha}|thread=thread-query-code|comment=comment-query-code`,
+            pr_number: prNumber,
+            head_sha: headSha,
+            thread_id: "thread-query-code",
+            latest_comment_fingerprint: "comment-query-code",
+            attempts: 1,
+            first_attempted_at: "2026-06-22T21:00:00Z",
+            last_attempted_at: "2026-06-22T21:00:00Z",
+          },
+        ],
+        timeline_artifacts: [
+          {
+            type: "verification_result",
+            gate: "codex_turn",
+            command: "python -m pytest tests/test_audit_log.py -k query_code",
+            head_sha: headSha,
+            outcome: "failed",
+            remediation_target: null,
+            next_action: "repair_still_valid_review_thread",
+            summary: "Focused query-code redaction probe still reproduces.",
+            recorded_at: "2026-06-22T21:05:00Z",
+            repair_targets: [STILL_VALID_REVIEW_THREAD_REPAIR_TARGET],
+            processed_review_thread_ids: [`thread-query-code@${headSha}`],
+            processed_review_thread_fingerprints: [`thread-query-code@${headSha}#comment-query-code`],
+          },
+        ],
+      }),
+    },
+  };
+  const reviewThread = createReviewThread({
+    id: "thread-query-code",
+    path: "core/llm/conversion_plan.py",
+    line: 699,
+    comments: {
+      nodes: [
+        {
+          id: "comment-query-code",
+          body: "P2: Redact query-only credential names such as ?code=...",
+          createdAt: "2026-06-22T20:55:00Z",
+          url: "https://example.test/pr/94#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const github = {
+    getIssue: async () => issue,
+    listAllIssues: async () => [issue],
+    listCandidateIssues: async () => [issue],
+    resolvePullRequestForBranch: async () => createPullRequest({
+      number: prNumber,
+      headRefName: branch,
+      headRefOid: headSha,
+      isDraft: false,
+      mergeStateStatus: "CLEAN",
+      mergeable: "MERGEABLE",
+    }),
+    getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => [reviewThread],
+  };
+
+  const rendered = renderIssueExplainDto(
+    await buildIssueExplainDto(github, config, state, issueNumber),
+  );
+
+  assert.match(rendered, /^runnable=yes$/m);
+  assert.match(rendered, /^stale_review_bot_repair_target .*next_action=repair_still_valid_review_thread$/m);
+  assert.doesNotMatch(rendered, /^reason_\d+=local_state blocked$/m);
 });
 
 test("buildIssueExplainDto reports dependency root blockers for stale configured-bot predecessors", async () => {

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -21,6 +21,7 @@ import {
 import { configuredReviewBotLogins } from "../core/review-providers";
 import { shouldAutoRetryTimeout } from "./supervisor-failure-helpers";
 import { buildStaleStabilizingNoPrRecoveryWarningLine } from "../no-pull-request-state";
+import { shouldReenterCodexConnectorValidReviewRepair } from "../codex-connector-valid-review-repair-selection";
 import {
   evaluateAutonomousExecutionTrust,
   isAutonomousExecutionTrustBlockedRecord,
@@ -517,6 +518,16 @@ export async function buildIssueExplainDto(
     /^codex_connector_review_fallback\b/u.test(codexConnectorDiagnostics.reviewFallbackSummary) &&
     /\bstatus=request_eligible\b/u.test(codexConnectorDiagnostics.reviewFallbackSummary) &&
     /\bnext_action=request_current_head_review\b/u.test(codexConnectorDiagnostics.reviewFallbackSummary);
+  const codexConnectorValidReviewRepairEligible =
+    record && pr && !trackedPrHydrationFailed
+      ? shouldReenterCodexConnectorValidReviewRepair({
+          config,
+          record,
+          pr,
+          checks: explainChecks,
+          reviewThreads: explainReviewThreads,
+        })
+      : false;
   const noActiveTrackedRecordSummary =
     record && state.activeIssueNumber === null
       ? formatNoActiveTrackedRecordClassificationLine(config, record, staleReviewBotRemediation)
@@ -579,6 +590,7 @@ export async function buildIssueExplainDto(
     record &&
     !isEligibleForSelection(record, config) &&
     !codexConnectorReviewRequestRecoveryEligible &&
+    !codexConnectorValidReviewRepairEligible &&
     !(isAutonomousExecutionTrustBlockedRecord(record) && trustDecision.allowed)
   ) {
     reasons.push(...buildNonRunnableLocalStateReasons(record, config));

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -76,6 +76,7 @@ import {
 } from "./stale-review-bot-remediation";
 import {
   formatStaleReviewBotRemediationLine,
+  formatStaleReviewBotRepairTargetLine,
   formatStaleReviewBotTerminalStopLine,
   formatStaleReviewBotThreadDiagnosticsLine,
 } from "./stale-review-bot-diagnostics-presenter";
@@ -710,7 +711,12 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(dto.staleDiagnosticSummary ? [dto.staleDiagnosticSummary] : []),
     ...(dto.staleReviewBotRemediation ? [formatStaleReviewBotRemediationLine(dto.staleReviewBotRemediation)] : []),
     ...(dto.staleReviewBotThreadDiagnostics
-      ? [formatStaleReviewBotThreadDiagnosticsLine(dto.staleReviewBotThreadDiagnostics)]
+      ? [
+          formatStaleReviewBotThreadDiagnosticsLine(dto.staleReviewBotThreadDiagnostics),
+          ...(dto.staleReviewBotThreadDiagnostics.validRepairTargets ?? []).map((target) =>
+            formatStaleReviewBotRepairTargetLine(dto.staleReviewBotThreadDiagnostics!, target),
+          ),
+        ]
       : []),
     ...(dto.staleReviewBotRemediation && dto.staleReviewBotThreadDiagnostics
       ? [

--- a/src/supervisor/supervisor-selection-readiness-summary.test.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.test.ts
@@ -546,7 +546,7 @@ Parallelizable: No
   const github = {
     pr,
     reviewThreads,
-    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }] as PullRequestCheck[],
+    checks: [] as PullRequestCheck[],
     listCandidateIssues: async () => [issue],
     listAllIssues: async () => [issue],
     getPullRequestIfExists: async function(this: { pr: typeof pr }, prNumber: number) {

--- a/src/supervisor/supervisor-selection-readiness-summary.test.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   GitHubIssue,
+  PullRequestCheck,
   ReviewThread,
   SupervisorStateFile,
 } from "../core/types";
@@ -543,11 +544,21 @@ Parallelizable: No
     },
   ];
   const github = {
+    pr,
+    reviewThreads,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }] as PullRequestCheck[],
     listCandidateIssues: async () => [issue],
     listAllIssues: async () => [issue],
-    getPullRequestIfExists: async () => pr,
-    getChecks: async () => [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
-    getUnresolvedReviewThreads: async () => reviewThreads,
+    getPullRequestIfExists: async function(this: { pr: typeof pr }, prNumber: number) {
+      assert.equal(this.pr.number, prNumber);
+      return this.pr;
+    },
+    getChecks: async function(this: { checks: PullRequestCheck[] }) {
+      return this.checks;
+    },
+    getUnresolvedReviewThreads: async function(this: { reviewThreads: ReviewThread[] }) {
+      return this.reviewThreads;
+    },
   };
 
   const readinessSummary = await buildReadinessSummary(github, config, state);

--- a/src/supervisor/supervisor-selection-readiness-summary.test.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.test.ts
@@ -10,6 +10,7 @@ import {
   buildSelectionWhySummary,
 } from "./supervisor-selection-readiness-summary";
 import { createConfig, createPullRequest, createRecord } from "./supervisor-test-helpers";
+import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "../codex-connector-valid-review-repair";
 
 function createIssue(overrides: Partial<GitHubIssue> = {}): GitHubIssue {
   return {
@@ -428,6 +429,139 @@ Parallelizable: No
 
   assert.match(whyLines.join("\n"), /^selected_issue=#2072$/m);
   assert.doesNotMatch(readinessSummary.readinessLines.join("\n"), /^blocked_issues=#2072 blocked_by=local_state:blocked$/m);
+});
+
+test("buildReadinessSummary selects still-valid Codex review repair target after retry exhaustion", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotInitialGraceWaitSeconds: 0,
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+  });
+  const issueNumber = 2385;
+  const prNumber = 45;
+  const branch = "codex/issue-2385";
+  const currentHead = "190f9fd34d4ffc4534c1927e91c7a53ae17535d5";
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Continue repair when unresolved Codex threads are still substantively valid",
+    body: `## Summary
+Continue repair for a still-valid unresolved Codex Connector thread.
+
+## Scope
+- route failed thread-scoped probes back into review repair
+
+Depends on: none
+Parallelizable: No
+
+## Execution order
+1 of 1
+
+## Acceptance criteria
+- the tracked PR is selected for another focused repair pass
+
+## Verification
+- npx tsx --test src/supervisor/supervisor-selection-readiness-summary.test.ts`,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "blocked",
+        branch,
+        pr_number: prNumber,
+        blocked_reason: "manual_review",
+        last_head_sha: currentHead,
+        processed_review_thread_ids: [`thread-query-code@${currentHead}`],
+        processed_review_thread_fingerprints: [`thread-query-code@${currentHead}#comment-query-code`],
+        review_loop_retry_state: [
+          {
+            fingerprint: `pr=${prNumber}|head=${currentHead}|thread=thread-query-code|comment=comment-query-code`,
+            pr_number: prNumber,
+            head_sha: currentHead,
+            thread_id: "thread-query-code",
+            latest_comment_fingerprint: "comment-query-code",
+            attempts: 1,
+            first_attempted_at: "2026-06-22T21:00:00Z",
+            last_attempted_at: "2026-06-22T21:00:00Z",
+          },
+        ],
+        timeline_artifacts: [
+          {
+            type: "verification_result",
+            gate: "codex_turn",
+            command: "python -m pytest tests/test_llm_conversion_plan.py -k query_code",
+            head_sha: currentHead,
+            outcome: "failed",
+            remediation_target: null,
+            next_action: "repair still-valid review thread",
+            summary: "query_params code probe still leaks.",
+            recorded_at: "2026-06-22T21:05:00Z",
+            repair_targets: [STILL_VALID_REVIEW_THREAD_REPAIR_TARGET],
+            processed_review_thread_ids: [`thread-query-code@${currentHead}`],
+            processed_review_thread_fingerprints: [`thread-query-code@${currentHead}#comment-query-code`],
+          },
+        ],
+      }),
+    },
+  };
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefName: branch,
+    headRefOid: currentHead,
+    isDraft: false,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-22T20:40:44Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-22T20:53:59Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: currentHead,
+  });
+  const reviewThreads: ReviewThread[] = [
+    {
+      id: "thread-query-code",
+      isResolved: false,
+      isOutdated: false,
+      path: "core/llm/conversion_plan.py",
+      line: 699,
+      comments: {
+        nodes: [
+          {
+            id: "comment-query-code",
+            body: "P2: Redact query-only credential names such as ?key=... or ?code=...",
+            createdAt: "2026-06-22T20:50:00Z",
+            url: "https://example.test/pr/45#discussion_r3455261710",
+            author: {
+              login: "chatgpt-codex-connector",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    },
+  ];
+  const github = {
+    listCandidateIssues: async () => [issue],
+    listAllIssues: async () => [issue],
+    getPullRequestIfExists: async () => pr,
+    getChecks: async () => [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    getUnresolvedReviewThreads: async () => reviewThreads,
+  };
+
+  const readinessSummary = await buildReadinessSummary(github, config, state);
+  const whyLines = await buildSelectionWhySummary(github, config, state);
+
+  assert.deepEqual(readinessSummary.blockedIssues, []);
+  assert.deepEqual(readinessSummary.runnableIssues, [
+    {
+      issueNumber,
+      title: "Continue repair when unresolved Codex threads are still substantively valid",
+      readiness: "execution_ready",
+    },
+  ]);
+  assert.match(whyLines.join("\n"), /^selected_issue=#2385$/m);
 });
 
 test("buildReadinessSummary selects stale review-commit residue recovery without timeout metadata", async () => {

--- a/src/supervisor/supervisor-selection-readiness-summary.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.ts
@@ -127,9 +127,15 @@ async function findCodexConnectorValidReviewRepairIssueNumbers(
       await shouldSelectCodexConnectorValidReviewRepair({
         config,
         record: state.issues[String(issue.number)],
-        getPullRequestIfExists: github.getPullRequestIfExists,
-        getChecks: github.getChecks,
-        getUnresolvedReviewThreads: github.getUnresolvedReviewThreads,
+        getPullRequestIfExists: github.getPullRequestIfExists
+          ? (prNumber, options) => github.getPullRequestIfExists!(prNumber, options)
+          : undefined,
+        getChecks: github.getChecks
+          ? (prNumber) => github.getChecks!(prNumber)
+          : undefined,
+        getUnresolvedReviewThreads: github.getUnresolvedReviewThreads
+          ? (prNumber) => github.getUnresolvedReviewThreads!(prNumber)
+          : undefined,
       })
     ) {
       repairIssueNumbers.add(issue.number);
@@ -482,9 +488,15 @@ export async function buildSelectionSummary(
       !(await shouldSelectCodexConnectorValidReviewRepair({
         config,
         record: existing,
-        getPullRequestIfExists: github.getPullRequestIfExists,
-        getChecks: github.getChecks,
-        getUnresolvedReviewThreads: github.getUnresolvedReviewThreads,
+        getPullRequestIfExists: github.getPullRequestIfExists
+          ? (prNumber, options) => github.getPullRequestIfExists!(prNumber, options)
+          : undefined,
+        getChecks: github.getChecks
+          ? (prNumber) => github.getChecks!(prNumber)
+          : undefined,
+        getUnresolvedReviewThreads: github.getUnresolvedReviewThreads
+          ? (prNumber) => github.getUnresolvedReviewThreads!(prNumber)
+          : undefined,
       })) &&
       !(isAutonomousExecutionTrustBlockedRecord(existing) && trustDecision.allowed)
     ) {

--- a/src/supervisor/supervisor-selection-readiness-summary.ts
+++ b/src/supervisor/supervisor-selection-readiness-summary.ts
@@ -39,6 +39,7 @@ import {
   formatMergedPrConvergenceOperatorEventLine,
 } from "./supervisor-operator-events";
 import { codexConnectorReviewRequestAction } from "../codex-connector-review-request-decision";
+import { shouldSelectCodexConnectorValidReviewRepair } from "../codex-connector-valid-review-repair-selection";
 import { configuredBotReviewThreads, manualReviewThreads } from "../review-thread-reporting";
 import { mergeConflictDetected, summarizeChecks } from "./supervisor-reporting";
 
@@ -112,6 +113,30 @@ async function findCodexConnectorReviewRequestRecoveryIssueNumbers(
   }
 
   return recoveryIssueNumbers;
+}
+
+async function findCodexConnectorValidReviewRepairIssueNumbers(
+  github: SelectionWhyGitHub,
+  config: SupervisorConfig,
+  state: SupervisorStateFile,
+  candidateIssues: GitHubIssue[],
+): Promise<ReadonlySet<number>> {
+  const repairIssueNumbers = new Set<number>();
+  for (const issue of candidateIssues) {
+    if (
+      await shouldSelectCodexConnectorValidReviewRepair({
+        config,
+        record: state.issues[String(issue.number)],
+        getPullRequestIfExists: github.getPullRequestIfExists,
+        getChecks: github.getChecks,
+        getUnresolvedReviewThreads: github.getUnresolvedReviewThreads,
+      })
+    ) {
+      repairIssueNumbers.add(issue.number);
+    }
+  }
+
+  return repairIssueNumbers;
 }
 
 export interface SupervisorCandidateDiscoveryDto {
@@ -219,6 +244,12 @@ export async function buildReadinessSummary(
   const candidateIssues = await github.listCandidateIssues();
   const issues = await github.listAllIssues();
   const recoveryIssueNumbers = await findCodexConnectorReviewRequestRecoveryIssueNumbers(github, config, state, candidateIssues);
+  const validReviewRepairIssueNumbers = await findCodexConnectorValidReviewRepairIssueNumbers(
+    github,
+    config,
+    state,
+    candidateIssues,
+  );
   return buildReadinessSummaryFromIssues(
     config,
     state,
@@ -227,6 +258,7 @@ export async function buildReadinessSummary(
     candidateDiscoveryWarningLine,
     [],
     recoveryIssueNumbers,
+    validReviewRepairIssueNumbers,
   );
 }
 
@@ -258,6 +290,7 @@ function buildReadinessSummaryFromIssues(
   candidateDiscoveryWarningLine: string | null,
   prefixedReadinessLines: string[] = [],
   codexConnectorReviewRequestRecoveryIssueNumbers: ReadonlySet<number> = new Set(),
+  codexConnectorValidReviewRepairIssueNumbers: ReadonlySet<number> = new Set(),
 ): SupervisorReadinessSummaryDto {
   const runnableIssues: SupervisorRunnableIssueDto[] = [];
   const blockedIssues: SupervisorBlockedIssueDto[] = [];
@@ -320,6 +353,7 @@ function buildReadinessSummaryFromIssues(
     if (
       !isEligibleForSelection(existing, config) &&
       !codexConnectorReviewRequestRecoveryIssueNumbers.has(issue.number) &&
+      !codexConnectorValidReviewRepairIssueNumbers.has(issue.number) &&
       !(isAutonomousExecutionTrustBlockedRecord(existing) && trustDecision.allowed)
     ) {
       blockedIssues.push({
@@ -445,6 +479,13 @@ export async function buildSelectionSummary(
     if (
       !isEligibleForSelection(existing, config) &&
       !(await shouldSelectCodexConnectorReviewRequestRecovery(github, config, existing)) &&
+      !(await shouldSelectCodexConnectorValidReviewRepair({
+        config,
+        record: existing,
+        getPullRequestIfExists: github.getPullRequestIfExists,
+        getChecks: github.getChecks,
+        getUnresolvedReviewThreads: github.getUnresolvedReviewThreads,
+      })) &&
       !(isAutonomousExecutionTrustBlockedRecord(existing) && trustDecision.allowed)
     ) {
       if (blockedPartialWorkIncident?.record.issue_number === issue.number) {

--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -15,6 +15,7 @@ import {
 } from "./turn-execution-orchestration";
 import { processedReviewThreadFingerprintKey, processedReviewThreadKey } from "./review-handling";
 import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "./codex-connector-valid-review-repair";
+import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./current-head-codex-repair-proof";
 import { SupervisorStateFile } from "./core/types";
 import {
   createConfig,
@@ -791,6 +792,162 @@ test("selectReviewThreadsForTurn re-includes exhausted Codex Connector threads w
 
   assert.equal(selected.length, 1);
   assert.equal(selected[0]?.id, "thread-1");
+});
+
+test("selectReviewThreadsForTurn ignores stale still-valid probe evidence after newer Codex finding comments", () => {
+  const selected = selectReviewThreadsForTurn({
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    }),
+    preRunState: "addressing_review",
+    record: {
+      processed_review_thread_ids: ["thread-1@head-a"],
+      processed_review_thread_fingerprints: ["thread-1@head-a#comment-old"],
+      review_loop_retry_state: [
+        {
+          fingerprint: "pr=116|head=head-a|thread=thread-1|comment=comment-new",
+          pr_number: 116,
+          head_sha: "head-a",
+          thread_id: "thread-1",
+          latest_comment_fingerprint: "comment-new",
+          attempts: 1,
+          first_attempted_at: "2026-06-07T01:00:00Z",
+          last_attempted_at: "2026-06-07T01:00:00Z",
+        },
+      ],
+      timeline_artifacts: [
+        {
+          type: "verification_result",
+          gate: "codex_turn",
+          command: "python -m pytest tests/test_audit_log.py -k query_code",
+          head_sha: "head-a",
+          outcome: "failed",
+          remediation_target: null,
+          next_action: "repair_still_valid_review_thread",
+          summary: "Earlier query-code probe reproduced an older finding.",
+          recorded_at: "2026-06-07T01:30:00Z",
+          repair_targets: [STILL_VALID_REVIEW_THREAD_REPAIR_TARGET],
+          processed_review_thread_ids: ["thread-1@head-a"],
+          processed_review_thread_fingerprints: ["thread-1@head-a#comment-old"],
+        },
+      ],
+      last_head_sha: "head-a",
+      review_follow_up_head_sha: null,
+      review_follow_up_remaining: 0,
+    },
+    pr: createPullRequest({ number: 116, headRefOid: "head-a" }),
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        comments: {
+          nodes: [
+            {
+              id: "comment-old",
+              body: "P2: Redact query-only credential names such as ?code=...",
+              createdAt: "2026-06-07T01:05:00Z",
+              url: "https://example.test/pr/116#discussion_r1",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+            {
+              id: "comment-new",
+              body: "P2: Also redact query-only callback tokens in the newer branch.",
+              createdAt: "2026-06-07T01:45:00Z",
+              url: "https://example.test/pr/116#discussion_r2",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.deepEqual(selected, []);
+});
+
+test("selectReviewThreadsForTurn stops at later current-head repair proof before older still-valid probe failures", () => {
+  const selected = selectReviewThreadsForTurn({
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    }),
+    preRunState: "addressing_review",
+    record: {
+      processed_review_thread_ids: ["thread-1@head-a"],
+      processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+      review_loop_retry_state: [
+        {
+          fingerprint: "pr=116|head=head-a|thread=thread-1|comment=comment-1",
+          pr_number: 116,
+          head_sha: "head-a",
+          thread_id: "thread-1",
+          latest_comment_fingerprint: "comment-1",
+          attempts: 1,
+          first_attempted_at: "2026-06-07T01:00:00Z",
+          last_attempted_at: "2026-06-07T01:00:00Z",
+        },
+      ],
+      timeline_artifacts: [
+        {
+          type: "verification_result",
+          gate: "codex_turn",
+          command: "python -m pytest tests/test_audit_log.py -k query_code",
+          head_sha: "head-a",
+          outcome: "failed",
+          remediation_target: null,
+          next_action: "repair_still_valid_review_thread",
+          summary: "Focused query-code redaction probe still reproduces.",
+          recorded_at: "2026-06-07T01:30:00Z",
+          repair_targets: [STILL_VALID_REVIEW_THREAD_REPAIR_TARGET],
+          processed_review_thread_ids: ["thread-1@head-a"],
+          processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+        },
+        {
+          type: "verification_result",
+          gate: "codex_turn",
+          command: "npx tsx --test src/audit-log.test.ts",
+          head_sha: "head-a",
+          outcome: "passed",
+          remediation_target: null,
+          next_action: "continue",
+          summary: "Focused repair verification passed.",
+          recorded_at: "2026-06-07T01:40:00Z",
+          repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+          processed_review_thread_ids: ["thread-1@head-a"],
+          processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+        },
+      ],
+      last_head_sha: "head-a",
+      review_follow_up_head_sha: null,
+      review_follow_up_remaining: 0,
+    },
+    pr: createPullRequest({ number: 116, headRefOid: "head-a" }),
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              body: "P2: Redact query-only credential names such as ?code=...",
+              createdAt: "2026-06-07T01:05:00Z",
+              url: "https://example.test/pr/116#discussion_r1",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.deepEqual(selected, []);
 });
 
 test("selectReviewThreadsForTurn matches Codex Connector retry exhaustion to the finding comment after later replies", () => {

--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -950,6 +950,95 @@ test("selectReviewThreadsForTurn stops at later current-head repair proof before
   assert.deepEqual(selected, []);
 });
 
+test("selectReviewThreadsForTurn clears still-valid failures with later targetless thread proof", () => {
+  const selected = selectReviewThreadsForTurn({
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    }),
+    preRunState: "addressing_review",
+    record: {
+      processed_review_thread_ids: ["thread-1@head-a"],
+      processed_review_thread_fingerprints: ["thread-1@head-a#comment-codex"],
+      review_loop_retry_state: [
+        {
+          fingerprint: "pr=116|head=head-a|thread=thread-1|comment=comment-codex",
+          pr_number: 116,
+          head_sha: "head-a",
+          thread_id: "thread-1",
+          latest_comment_fingerprint: "comment-codex",
+          attempts: 1,
+          first_attempted_at: "2026-06-07T01:00:00Z",
+          last_attempted_at: "2026-06-07T01:00:00Z",
+        },
+      ],
+      timeline_artifacts: [
+        {
+          type: "verification_result",
+          gate: "codex_turn",
+          command: "python -m pytest tests/test_audit_log.py -k query_code",
+          head_sha: "head-a",
+          outcome: "failed",
+          remediation_target: null,
+          next_action: "repair_still_valid_review_thread",
+          summary: "Focused query-code redaction probe still reproduces.",
+          recorded_at: "2026-06-07T01:30:00Z",
+          repair_targets: [STILL_VALID_REVIEW_THREAD_REPAIR_TARGET],
+          processed_review_thread_ids: ["thread-1@head-a"],
+          processed_review_thread_fingerprints: ["thread-1@head-a#comment-codex"],
+        },
+        {
+          type: "verification_result",
+          gate: "codex_turn",
+          command: "npx tsx --test src/audit-log.test.ts",
+          head_sha: "head-a",
+          outcome: "passed",
+          remediation_target: null,
+          next_action: "continue",
+          summary: "Focused verifier passed after checking the current thread.",
+          recorded_at: "2026-06-07T01:40:00Z",
+          processed_review_thread_ids: ["thread-1@head-a"],
+          processed_review_thread_fingerprints: ["thread-1@head-a#comment-reply"],
+        },
+      ],
+      last_head_sha: "head-a",
+      review_follow_up_head_sha: null,
+      review_follow_up_remaining: 0,
+    },
+    pr: createPullRequest({ number: 116, headRefOid: "head-a" }),
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        comments: {
+          nodes: [
+            {
+              id: "comment-codex",
+              body: "P2: Redact query-only credential names such as ?code=...",
+              createdAt: "2026-06-07T01:05:00Z",
+              url: "https://example.test/pr/116#discussion_r1",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+            {
+              id: "comment-reply",
+              body: "Supervisor reply after the no-source revalidation.",
+              createdAt: "2026-06-07T01:35:00Z",
+              url: "https://example.test/pr/116#discussion_r2",
+              author: {
+                login: "github-actions[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.deepEqual(selected, []);
+});
+
 test("selectReviewThreadsForTurn matches Codex Connector retry exhaustion to the finding comment after later replies", () => {
   const selected = selectReviewThreadsForTurn({
     config: createConfig({

--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -14,6 +14,7 @@ import {
   shouldResumeAgentTurn,
 } from "./turn-execution-orchestration";
 import { processedReviewThreadFingerprintKey, processedReviewThreadKey } from "./review-handling";
+import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "./codex-connector-valid-review-repair";
 import { SupervisorStateFile } from "./core/types";
 import {
   createConfig,
@@ -723,6 +724,73 @@ test("selectReviewThreadsForTurn excludes Codex Connector must-fix threads after
   });
 
   assert.deepEqual(selected, []);
+});
+
+test("selectReviewThreadsForTurn re-includes exhausted Codex Connector threads with failed still-valid probe evidence", () => {
+  const selected = selectReviewThreadsForTurn({
+    config: createConfig({
+      reviewBotLogins: ["chatgpt-codex-connector[bot]"],
+    }),
+    preRunState: "addressing_review",
+    record: {
+      processed_review_thread_ids: ["thread-1@head-a"],
+      processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+      review_loop_retry_state: [
+        {
+          fingerprint: "pr=116|head=head-a|thread=thread-1|comment=comment-1",
+          pr_number: 116,
+          head_sha: "head-a",
+          thread_id: "thread-1",
+          latest_comment_fingerprint: "comment-1",
+          attempts: 1,
+          first_attempted_at: "2026-06-07T01:00:00Z",
+          last_attempted_at: "2026-06-07T01:00:00Z",
+        },
+      ],
+      timeline_artifacts: [
+        {
+          type: "verification_result",
+          gate: "codex_turn",
+          command: "python -m pytest tests/test_audit_log.py -k query_code",
+          head_sha: "head-a",
+          outcome: "failed",
+          remediation_target: null,
+          next_action: "repair still-valid review thread",
+          summary: "Focused query-code redaction probe still reproduces.",
+          recorded_at: "2026-06-07T01:30:00Z",
+          repair_targets: [STILL_VALID_REVIEW_THREAD_REPAIR_TARGET],
+          processed_review_thread_ids: ["thread-1@head-a"],
+          processed_review_thread_fingerprints: ["thread-1@head-a#comment-1"],
+        },
+      ],
+      last_head_sha: "head-a",
+      review_follow_up_head_sha: null,
+      review_follow_up_remaining: 0,
+    },
+    pr: createPullRequest({ number: 116, headRefOid: "head-a" }),
+    reviewThreads: [
+      createReviewThread({
+        id: "thread-1",
+        comments: {
+          nodes: [
+            {
+              id: "comment-1",
+              body: "P2: Redact query-only credential names such as ?code=...",
+              createdAt: "2026-06-07T01:05:00Z",
+              url: "https://example.test/pr/116#discussion_r1",
+              author: {
+                login: "chatgpt-codex-connector[bot]",
+                typeName: "Bot",
+              },
+            },
+          ],
+        },
+      }),
+    ],
+  });
+
+  assert.equal(selected.length, 1);
+  assert.equal(selected[0]?.id, "thread-1");
 });
 
 test("selectReviewThreadsForTurn matches Codex Connector retry exhaustion to the finding comment after later replies", () => {

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -26,6 +26,7 @@ import {
   codexConnectorMustFixReviewThreads,
   latestCodexConnectorReviewCommentFingerprint,
 } from "./codex-connector-review-policy";
+import { codexConnectorStillValidReviewRepairThreads } from "./codex-connector-valid-review-repair";
 import {
   actionableConfiguredBotReviewThreads,
   configuredBotReviewThreads,
@@ -180,6 +181,7 @@ export function selectReviewThreadsForTurn(args: {
     | "review_follow_up_head_sha"
     | "review_follow_up_remaining"
     | "review_loop_retry_state"
+    | "timeline_artifacts"
   >;
   pr: GitHubPullRequest | null;
   reviewThreads: ReviewThread[];
@@ -210,6 +212,11 @@ export function selectReviewThreadsForTurn(args: {
       !hasProcessedReviewThread(args.record, currentPr, thread, retryFingerprintForThread(thread)) &&
       reviewLoopRetryBudgetAvailable(thread, retryFingerprintForThread(thread)),
   );
+  const stillValidRepairThreads = codexConnectorStillValidReviewRepairThreads({
+    record: args.record,
+    pr: currentPr,
+    reviewThreads: activeConfiguredBotThreads,
+  });
   const codexConnectorMustFixThreads = codexConnectorMustFixThreadCandidates.filter((thread) =>
     reviewLoopRetryBudgetAvailable(thread, latestCodexConnectorReviewCommentFingerprint(thread)),
   );
@@ -221,7 +228,14 @@ export function selectReviewThreadsForTurn(args: {
   if (codexConnectorReviewChurnDiagnostic && codexConnectorMustFixThreads.length > 0) {
     return uniqueReviewThreadsInOrder(
       activeConfiguredBotThreads,
-      new Set([...pendingThreads, ...codexConnectorMustFixThreads].map((thread) => thread.id)),
+      new Set([...pendingThreads, ...stillValidRepairThreads, ...codexConnectorMustFixThreads].map((thread) => thread.id)),
+    );
+  }
+
+  if (stillValidRepairThreads.length > 0) {
+    return uniqueReviewThreadsInOrder(
+      activeConfiguredBotThreads,
+      new Set([...pendingThreads, ...stillValidRepairThreads].map((thread) => thread.id)),
     );
   }
 

--- a/src/turn-execution-post-publication-review.test.ts
+++ b/src/turn-execution-post-publication-review.test.ts
@@ -110,7 +110,49 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts records failed stil
   assert.deepEqual(artifacts?.[0]?.processed_review_thread_ids, [`${reviewThread.id}@${headSha}`]);
   assert.deepEqual(artifacts?.[0]?.processed_review_thread_fingerprints, [
     `${reviewThread.id}@${headSha}#comment-still-valid-probe`,
+    `${reviewThread.id}@${headSha}#comment-supervisor-reply`,
   ]);
+});
+
+test("buildPostPublicationCodexVerificationTimelineArtifacts does not record unscoped failed probes", () => {
+  const headSha = "head-unscoped-still-valid-probe";
+  const reviewThread = createReviewThread({
+    id: "thread-unscoped-still-valid-probe",
+    path: "src/review.ts",
+    line: 41,
+    comments: {
+      nodes: [
+        {
+          id: "comment-unscoped-still-valid-probe",
+          body: "P2: Keep query token redaction active for this path.",
+          createdAt: "2026-06-22T22:40:00Z",
+          url: "https://example.test/pr/406#discussion_r405",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const artifacts = buildPostPublicationCodexVerificationTimelineArtifacts({
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    codexVerificationCommand: null,
+    failedCodexVerificationCommand: "npm test failed",
+    workspaceStatus: { headSha, hasUncommittedChanges: false },
+    preRunState: "addressing_review",
+    structuredSummary: "npm test failed.",
+    postRunState: "blocked",
+    hasVerifiedNoSourceChangeReviewThreadEvidence: false,
+    verifiedNoSourceChangeReviewThreads: [],
+    reviewThreadsToProcess: [reviewThread],
+    changedFilesAfterPublication: [],
+    artifactOnlyChangedFilesAfterPublication: [],
+  });
+
+  assert.equal(artifacts, null);
 });
 
 test("buildPostPublicationCodexVerificationTimelineArtifacts does not record failed probes from dirty workspaces", () => {

--- a/src/turn-execution-post-publication-review.test.ts
+++ b/src/turn-execution-post-publication-review.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "./codex-connector-valid-review-repair";
 import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./current-head-codex-repair-proof";
 import { buildPostPublicationCodexVerificationTimelineArtifacts } from "./turn-execution-post-publication-review";
 import {
@@ -51,6 +52,54 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts persists scoped thr
   assert.deepEqual(artifacts?.[0]?.processed_review_thread_ids, [`${reviewThread.id}@${headSha}`]);
   assert.deepEqual(artifacts?.[0]?.processed_review_thread_fingerprints, [
     `${reviewThread.id}@${headSha}#comment-normal-repair`,
+  ]);
+});
+
+test("buildPostPublicationCodexVerificationTimelineArtifacts records failed still-valid Codex probe targets", () => {
+  const headSha = "head-still-valid-probe";
+  const reviewThread = createReviewThread({
+    id: "thread-still-valid-probe",
+    path: "src/review.ts",
+    line: 41,
+    comments: {
+      nodes: [
+        {
+          id: "comment-still-valid-probe",
+          body: "P2: Keep query token redaction active for this path.",
+          createdAt: "2026-06-22T22:40:00Z",
+          url: "https://example.test/pr/406#discussion_r405",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const artifacts = buildPostPublicationCodexVerificationTimelineArtifacts({
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    codexVerificationCommand: null,
+    failedCodexVerificationCommand: "python -m pytest tests/test_audit_log.py -k query_code failed",
+    workspaceStatus: { headSha, hasUncommittedChanges: false },
+    preRunState: "addressing_review",
+    structuredSummary: "Focused query-code redaction probe still reproduces.",
+    postRunState: "blocked",
+    hasVerifiedNoSourceChangeReviewThreadEvidence: false,
+    verifiedNoSourceChangeReviewThreads: [],
+    reviewThreadsToProcess: [reviewThread],
+    changedFilesAfterPublication: ["src/review.ts"],
+    artifactOnlyChangedFilesAfterPublication: [],
+  });
+
+  assert.equal(artifacts?.length, 1);
+  assert.equal(artifacts?.[0]?.outcome, "failed");
+  assert.deepEqual(artifacts?.[0]?.repair_targets, [STILL_VALID_REVIEW_THREAD_REPAIR_TARGET]);
+  assert.equal(artifacts?.[0]?.next_action, "repair_still_valid_review_thread");
+  assert.deepEqual(artifacts?.[0]?.processed_review_thread_ids, [`${reviewThread.id}@${headSha}`]);
+  assert.deepEqual(artifacts?.[0]?.processed_review_thread_fingerprints, [
+    `${reviewThread.id}@${headSha}#comment-still-valid-probe`,
   ]);
 });
 

--- a/src/turn-execution-post-publication-review.test.ts
+++ b/src/turn-execution-post-publication-review.test.ts
@@ -73,6 +73,16 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts records failed stil
             typeName: "Bot",
           },
         },
+        {
+          id: "comment-supervisor-reply",
+          body: "Supervisor reply after the first failed repair attempt.",
+          createdAt: "2026-06-22T22:45:00Z",
+          url: "https://example.test/pr/406#discussion_r405_reply",
+          author: {
+            login: "github-actions[bot]",
+            typeName: "Bot",
+          },
+        },
       ],
     },
   });
@@ -101,6 +111,47 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts records failed stil
   assert.deepEqual(artifacts?.[0]?.processed_review_thread_fingerprints, [
     `${reviewThread.id}@${headSha}#comment-still-valid-probe`,
   ]);
+});
+
+test("buildPostPublicationCodexVerificationTimelineArtifacts does not record failed probes from dirty workspaces", () => {
+  const headSha = "head-dirty-still-valid-probe";
+  const reviewThread = createReviewThread({
+    id: "thread-dirty-still-valid-probe",
+    path: "src/review.ts",
+    line: 41,
+    comments: {
+      nodes: [
+        {
+          id: "comment-dirty-still-valid-probe",
+          body: "P2: Keep query token redaction active for this path.",
+          createdAt: "2026-06-22T22:40:00Z",
+          url: "https://example.test/pr/406#discussion_r405",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const artifacts = buildPostPublicationCodexVerificationTimelineArtifacts({
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    codexVerificationCommand: null,
+    failedCodexVerificationCommand: "python -m pytest tests/test_audit_log.py -k query_code failed",
+    workspaceStatus: { headSha, hasUncommittedChanges: true },
+    preRunState: "addressing_review",
+    structuredSummary: "Focused query-code redaction probe still reproduces against local edits.",
+    postRunState: "blocked",
+    hasVerifiedNoSourceChangeReviewThreadEvidence: false,
+    verifiedNoSourceChangeReviewThreads: [],
+    reviewThreadsToProcess: [reviewThread],
+    changedFilesAfterPublication: [],
+    artifactOnlyChangedFilesAfterPublication: [],
+  });
+
+  assert.equal(artifacts, null);
 });
 
 test("buildPostPublicationCodexVerificationTimelineArtifacts preserves no-source-change repair targets", () => {

--- a/src/turn-execution-post-publication-review.ts
+++ b/src/turn-execution-post-publication-review.ts
@@ -2,7 +2,9 @@ import type { LocalReviewRepairContext } from "./codex";
 import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "./codex-connector-valid-review-repair";
 import {
   codexConnectorMustFixReviewThreads,
+  latestCodexConnectorReviewComment,
   latestCodexConnectorReviewCommentFingerprint,
+  latestCodexConnectorReviewCommentNode,
 } from "./codex-connector-review-policy";
 import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./current-head-codex-repair-proof";
 import {
@@ -71,16 +73,104 @@ function processedCodexConnectorReviewThreadFingerprintsForHead(
     return undefined;
   }
   return threads.flatMap((thread) => {
-    const fingerprint = latestCodexConnectorReviewCommentFingerprint(thread) ??
-      latestReviewThreadCommentFingerprint(thread);
-    return fingerprint
-      ? [processedReviewThreadFingerprintKey(thread.id, headSha, fingerprint)]
-      : [];
+    const fingerprints = [
+      latestCodexConnectorReviewCommentFingerprint(thread),
+      latestReviewThreadCommentFingerprint(thread),
+    ].filter((fingerprint): fingerprint is string => Boolean(fingerprint));
+    return [...new Set(fingerprints)].map((fingerprint) =>
+      processedReviewThreadFingerprintKey(thread.id, headSha, fingerprint),
+    );
   });
 }
 
 const VERIFIED_NO_SOURCE_CHANGE_REVIEW_THREAD_RESIDUE_TARGET =
   "verified_no_source_change_review_thread_residue";
+
+const FAILED_STILL_VALID_PROBE_EVIDENCE_STOP_WORDS = new Set([
+  "about",
+  "after",
+  "also",
+  "before",
+  "blocked",
+  "codex",
+  "connector",
+  "error",
+  "failed",
+  "failure",
+  "finding",
+  "focused",
+  "from",
+  "into",
+  "latest",
+  "line",
+  "only",
+  "path",
+  "probe",
+  "repair",
+  "review",
+  "still",
+  "test",
+  "tests",
+  "that",
+  "this",
+  "thread",
+  "valid",
+  "with",
+]);
+
+function normalizeEvidenceText(value: string): string {
+  return value.toLowerCase().replace(/\s+/gu, " ").trim();
+}
+
+function evidenceTokens(value: string): Set<string> {
+  return new Set(
+    normalizeEvidenceText(value)
+      .split(/[^a-z0-9_]+/u)
+      .filter((token) => token.length >= 4 && !FAILED_STILL_VALID_PROBE_EVIDENCE_STOP_WORDS.has(token)),
+  );
+}
+
+function textIncludesLiteralEvidence(evidenceText: string, value: string | null | undefined): boolean {
+  const normalizedValue = normalizeEvidenceText(value ?? "");
+  return normalizedValue.length > 0 && evidenceText.includes(normalizedValue);
+}
+
+function hasFailedStillValidProbeEvidenceForThread(args: {
+  command: string | null | undefined;
+  summary: string | null | undefined;
+  thread: ReviewThread;
+}): boolean {
+  const evidenceText = normalizeEvidenceText(
+    [args.command, args.summary].filter((value): value is string => Boolean(value?.trim())).join("\n"),
+  );
+  if (!evidenceText) {
+    return false;
+  }
+
+  const latestCodexCommentNode = latestCodexConnectorReviewCommentNode(args.thread);
+  const latestThreadComment = args.thread.comments.nodes[args.thread.comments.nodes.length - 1] ?? null;
+  const literalThreadEvidence = [
+    args.thread.id,
+    args.thread.path ?? null,
+    latestCodexCommentNode?.id ?? null,
+    latestCodexCommentNode?.url ?? null,
+    latestThreadComment?.id ?? null,
+    latestThreadComment?.url ?? null,
+  ];
+  if (literalThreadEvidence.some((value) => textIncludesLiteralEvidence(evidenceText, value))) {
+    return true;
+  }
+
+  const findingBody = latestCodexConnectorReviewComment(args.thread)?.body ?? "";
+  const findingTokens = evidenceTokens(findingBody);
+  if (findingTokens.size === 0) {
+    return false;
+  }
+
+  const matchedTokenCount = [...evidenceTokens(evidenceText)]
+    .filter((token) => findingTokens.has(token)).length;
+  return matchedTokenCount >= (findingTokens.size === 1 ? 1 : 2);
+}
 
 function normalizeChangedFilePath(filePath: string): string {
   return filePath.replace(/\\/g, "/").replace(/^(?:\.\/)+/u, "");
@@ -276,7 +366,14 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
             ),
         )
       : null;
-  const stillValidRepairProbeThreads = codexConnectorMustFixReviewThreads(args.reviewThreadsToProcess);
+  const stillValidRepairProbeThreads = codexConnectorMustFixReviewThreads(args.reviewThreadsToProcess)
+    .filter((thread) =>
+      hasFailedStillValidProbeEvidenceForThread({
+        command: args.failedCodexVerificationCommand,
+        summary: args.structuredSummary,
+        thread,
+      }),
+    );
   const stillValidRepairProbeThreadIds =
     processedReviewThreadIdsForHead(stillValidRepairProbeThreads, currentPrHeadSha);
   const stillValidRepairProbeThreadFingerprints =

--- a/src/turn-execution-post-publication-review.ts
+++ b/src/turn-execution-post-publication-review.ts
@@ -1,6 +1,9 @@
 import type { LocalReviewRepairContext } from "./codex";
 import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "./codex-connector-valid-review-repair";
-import { codexConnectorMustFixReviewThreads } from "./codex-connector-review-policy";
+import {
+  codexConnectorMustFixReviewThreads,
+  latestCodexConnectorReviewCommentFingerprint,
+} from "./codex-connector-review-policy";
 import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./current-head-codex-repair-proof";
 import {
   latestReviewThreadCommentFingerprint,
@@ -54,6 +57,22 @@ function processedReviewThreadFingerprintsForHead(threads: ReviewThread[], headS
   }
   return threads.flatMap((thread) => {
     const fingerprint = latestReviewThreadCommentFingerprint(thread);
+    return fingerprint
+      ? [processedReviewThreadFingerprintKey(thread.id, headSha, fingerprint)]
+      : [];
+  });
+}
+
+function processedCodexConnectorReviewThreadFingerprintsForHead(
+  threads: ReviewThread[],
+  headSha: string | null,
+): string[] | undefined {
+  if (!headSha || threads.length === 0) {
+    return undefined;
+  }
+  return threads.flatMap((thread) => {
+    const fingerprint = latestCodexConnectorReviewCommentFingerprint(thread) ??
+      latestReviewThreadCommentFingerprint(thread);
     return fingerprint
       ? [processedReviewThreadFingerprintKey(thread.id, headSha, fingerprint)]
       : [];
@@ -261,7 +280,7 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   const stillValidRepairProbeThreadIds =
     processedReviewThreadIdsForHead(stillValidRepairProbeThreads, currentPrHeadSha);
   const stillValidRepairProbeThreadFingerprints =
-    processedReviewThreadFingerprintsForHead(stillValidRepairProbeThreads, currentPrHeadSha);
+    processedCodexConnectorReviewThreadFingerprintsForHead(stillValidRepairProbeThreads, currentPrHeadSha);
   const hasStillValidRepairProbeThreadEvidence =
     (stillValidRepairProbeThreadIds?.length ?? 0) > 0 ||
     (stillValidRepairProbeThreadFingerprints?.length ?? 0) > 0;
@@ -270,6 +289,7 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
     args.failedCodexVerificationCommand &&
     args.preRunState === "addressing_review" &&
     args.postRunState === "blocked" &&
+    !args.workspaceStatus.hasUncommittedChanges &&
     args.workspaceStatus.headSha === args.currentPr.headRefOid &&
     hasStillValidRepairProbeThreadEvidence;
   const stillValidRepairProbeTimelineArtifacts = canEmitStillValidRepairProbeFailure

--- a/src/turn-execution-post-publication-review.ts
+++ b/src/turn-execution-post-publication-review.ts
@@ -1,4 +1,6 @@
 import type { LocalReviewRepairContext } from "./codex";
+import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "./codex-connector-valid-review-repair";
+import { codexConnectorMustFixReviewThreads } from "./codex-connector-review-policy";
 import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./current-head-codex-repair-proof";
 import {
   latestReviewThreadCommentFingerprint,
@@ -21,7 +23,10 @@ import {
   WorkspaceStatus,
 } from "./core/types";
 import { upsertTimelineArtifact } from "./timeline-artifacts";
-import { conciseCodexVerificationSummary } from "./run-once-turn-verification-evidence";
+import {
+  conciseCodexVerificationSummary,
+  conciseFailedCodexVerificationSummary,
+} from "./run-once-turn-verification-evidence";
 
 function sameStringList(left: string[] | null | undefined, right: string[] | null | undefined): boolean {
   const normalizedLeft = left ?? [];
@@ -166,6 +171,7 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   record: IssueRunRecord;
   currentPr: GitHubPullRequest | null;
   codexVerificationCommand: string | null;
+  failedCodexVerificationCommand?: string | null;
   workspaceStatus: Pick<WorkspaceStatus, "hasUncommittedChanges" | "headSha">;
   preRunState: IssueRunRecord["state"];
   structuredSummary: string | null | undefined;
@@ -251,5 +257,51 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
             ),
         )
       : null;
-  return codexTurnVerificationTimelineArtifacts;
+  const stillValidRepairProbeThreads = codexConnectorMustFixReviewThreads(args.reviewThreadsToProcess);
+  const stillValidRepairProbeThreadIds =
+    processedReviewThreadIdsForHead(stillValidRepairProbeThreads, currentPrHeadSha);
+  const stillValidRepairProbeThreadFingerprints =
+    processedReviewThreadFingerprintsForHead(stillValidRepairProbeThreads, currentPrHeadSha);
+  const hasStillValidRepairProbeThreadEvidence =
+    (stillValidRepairProbeThreadIds?.length ?? 0) > 0 ||
+    (stillValidRepairProbeThreadFingerprints?.length ?? 0) > 0;
+  const canEmitStillValidRepairProbeFailure =
+    args.currentPr &&
+    args.failedCodexVerificationCommand &&
+    args.preRunState === "addressing_review" &&
+    args.postRunState === "blocked" &&
+    args.workspaceStatus.headSha === args.currentPr.headRefOid &&
+    hasStillValidRepairProbeThreadEvidence;
+  const stillValidRepairProbeTimelineArtifacts = canEmitStillValidRepairProbeFailure
+    ? upsertTimelineArtifact(
+        args.record,
+        {
+          type: "verification_result",
+          gate: "codex_turn",
+          command: args.failedCodexVerificationCommand!,
+          head_sha: args.currentPr!.headRefOid,
+          outcome: "failed",
+          remediation_target: null,
+          next_action: "repair_still_valid_review_thread",
+          summary: conciseFailedCodexVerificationSummary(args.structuredSummary),
+          recorded_at: new Date().toISOString(),
+          repair_targets: [STILL_VALID_REVIEW_THREAD_REPAIR_TARGET],
+          processed_review_thread_ids: stillValidRepairProbeThreadIds ?? [],
+          processed_review_thread_fingerprints: stillValidRepairProbeThreadFingerprints ?? [],
+        },
+        (candidate) =>
+          candidate.type === "verification_result" &&
+          candidate.gate === "codex_turn" &&
+          candidate.outcome === "failed" &&
+          candidate.head_sha === args.currentPr!.headRefOid &&
+          candidate.command === args.failedCodexVerificationCommand &&
+          candidate.repair_targets?.includes(STILL_VALID_REVIEW_THREAD_REPAIR_TARGET) === true &&
+          sameStringList(candidate.processed_review_thread_ids, stillValidRepairProbeThreadIds) &&
+          sameStringList(
+            candidate.processed_review_thread_fingerprints,
+            stillValidRepairProbeThreadFingerprints,
+          ),
+      )
+    : null;
+  return stillValidRepairProbeTimelineArtifacts ?? codexTurnVerificationTimelineArtifacts;
 }


### PR DESCRIPTION
Fixes #2385

## What changed
- Added shared detection for failed current-head Codex turn artifacts that prove unresolved Codex Connector review threads are still substantively valid.
- Routed those still-valid thread targets back into PR lifecycle repair and turn thread selection even after the normal Codex review-loop retry budget is exhausted.
- Surfaced the recovery path through stale-review-bot diagnostics, `status --why`, issue explain, and selection/readiness summaries.

## Why
The supervisor could previously stop at `stale_review_bot` / `manual_review` once Codex Connector retry bookkeeping was exhausted, even when a current-head thread-scoped verification run had already proven the unresolved thread was still valid. That left the PR blocked without giving the agent another repair turn.

## Validation
- `rtk npx tsc --noEmit`
- `rtk npx tsx --test src/turn-execution-orchestration.test.ts src/pull-request-state-policy.test.ts`
- `rtk npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts src/supervisor/supervisor-selection-readiness-summary.test.ts src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts`
- `rtk npx tsx --test src/run-once-issue-selection.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts`
- `rtk npm run verify:paths -- --exclude-path supervisor.config.coderabbit.json --exclude-path supervisor.config.codex.json`
- `rtk npm run verify:subprocess-safety`
- `rtk npm run build`

Note: full `rtk npm run verify:supervisor-pre-pr` is blocked in this checkout by pre-existing host-local path diffs in `supervisor.config.coderabbit.json` and `supervisor.config.codex.json`; those files were intentionally left unstaged.