### PR TITLE
[codex] Allow proven P1 Codex repair residue

### DIFF
--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -238,6 +238,24 @@ function unresolvedCodexConnectorMustFixThreads(reviewThreads: ReviewThread[]): 
   });
 }
 
+function unresolvedCodexConnectorP1Threads(reviewThreads: ReviewThread[]): ReviewThread[] {
+  return unresolvedCodexConnectorMustFixThreads(reviewThreads).filter(
+    (thread) => latestCodexConnectorPSeverity(thread) === "P1",
+  );
+}
+
+function appendUniqueThreads(baseThreads: ReviewThread[], additionalThreads: ReviewThread[]): ReviewThread[] {
+  const threadIds = new Set(baseThreads.map((thread) => thread.id));
+  const threads = [...baseThreads];
+  for (const thread of additionalThreads) {
+    if (!threadIds.has(thread.id)) {
+      threadIds.add(thread.id);
+      threads.push(thread);
+    }
+  }
+  return threads;
+}
+
 function allUnresolvedCodexConnectorMustFixThreadsCanUseCurrentHeadRepairProof(
   config: SupervisorConfig,
   reviewThreads: ReviewThread[],
@@ -365,17 +383,24 @@ export function projectCurrentHeadCodexRepairProof(args: {
 
   const currentThreads = currentConfiguredBotThreads(args.config, args.reviewThreads);
   const noMajorSupport = currentHeadNoMajorSupportSummary(args.record, args.pr);
-  const repairResidueThreads = currentRepairResidueThreads(currentThreads, noMajorSupport !== null);
+  const p1ProofAllowed = noMajorSupport !== null;
+  const repairResidueThreads = currentRepairResidueThreads(currentThreads, p1ProofAllowed);
   if (
     !repairResidueThreads ||
     !allUnresolvedCodexConnectorMustFixThreadsCanUseCurrentHeadRepairProof(
       args.config,
       args.reviewThreads,
-      noMajorSupport !== null,
+      p1ProofAllowed,
     )
   ) {
     return null;
   }
+  const proofCoverageThreads = p1ProofAllowed
+    ? appendUniqueThreads(
+        repairResidueThreads,
+        unresolvedCodexConnectorP1Threads(configuredBotReviewThreads(args.config, args.reviewThreads)),
+      )
+    : repairResidueThreads;
   if (
     repairResidueThreads.length > 0 &&
     !repairResidueThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
@@ -384,7 +409,7 @@ export function projectCurrentHeadCodexRepairProof(args: {
   }
 
   const configuredLocalCiRequired = hasConfiguredLocalCiCommand(args.config);
-  const structuredProof = currentHeadVerifiedRepairResidueArtifacts(args.record, args.pr, repairResidueThreads)
+  const structuredProof = currentHeadVerifiedRepairResidueArtifacts(args.record, args.pr, proofCoverageThreads)
     .map((structuredArtifact) => {
       const localVerificationEvidence = configuredLocalCiRequired
         ? currentHeadLocalVerificationEvidence({
@@ -419,7 +444,7 @@ export function projectCurrentHeadCodexRepairProof(args: {
   }
 
   const threadScopedProof = noMajorSupport
-    ? currentHeadThreadScopedVerificationArtifacts(args.record, args.pr, repairResidueThreads)
+    ? currentHeadThreadScopedVerificationArtifacts(args.record, args.pr, proofCoverageThreads)
         .map((artifact) => {
           const localVerificationEvidence = configuredLocalCiRequired
             ? currentHeadLocalVerificationEvidence({
@@ -480,7 +505,7 @@ export function projectCurrentHeadCodexRepairProof(args: {
     return null;
   }
 
-  const currentHeadVerification = currentHeadCodexTurnVerificationArtifact(args.record, args.pr, repairResidueThreads);
+  const currentHeadVerification = currentHeadCodexTurnVerificationArtifact(args.record, args.pr, proofCoverageThreads);
   if (!currentHeadVerification) {
     return null;
   }

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -205,12 +205,17 @@ function headScopedProcessedThreadEvidenceCount(
   );
 }
 
-function currentRepairResidueThreads(currentThreads: ReviewThread[]): ReviewThread[] | null {
+function currentRepairResidueThreads(currentThreads: ReviewThread[], p1ProofAllowed: boolean): ReviewThread[] | null {
   const mustFixThreads = codexConnectorMustFixReviewThreads(currentThreads);
-  if (!mustFixThreads.every((thread) => latestCodexConnectorPSeverity(thread) === "P2")) {
+  if (!mustFixThreads.every((thread) => codexConnectorSeverityCanUseCurrentHeadRepairProof(thread, p1ProofAllowed))) {
     return null;
   }
   return mustFixThreads;
+}
+
+function codexConnectorSeverityCanUseCurrentHeadRepairProof(thread: ReviewThread, p1ProofAllowed: boolean): boolean {
+  const severity = latestCodexConnectorPSeverity(thread);
+  return severity === "P2" || (severity === "P1" && p1ProofAllowed);
 }
 
 function unresolvedCodexConnectorMustFixThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
@@ -233,13 +238,14 @@ function unresolvedCodexConnectorMustFixThreads(reviewThreads: ReviewThread[]): 
   });
 }
 
-function allUnresolvedCodexConnectorMustFixThreadsAreP2(
+function allUnresolvedCodexConnectorMustFixThreadsCanUseCurrentHeadRepairProof(
   config: SupervisorConfig,
   reviewThreads: ReviewThread[],
+  p1ProofAllowed: boolean,
 ): boolean {
   return unresolvedCodexConnectorMustFixThreads(
     configuredBotReviewThreads(config, reviewThreads),
-  ).every((thread) => latestCodexConnectorPSeverity(thread) === "P2");
+  ).every((thread) => codexConnectorSeverityCanUseCurrentHeadRepairProof(thread, p1ProofAllowed));
 }
 
 function isCurrentHeadNoMajorMergeGuardFailure(
@@ -358,8 +364,16 @@ export function projectCurrentHeadCodexRepairProof(args: {
   }
 
   const currentThreads = currentConfiguredBotThreads(args.config, args.reviewThreads);
-  const repairResidueThreads = currentRepairResidueThreads(currentThreads);
-  if (!repairResidueThreads || !allUnresolvedCodexConnectorMustFixThreadsAreP2(args.config, args.reviewThreads)) {
+  const noMajorSupport = currentHeadNoMajorSupportSummary(args.record, args.pr);
+  const repairResidueThreads = currentRepairResidueThreads(currentThreads, noMajorSupport !== null);
+  if (
+    !repairResidueThreads ||
+    !allUnresolvedCodexConnectorMustFixThreadsCanUseCurrentHeadRepairProof(
+      args.config,
+      args.reviewThreads,
+      noMajorSupport !== null,
+    )
+  ) {
     return null;
   }
   if (
@@ -404,7 +418,6 @@ export function projectCurrentHeadCodexRepairProof(args: {
     };
   }
 
-  const noMajorSupport = currentHeadNoMajorSupportSummary(args.record, args.pr);
   const threadScopedProof = noMajorSupport
     ? currentHeadThreadScopedVerificationArtifacts(args.record, args.pr, repairResidueThreads)
         .map((artifact) => {

--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -3325,13 +3325,13 @@ test("handlePostTurnPullRequestTransitionsPhase keeps verified repair thread res
   }
 });
 
-test("handlePostTurnPullRequestTransitionsPhase keeps P1 verified current-head repair residue blocked", async () => {
+test("handlePostTurnPullRequestTransitionsPhase resolves P1 verified current-head repair residue after no-major", async () => {
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
     configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
     verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
   });
-  const issue = createIssue({ title: "Do not auto-resolve P1 verified current-head repair residue" });
+  const issue = createIssue({ title: "Resolve P1 verified current-head repair residue after no-major" });
   const scenario = createCodexConnectorTrackedReviewResidueScenario({
     issueNumber: issue.number,
     prNumber: 2035,
@@ -3341,7 +3341,7 @@ test("handlePostTurnPullRequestTransitionsPhase keeps P1 verified current-head r
     path: "src/review.ts",
     line: 301,
     severity: "P1",
-    commentBody: "P1: Keep higher-severity current-head repair residue blocked for operator review.",
+    commentBody: "P1: Require scoped proof before resolving higher-severity current-head repair residue.",
     discussionUrl: "https://example.test/pr/2035#discussion_r2035",
     verifiedRepair: {
       summary: "Focused verifier passed after the repair commit.",
@@ -3416,6 +3416,8 @@ test("handlePostTurnPullRequestTransitionsPhase keeps P1 verified current-head r
   });
 
   assert.equal(result.record.state, "blocked");
-  assert.deepEqual(replyCalls, []);
-  assert.deepEqual(resolveCalls, []);
+  assert.deepEqual(replyCalls.map((call) => call.threadId), ["thread-codex-p1-repair"]);
+  assert.deepEqual(resolveCalls, ["thread-codex-p1-repair"]);
+  assert.match(replyCalls[0]?.body ?? "", /reason=verified_current_head_repair_auto_resolve/);
+  assert.match(replyCalls[0]?.body ?? "", /p_severity=P1/);
 });

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -2726,6 +2726,10 @@ test("current-head repair proof rejects unresolved outdated high-severity Codex 
       command: "npm run verify:pre-pr",
       evidenceSource: "codex_turn_timeline_artifact",
     },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-06-14T05:18:00Z",
+      observedAt: "2026-06-14T05:21:00Z",
+    },
   });
   const outdatedP1Thread = createReviewThread({
     id: "thread-outdated-p1",

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -737,6 +737,104 @@ test("thread-scoped current-head verification artifact proves repaired Codex P2 
   );
 });
 
+test("thread-scoped current-head verification artifact proves repaired mixed P1 and P2 Codex residue", () => {
+  const issueNumber = 2387;
+  const prNumber = 72;
+  const headSha = "f9e584d660a4ae175a9b72980e2dcc83d9d86413";
+  const verificationRanAt = "2026-06-26T08:01:05.083Z";
+  const findings = [
+    ["PRRT_kwDOTAxt0M6Machd", "PRRC_kwDOTAxt0M6Machd", 1293, "P1", "Require each mode to cover all high-risk labels"],
+    ["PRRT_kwDOTAxt0M6Mache", "PRRC_kwDOTAxt0M6Mache", 1234, "P2", "Validate the comparison fixture manifest before scoring"],
+    ["PRRT_kwDOTAxt0M6Ma6T5", "PRRC_kwDOTAxt0M6Ma6T5", 1318, "P2", "Reject non-string high-risk value mismatches"],
+    ["PRRT_kwDOTAxt0M6MbQYm", "PRRC_kwDOTAxt0M6MbQYm", 935, "P2", "Validate high-risk block ids against fixtures"],
+    ["PRRT_kwDOTAxt0M6MbQYq", "PRRC_kwDOTAxt0M6MbQYq", 1143, "P2", "Bind captured values to the high-risk block"],
+    ["PRRT_kwDOTAxt0M6MbbY1", "PRRC_kwDOTAxt0M6MbbY1", 937, "P2", "Validate high-risk label IDs against the taxonomy"],
+    ["PRRT_kwDOTAxt0M6MbbY_", "PRRC_kwDOTAxt0M6MbbY_", 1168, "P2", "Accept parsed values from full-field cells"],
+    ["PRRT_kwDOTAxt0M6MbjJ3", "PRRC_kwDOTAxt0M6MbjJ3", 1312, "P2", "Reject string actuals for non-string labels"],
+  ] as const;
+  const scenarios = findings.map(([threadId, commentId, line, severity, title]) =>
+    createCodexConnectorTrackedReviewResidueScenario({
+      issueNumber,
+      prNumber,
+      headSha,
+      threadId,
+      commentId,
+      path: "scripts/evaluate_dataset.py",
+      line,
+      severity,
+      commentBody: `${severity}: ${title}.`,
+      discussionUrl: `https://example.test/pr/72#discussion_${threadId}`,
+      verifiedRepair: {
+        summary: "Focused current-head verification covered the 8 Connector findings.",
+        ranAt: verificationRanAt,
+        command: "python3 -m unittest tests.test_evaluate_dataset",
+        evidenceSource: "codex_turn_timeline_artifact",
+      },
+      currentHeadNoMajorReview: {
+        requestedAt: "2026-06-26T06:36:48Z",
+        observedAt: "2026-06-26T06:45:03Z",
+      },
+    }),
+  );
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    codexConnectorAutoMergeEnabled: true,
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const reviewThreads = scenarios.map((scenario) => scenario.reviewThread);
+  const processedReviewThreadIds = reviewThreads.map((thread) => `${thread.id}@${headSha}`);
+  const processedReviewThreadFingerprints = reviewThreads.map(
+    (thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]?.id}`,
+  );
+  const record = createRecord({
+    ...scenarios[0].recordPatch,
+    blocked_reason: "stale_review_bot",
+    processed_review_thread_ids: processedReviewThreadIds,
+    processed_review_thread_fingerprints: processedReviewThreadFingerprints,
+    last_failure_signature: findings.map(([threadId]) => threadId).join("|"),
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python3 -m unittest tests.test_evaluate_dataset",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head verification covered the 8 Connector findings.",
+        recorded_at: verificationRanAt,
+        processed_review_thread_ids: processedReviewThreadIds,
+        processed_review_thread_fingerprints: processedReviewThreadFingerprints,
+      },
+    ],
+  });
+  const pr = createPullRequest(scenarios[0].pullRequestPatch);
+
+  assert.equal(
+    hasVerifiedCurrentHeadRepairReviewMetadataResidue({
+      config,
+      record,
+      pr,
+      checks: scenarios[0].passingChecks,
+      reviewThreads,
+    }),
+    true,
+  );
+  assert.equal(inferStateFromPullRequest(config, record, pr, scenarios[0].passingChecks, reviewThreads), "ready_to_merge");
+  assert.deepEqual(effectiveConfiguredBotReviewThreadsForState(config, record, pr, scenarios[0].passingChecks, reviewThreads), []);
+  assert.match(
+    currentHeadVerifiedRepairResidueArtifactEvidenceSummary({
+      config,
+      record,
+      pr,
+      checks: scenarios[0].passingChecks,
+      reviewThreads,
+    }) ?? "",
+    /thread_scoped_current_head_verification_artifact:Focused current-head verification covered the 8 Connector findings.;codex_no_major_support=codex_pr_success_comment_after_current_head_request/u,
+  );
+});
+
 test("same-head no-major comment without thread-scoped verification does not prove Codex P2 residue", () => {
   const issueNumber = 2383;
   const prNumber = 44;

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -503,7 +503,7 @@ test("buildStaleReviewBotRemediation accepts green current-head checks as verifi
   assert.equal(diagnostics?.autoRepairSuppressedReason, "none");
 });
 
-test("buildStaleReviewBotRemediation keeps P1 current-head repair residue blocked after no-major", () => {
+test("buildStaleReviewBotRemediation accepts P1 current-head repair residue with scoped proof after no-major", () => {
   const issueNumber = 188;
   const prNumber = 195;
   const headSha = "f2b1be31eaf78a3d1c7f1ccd28e730bb38e00b1d";
@@ -516,7 +516,7 @@ test("buildStaleReviewBotRemediation keeps P1 current-head repair residue blocke
     path: "src/app.ts",
     line: 88,
     severity: "P1",
-    commentBody: "P1: Do not auto-resolve higher-severity current-head repair residue.",
+    commentBody: "P1: Require scoped proof before promoting higher-severity current-head repair residue.",
     discussionUrl: "https://example.test/pr/195#discussion_r3316522485",
     verifiedRepair: {
       summary: "Focused verifier passed after the repair commit.",
@@ -556,13 +556,14 @@ test("buildStaleReviewBotRemediation keeps P1 current-head repair residue blocke
     remediation,
   });
 
-  assert.equal(remediation?.classification, "unresolved_work");
+  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
   assert.equal(remediation?.codexCurrentHeadReviewState, "observed");
-  assert.equal(diagnostics?.verifiedStaleResidueThreads, 0);
-  assert.equal(diagnostics?.autoRepairSuppressedReason, "not_verified_stale_residue");
+  assert.equal(diagnostics?.verifiedStaleResidueThreads, 1);
+  assert.equal(diagnostics?.missingVerificationEvidenceThreads, 0);
+  assert.equal(diagnostics?.autoRepairSuppressedReason, "none");
 });
 
-test("buildStaleReviewBotRemediation keeps mixed no-source and repair evidence on the repair safety path", () => {
+test("buildStaleReviewBotRemediation keeps mixed P1 no-source and repair evidence on the repair safety path", () => {
   const issueNumber = 2259;
   const prNumber = 2261;
   const headSha = "d7fdcf2f9ae36d48cd4eb6dc7d35de103d34856f";
@@ -634,10 +635,11 @@ test("buildStaleReviewBotRemediation keeps mixed no-source and repair evidence o
     remediation,
   });
 
-  assert.equal(remediation?.classification, "unresolved_work");
+  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
   assert.equal(remediation?.codexCurrentHeadReviewState, "observed");
-  assert.equal(diagnostics?.verifiedStaleResidueThreads, 0);
-  assert.equal(diagnostics?.autoRepairSuppressedReason, "not_verified_stale_residue");
+  assert.equal(diagnostics?.verifiedStaleResidueThreads, 1);
+  assert.equal(diagnostics?.missingVerificationEvidenceThreads, 0);
+  assert.equal(diagnostics?.autoRepairSuppressedReason, "none");
 });
 
 test("buildStaleReviewBotRemediation rejects review-bot-only checks as verified repair evidence", () => {


### PR DESCRIPTION
## Summary
- allow current-head Codex repair proof to promote P1 inline residue when a same-head no-major support signal exists
- keep P2 structured proof compatibility and continue rejecting P0 / escalated P3 / uncovered high-severity residue
- add a PR #72-shaped regression fixture covering one P1 plus seven P2 Connector threads with exact thread-scoped verification evidence

## Root cause
The current-head repair proof projection only admitted P2 must-fix Connector threads. A PR with complete scoped verification and a same-head Codex no-major comment still fell back to manual review when any covered current-head residue was P1.

## Validation
- `npx tsx --test src/pull-request-state-policy.test.ts`
- `npx tsx --test src/pull-request-state-policy.test.ts src/supervisor/stale-review-bot-remediation.test.ts src/supervisor/supervisor-pr-readiness.test.ts src/post-turn-pull-request-codex-connector.test.ts src/operator-actions.test.ts`
- `npm run verify:supervisor-pre-pr` with host-local supervisor config files temporarily stashed and restored

Closes #2387