### PR TITLE
[codex] Replay manual-review Codex repair proof

### DIFF
--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -1,0 +1,169 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CODEX_CONNECTOR_REVIEW_BOT_LOGIN } from "./codex-connector-tracked-pr-test-helpers";
+import {
+  currentHeadCodexRepairProofRejectionReasons,
+  projectCurrentHeadCodexRepairProof,
+  VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
+} from "./current-head-codex-repair-proof";
+import {
+  createConfig,
+  createPullRequest,
+  createRecord,
+  createReviewThread,
+} from "./pull-request-state-test-helpers";
+
+function codexThread(args: {
+  id: string;
+  commentId: string;
+  severity?: "P1" | "P2";
+  line: number;
+}) {
+  return createReviewThread({
+    id: args.id,
+    path: "scripts/evaluate_dataset.py",
+    line: args.line,
+    comments: {
+      nodes: [
+        {
+          id: args.commentId,
+          body: `${args.severity ?? "P1"}: Verify this current-head residue is covered.`,
+          createdAt: "2026-06-26T06:20:00Z",
+          url: `https://example.test/pr/72#discussion_${args.id}`,
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+}
+
+test("projectCurrentHeadCodexRepairProof accepts structured P1 residue proof with exact current-head local CI", () => {
+  const headSha = "f9e584d660a4ae175a9b72980e2dcc83d9d86413";
+  const threads = [
+    codexThread({ id: "thread-p1-a", commentId: "comment-p1-a", line: 1293 }),
+    codexThread({ id: "thread-p1-b", commentId: "comment-p1-b", line: 1318 }),
+  ];
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "python3 scripts/ci/repo_hygiene.py",
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    codex_connector_review_requested_observed_at: "2026-06-26T06:10:00Z",
+    codex_connector_review_requested_head_sha: headSha,
+    processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI passed on current head.",
+      ran_at: "2026-06-26T06:35:00Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "python3 scripts/ci/repo_hygiene.py",
+      failure_class: null,
+      remediation_target: null,
+    },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python3 scripts/ci/repo_hygiene.py",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Current head rejects the active Connector residue cases.",
+        recorded_at: "2026-06-26T06:36:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+        processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-26T06:30:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    codexConnectorReviewRequestedAt: "2026-06-26T06:10:00Z",
+    codexConnectorReviewRequestedHeadSha: headSha,
+  });
+
+  const proof = projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+  });
+
+  assert.equal(proof?.source, "structured_artifact");
+  assert.equal(proof?.localVerificationEvidenceSource, "latest_local_ci_result");
+  assert.equal(proof?.currentConfiguredThreadCount, 2);
+});
+
+test("projectCurrentHeadCodexRepairProof rejects compound-command artifacts without exact local CI evidence", () => {
+  const headSha = "f9e584d660a4ae175a9b72980e2dcc83d9d86413";
+  const threads = [
+    codexThread({ id: "thread-p1-a", commentId: "comment-p1-a", line: 1293 }),
+    codexThread({ id: "thread-p1-b", commentId: "comment-p1-b", line: 1318 }),
+  ];
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "python3 scripts/ci/repo_hygiene.py",
+  });
+  const compoundCommand =
+    "python3 -m unittest tests.test_evaluate_dataset; python3 scripts/ci/repo_hygiene.py; gh pr checks 72";
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    codex_connector_review_requested_observed_at: "2026-06-26T06:10:00Z",
+    codex_connector_review_requested_head_sha: headSha,
+    processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+    latest_local_ci_result: null,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: compoundCommand,
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Current head covers both Connector residue cases.",
+        recorded_at: "2026-06-26T06:36:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+        processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-26T06:30:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    codexConnectorReviewRequestedAt: "2026-06-26T06:10:00Z",
+    codexConnectorReviewRequestedHeadSha: headSha,
+  });
+
+  assert.equal(projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+  }), null);
+  assert.deepEqual(currentHeadCodexRepairProofRejectionReasons({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+  }), ["current_head_repair_proof_scoped_artifact_command_mismatch_with_configured_local_ci"]);
+});

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -5,6 +5,7 @@ import {
   latestCodexConnectorReviewComment,
   latestCodexConnectorPSeverity,
 } from "./codex-connector-review-policy";
+import { displayLocalCiCommand } from "./core/config";
 import { configuredReviewProviderKinds } from "./core/review-providers";
 import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig, TimelineArtifact } from "./core/types";
 import { hasCodexConnectorStrongRiskWording } from "./external-review/external-review-normalization";
@@ -174,6 +175,14 @@ function repairArtifactCoversCurrentThreads(
       latestReviewThreadCommentPredatesArtifact(thread, artifact)
     );
   });
+}
+
+function coveredCurrentThreadCount(
+  artifact: TimelineArtifact,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  currentThreads: ReviewThread[],
+): number {
+  return currentThreads.filter((thread) => repairArtifactCoversCurrentThreads(artifact, pr, [thread])).length;
 }
 
 function latestReviewThreadCommentPredatesArtifact(
@@ -517,6 +526,98 @@ export function projectCurrentHeadCodexRepairProof(args: {
     processedThreadEvidenceCount,
     currentConfiguredThreadCount: repairResidueThreads.length,
   };
+}
+
+export function currentHeadCodexRepairProofRejectionReasons(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+}): string[] {
+  if (projectCurrentHeadCodexRepairProof(args)) {
+    return [];
+  }
+  if (!projectionSafetyGatesPass(args)) {
+    return ["current_head_repair_proof_safety_gates_not_met"];
+  }
+
+  const currentThreads = currentConfiguredBotThreads(args.config, args.reviewThreads);
+  const noMajorSupport = currentHeadNoMajorSupportSummary(args.record, args.pr);
+  const p1ProofAllowed = noMajorSupport !== null;
+  const repairResidueThreads = currentRepairResidueThreads(currentThreads, p1ProofAllowed);
+  if (!repairResidueThreads) {
+    return ["current_head_repair_proof_unsupported_thread_severity"];
+  }
+  const proofCoverageThreads = p1ProofAllowed
+    ? appendUniqueThreads(
+        repairResidueThreads,
+        unresolvedCodexConnectorP1Threads(configuredBotReviewThreads(args.config, args.reviewThreads)),
+      )
+    : repairResidueThreads;
+  const reasons: string[] = [];
+  if (
+    repairResidueThreads.length > 0 &&
+    !repairResidueThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
+  ) {
+    reasons.push("current_head_repair_proof_processed_thread_evidence_missing");
+  }
+
+  const currentHeadPassedArtifacts = (args.record.timeline_artifacts ?? []).filter(
+    (artifact) =>
+      artifact.type === "verification_result" &&
+      artifact.gate === "codex_turn" &&
+      artifact.outcome === "passed" &&
+      artifact.head_sha === args.pr.headRefOid,
+  );
+  const structuredArtifacts = currentHeadPassedArtifacts.filter(
+    (artifact) =>
+      artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true,
+  );
+  if (structuredArtifacts.length === 0) {
+    const coveringUnmarkedArtifact = currentHeadPassedArtifacts.find((artifact) =>
+      repairArtifactCoversCurrentThreads(artifact, args.pr, proofCoverageThreads)
+    );
+    reasons.push(
+      coveringUnmarkedArtifact
+        ? "current_head_repair_proof_repair_target_missing"
+        : "current_head_repair_proof_structured_artifact_missing",
+    );
+  } else if (!structuredArtifacts.some((artifact) => repairArtifactCoversCurrentThreads(artifact, args.pr, proofCoverageThreads))) {
+    const bestCoverage = Math.max(
+      0,
+      ...structuredArtifacts.map((artifact) => coveredCurrentThreadCount(artifact, args.pr, proofCoverageThreads)),
+    );
+    reasons.push(`current_head_repair_proof_thread_coverage_${bestCoverage}_of_${proofCoverageThreads.length}`);
+  }
+
+  if (hasConfiguredLocalCiCommand(args.config)) {
+    const latestLocalCi = args.record.latest_local_ci_result;
+    if (latestLocalCi?.outcome === "passed" && latestLocalCi.head_sha === args.pr.headRefOid) {
+      return reasons;
+    }
+    const configuredLocalCiCommand = displayLocalCiCommand(args.config.localCiCommand ?? undefined);
+    const scopedProofArtifacts = [
+      ...structuredArtifacts,
+      ...currentHeadThreadScopedVerificationArtifacts(args.record, args.pr, proofCoverageThreads),
+    ].filter((artifact, index, artifacts) => artifacts.findIndex((candidate) => candidate === artifact) === index);
+    const coveringScopedProofArtifacts = scopedProofArtifacts.filter((artifact) =>
+      repairArtifactCoversCurrentThreads(artifact, args.pr, proofCoverageThreads)
+    );
+    if (latestLocalCi?.head_sha === args.pr.headRefOid) {
+      reasons.push("current_head_repair_proof_latest_local_ci_result_not_passed");
+    } else if (
+      configuredLocalCiCommand &&
+      coveringScopedProofArtifacts.length > 0 &&
+      coveringScopedProofArtifacts.every((artifact) => artifact.command?.trim() !== configuredLocalCiCommand)
+    ) {
+      reasons.push("current_head_repair_proof_scoped_artifact_command_mismatch_with_configured_local_ci");
+    } else {
+      reasons.push("current_head_repair_proof_latest_local_ci_result_missing");
+    }
+  }
+
+  return reasons.length > 0 ? reasons : ["current_head_repair_proof_missing"];
 }
 
 export function hasCurrentHeadVerifiedRepairResidueArtifact(

--- a/src/external-review/external-review-family-layout.test.ts
+++ b/src/external-review/external-review-family-layout.test.ts
@@ -37,6 +37,7 @@ const EXPECTED_TEST_FILES = [
   "external-review-regression-candidate-qualification.test.ts",
   "external-review-regression-candidates.test.ts",
   "external-review-signal-collection.test.ts",
+  "external-review-signal-heuristics.test.ts",
 ] as const;
 
 test("external-review runtime modules and focused tests stay aligned", async () => {

--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -24,6 +24,8 @@ const EXPECTED_TOP_LEVEL_ENTRIES = {
     "codex-connector-review-request-identity.ts",
     "codex-connector-review-request-transition.ts",
     "codex-connector-tracked-pr-test-helpers.ts",
+    "codex-connector-valid-review-repair-selection.ts",
+    "codex-connector-valid-review-repair.ts",
     "committed-guardrails-cli.ts",
     "committed-guardrails.ts",
     "conversation-resolution-blocker-diagnostics.ts",

--- a/src/pull-request-state-thread-reprocessing.test.ts
+++ b/src/pull-request-state-thread-reprocessing.test.ts
@@ -549,7 +549,7 @@ test("inferStateFromPullRequest softens unresolved Codex Connector P3 nitpick-on
   assert.equal(inferStateFromPullRequest(config, record, pr, passingChecks(), [p3NitpickThread]), "ready_to_merge");
 });
 
-test("inferStateFromPullRequest waits for current-head Codex Connector review instead of reprocessing stale processed nitpicks", () => {
+test("inferStateFromPullRequest blocks stale processed nitpicks when changes-requested is still active", () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector[bot]"],
     configuredBotInitialGraceWaitSeconds: 0,
@@ -571,7 +571,8 @@ test("inferStateFromPullRequest waits for current-head Codex Connector review in
     headRefOid: "head-a",
     currentHeadCiGreenAt: "2026-03-11T00:00:00Z",
     configuredBotCurrentHeadObservedAt: null,
-    configuredBotTopLevelReviewStrength: null,
+    configuredBotOnlyChangesRequestedReview: true,
+    configuredBotTopLevelReviewStrength: "blocking",
   });
   const p3NitpickThread = createReviewThread({
     comments: {
@@ -592,7 +593,7 @@ test("inferStateFromPullRequest waits for current-head Codex Connector review in
 
   assert.equal(
     inferStateFromPullRequest(config, record, pr, passingChecks(), [p3NitpickThread], Date.parse("2026-03-11T00:12:00Z")),
-    "waiting_ci",
+    "blocked",
   );
 });
 

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -3171,6 +3171,147 @@ test("reconcileRecoverableBlockedIssueStates leaves already-preserved same-head 
   assert.deepEqual(state.issues["366"], original);
 });
 
+test("reconcileRecoverableBlockedIssueStates replays accepted current-head repair proof from same-head manual review", async () => {
+  const headSha = "head-current-366";
+  const threadId = "thread-authority";
+  const commentId = "comment-authority";
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    localCiCommand: "npm run verify:pre-pr",
+    staleConfiguredBotReviewPolicy: "reply_and_resolve",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const progressSnapshot = JSON.stringify({
+    headRefOid: headSha,
+    unresolvedReviewThreadIds: [threadId],
+    unresolvedReviewThreadFingerprints: [`${threadId}#${commentId}`],
+    codexConnectorReviewChurnProgress: {
+      currentHeadSha: headSha,
+      currentEffectiveMustFixCount: 1,
+      dominantFile: "src/release-readiness.ts",
+      dominantFilePercent: 100,
+      clusterCategorySignature: "truth_source",
+      representativeThreadIds: [threadId],
+    },
+  });
+  const original = createRecord({
+    state: "blocked",
+    blocked_reason: "manual_review",
+    pr_number: 191,
+    last_head_sha: headSha,
+    last_error:
+      "Clustered Codex Connector churn made no progress; inspect dominant file src/release-readiness.ts with current effective must-fix count 1 before restarting the loop.",
+    last_failure_signature: "codex-review-churn:P2:src/release-readiness.ts",
+    repeated_failure_signature_count: 3,
+    last_tracked_pr_progress_snapshot: progressSnapshot,
+    last_tracked_pr_progress_summary:
+      "manual_review_preserved=codex_connector_churn_unresolved_configured_bot_threads",
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    processed_review_thread_ids: [`${threadId}@${headSha}`],
+    processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Configured local CI passed on current head.",
+      ran_at: "2026-06-01T06:17:00Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "npm run verify:pre-pr",
+      failure_class: null,
+      remediation_target: null,
+    },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run verify:pre-pr",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused verifier proved current head covers the Connector residue.",
+        recorded_at: "2026-06-01T06:18:00Z",
+        repair_targets: ["verified_current_head_repair_review_thread_residue"],
+        processed_review_thread_ids: [`${threadId}@${headSha}`],
+        processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
+      },
+    ],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+  const issue = createIssue({
+    title: "Recovery issue",
+    updatedAt: "2026-06-01T06:19:00Z",
+  });
+  const pr = createPullRequest({
+    number: 191,
+    title: "Recovery implementation",
+    url: "https://example.test/pr/191",
+    headRefName: "codex/reopen-issue-366",
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+  });
+
+  let saveCalls = 0;
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [
+        createReviewThread({
+          id: threadId,
+          path: "src/release-readiness.ts",
+          comments: {
+            nodes: [{
+              id: commentId,
+              body: "P2 authority finding",
+              createdAt: "2026-06-01T06:12:00Z",
+              url: "https://example.test/pr/191#discussion_authority",
+              author: { login: "chatgpt-codex-connector", typeName: "Bot" },
+            }],
+          },
+        }),
+      ],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-06-01T06:20:00Z",
+        };
+      },
+      async save(): Promise<void> {
+        saveCalls += 1;
+      },
+    },
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "ready_to_merge",
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["366"];
+  assert.equal(updated.state, "ready_to_merge");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    "tracked_pr_lifecycle_recovered: resumed issue #366 from blocked to ready_to_merge using fresh tracked PR #191 facts at head head-current-366",
+  ]);
+});
+
 test("reconcileRecoverableBlockedIssueStates ignores human replies when comparing same-head Codex Connector churn guidance", async () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector"],

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -735,7 +735,10 @@ test("executeCodexTurnPhase persists no-change current-head Codex thread and ver
       next_action: "continue",
       summary: "Revalidated the current code against both live P2 threads with no source changes.",
       recorded_at: state.issues["492"]?.timeline_artifacts?.[1]?.recorded_at ?? "",
-      repair_targets: ["verified_no_source_change_review_thread_residue"],
+      repair_targets: [
+        "verified_no_source_change_review_thread_residue",
+        "verified_current_head_repair_review_thread_residue",
+      ],
       processed_review_thread_ids: [
         `PRRT_kwDOSHIe7c6HbSbo@${headSha}`,
         `PRRT_kwDOSHIe7c6HbjhR@${headSha}`,

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -899,6 +899,7 @@ export async function executeCodexTurnPhase(
           preRunReviewThreads: args.context.reviewThreads,
           postRunReviewThreads: reviewThreads,
           codexVerificationCommand,
+          structuredSummary: structuredResult?.summary,
           workspaceStatus,
           changedFilesAfterPublication,
         });
@@ -954,6 +955,7 @@ export async function executeCodexTurnPhase(
           ...(postRunSnapshot?.codexConnectorRequestObservationPatch ?? {}),
           ...(postRunSnapshot?.copilotRequestObservationPatch ?? {}),
           ...(postRunSnapshot?.copilotTimeoutPatch ?? {}),
+          ...postPublicationReviewPersistence.currentHeadLocalCiPatch,
           ...processedReviewThreadPatch,
           ...reviewFollowUpPatch,
           blocked_verification_retry_count: pr

--- a/src/supervisor/replay-corpus-runner.test.ts
+++ b/src/supervisor/replay-corpus-runner.test.ts
@@ -413,6 +413,8 @@ test("runReplayCorpus replays the checked-in PR lifecycle safety cases without m
     "codex-current-head-success-unresolved-must-fix",
     "phase0-aegisops-repeated-codex-feedback-terminal",
     "phase0-hrcore-current-head-repair-metadata-residue",
+    "phase5-aegisops-external-handoff-review-ci-merge",
+    "phase5-hrcore-external-handoff-metadata-residue",
   ]);
 });
 

--- a/src/supervisor/replay-corpus.test.ts
+++ b/src/supervisor/replay-corpus.test.ts
@@ -65,7 +65,7 @@ test("Phase 0 replay fixtures are checked into the corpus with stable terminal o
       {
         nextState: "blocked",
         shouldRunCodex: false,
-        blockedReason: "stale_review_bot",
+        blockedReason: "manual_review",
         failureSignature: "stalled-bot:thread-production-source-denylist",
       },
       {
@@ -146,7 +146,7 @@ test("Phase 5 replay corpus cases keep external orchestration handoffs bounded",
       {
         nextState: "blocked",
         shouldRunCodex: false,
-        blockedReason: "stale_review_bot",
+        blockedReason: "manual_review",
         failureSignature: "stalled-bot:thread-production-source-denylist",
       },
       {

--- a/src/supervisor/stale-review-bot-diagnostics-presenter.ts
+++ b/src/supervisor/stale-review-bot-diagnostics-presenter.ts
@@ -86,7 +86,7 @@ export function formatStaleReviewBotRemediationLine(remediation: StaleReviewBotR
 export function formatStaleReviewBotThreadDiagnosticsLine(
   diagnostics: StaleReviewBotThreadDiagnosticsDto,
 ): string {
-  return [
+  const tokens = [
     "stale_review_bot_thread_diagnostics",
     `issue=#${diagnostics.issueNumber}`,
     `pr=${diagnostics.prNumber === null ? "none" : `#${diagnostics.prNumber}`}`,
@@ -97,7 +97,13 @@ export function formatStaleReviewBotThreadDiagnosticsLine(
     `missing_verification_evidence_threads=${diagnostics.missingVerificationEvidenceThreads}`,
     `repeat_stop_exhausted=${diagnostics.repeatStopExhausted}`,
     `auto_repair_suppressed_reason=${diagnostics.autoRepairSuppressedReason}`,
-  ].join(" ");
+  ];
+  if ((diagnostics.currentHeadRepairProofRejectionReasons ?? []).length > 0) {
+    tokens.push(
+      `current_head_repair_proof_rejection=${diagnostics.currentHeadRepairProofRejectionReasons!.join(",")}`,
+    );
+  }
+  return tokens.join(" ");
 }
 
 export function formatStaleReviewBotRepairTargetLine(

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -94,6 +94,92 @@ test("classifyStaleReviewBotRemediationPolicy accepts explicit P2 repair evidenc
   );
 });
 
+test("buildStaleReviewBotThreadDiagnostics reports current-head repair proof local CI shape mismatches", () => {
+  const headSha = "head-proof-diagnostics";
+  const thread = createReviewThread({
+    id: "thread-proof-diagnostics",
+    path: "scripts/evaluate_dataset.py",
+    line: 1293,
+    comments: {
+      nodes: [
+        {
+          id: "comment-proof-diagnostics",
+          body: "P2: Verify this current-head residue is covered.",
+          createdAt: "2026-06-26T06:20:00Z",
+          url: "https://example.test/pr/72#discussion_proof_diagnostics",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "python3 scripts/ci/repo_hygiene.py",
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-proof-diagnostics`],
+    latest_local_ci_result: null,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python3 -m unittest tests.test_evaluate_dataset; python3 scripts/ci/repo_hygiene.py",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Current head covers the Connector residue case.",
+        recorded_at: "2026-06-26T06:36:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${thread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-proof-diagnostics`],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-26T06:30:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    codexConnectorReviewRequestedAt: "2026-06-26T06:10:00Z",
+    codexConnectorReviewRequestedHeadSha: headSha,
+  });
+
+  const diagnostics = buildStaleReviewBotThreadDiagnostics({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+    remediation: {
+      issueNumber: 366,
+      prNumber: null,
+      reasonCode: "stale_review_bot",
+      currentHeadSha: headSha,
+      processedOnCurrentHead: "yes",
+      codeCiState: "green",
+      classification: "unknown_needs_operator",
+      codexCurrentHeadReviewState: "observed",
+      reviewThreadUrl: "https://example.test/pr/72#discussion_proof_diagnostics",
+      verificationEvidenceSummary: null,
+      missingProbeReason: "current_head_verification_evidence_missing",
+      manualNextStep: "inspect_exact_review_thread_then_resolve_or_leave_manual_note",
+      summary: "code_or_ci_green_but_review_thread_metadata_unresolved",
+    },
+  });
+
+  assert.deepEqual(diagnostics?.currentHeadRepairProofRejectionReasons, [
+    "current_head_repair_proof_scoped_artifact_command_mismatch_with_configured_local_ci",
+  ]);
+});
+
 test("classifyStaleReviewBotRemediationPolicy rejects repair-attempt shortcut without Codex no-major", () => {
   assert.deepEqual(
     policy({

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -25,7 +25,10 @@ import {
   pendingBotReviewThreads,
 } from "../review-thread-reporting";
 import { configuredReviewProviderKinds } from "../core/review-providers";
-import { projectCurrentHeadCodexRepairProof } from "../current-head-codex-repair-proof";
+import {
+  currentHeadCodexRepairProofRejectionReasons,
+  projectCurrentHeadCodexRepairProof,
+} from "../current-head-codex-repair-proof";
 import { currentHeadPassingNonReviewChecks } from "../local-ci-policy";
 import {
   buildCodexConnectorStillValidReviewRepairTargets,
@@ -81,6 +84,7 @@ export interface StaleReviewBotThreadDiagnosticsDto {
   missingVerificationEvidenceThreads: number;
   repeatStopExhausted: "yes" | "no";
   autoRepairSuppressedReason: StaleReviewBotAutoRepairSuppressedReason;
+  currentHeadRepairProofRejectionReasons?: string[];
   validRepairTargets?: CodexConnectorValidReviewRepairTarget[];
 }
 
@@ -1116,6 +1120,25 @@ export function buildStaleReviewBotThreadDiagnostics(args: {
   const missingVerificationEvidenceThreads = remediation.missingProbeReason
     ? Math.max(actionableMustFixThreads.length - validRepairTargets.length, validRepairTargets.length > 0 ? 0 : 1)
     : 0;
+  const currentHeadRepairProofRejectionReasons =
+    config &&
+    args.pr &&
+    codexConfigured &&
+    args.record.blocked_reason === "manual_review" &&
+    args.record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
+    !isVerifiedResidue &&
+    actionableMustFixThreads.length > 0
+      ? currentHeadCodexRepairProofRejectionReasons({
+          config,
+          record: args.record,
+          pr: args.pr,
+          checks: args.checks,
+          reviewThreads,
+        })
+      : [];
+  const reportableCurrentHeadRepairProofRejectionReasons = currentHeadRepairProofRejectionReasons.filter(
+    (reason) => reason !== "current_head_repair_proof_structured_artifact_missing",
+  );
 
   return {
     issueNumber: args.record.issue_number,
@@ -1136,6 +1159,9 @@ export function buildStaleReviewBotThreadDiagnostics(args: {
       actionableMustFixThreads,
       repeatStopExhausted,
     }),
+    ...(reportableCurrentHeadRepairProofRejectionReasons.length > 0
+      ? { currentHeadRepairProofRejectionReasons: reportableCurrentHeadRepairProofRejectionReasons }
+      : {}),
     validRepairTargets,
   };
 }

--- a/src/supervisor/supervisor-execution-cleanup.test.ts
+++ b/src/supervisor/supervisor-execution-cleanup.test.ts
@@ -1309,7 +1309,7 @@ test("runOnce clears a stale active issue reservation before selecting the next 
   (supervisor as unknown as { github: Record<string, unknown> }).github = {
     authStatus: async () => ({ ok: true, message: null }),
     listAllIssues: async () => [nextIssue, staleIssue],
-    listCandidateIssues: async () => [nextIssue, staleIssue],
+    listCandidateIssues: async () => [nextIssue],
     getIssue: async (issueNumber: number) => (issueNumber === nextIssueNumber ? nextIssue : staleIssue),
     resolvePullRequestForBranch: async (branchName: string, prNumber: number | null) => {
       assert.equal(branchName, nextBranch);

--- a/src/supervisor/supervisor-execution-orchestration.test.ts
+++ b/src/supervisor/supervisor-execution-orchestration.test.ts
@@ -2115,7 +2115,7 @@ test("runPreparedIssue auto-handles stale Codex Connector conversation residue b
   assert.ok(record.provider_success_observed_at);
 });
 
-test("runPreparedIssue auto-resolves verified current-head repair residue before repeat-stop suppression", async () => {
+test("runPreparedIssue promotes accepted current-head repair proof before repeat-stop suppression", async () => {
   const fixture = await createSupervisorFixture();
   fixture.config.sameFailureSignatureRepeatLimit = 3;
   fixture.config.reviewBotLogins = ["chatgpt-codex-connector"];
@@ -2194,6 +2194,22 @@ test("runPreparedIssue auto-resolves verified current-head repair residue before
       processedReviewThreadFingerprints: threadIds.map((threadId) => `${threadId}@${headSha}#comment-${threadId}`),
       verificationProbeOutcomes: [],
     }),
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm test -- src/current-repair.test.ts",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused verifier proved current head covers the configured-bot repair residue.",
+        recorded_at: "2026-05-30T01:02:30Z",
+        repair_targets: ["verified_current_head_repair_review_thread_residue"],
+        processed_review_thread_ids: threadIds.map((threadId) => `${threadId}@${headSha}`),
+        processed_review_thread_fingerprints: threadIds.map((threadId) => `${threadId}@${headSha}#comment-${threadId}`),
+      },
+    ],
     last_tracked_pr_repeat_failure_decision: "stop_no_progress",
     stale_review_bot_reply_progress_keys: [],
     stale_review_bot_resolve_progress_keys: [],
@@ -2212,7 +2228,7 @@ test("runPreparedIssue auto-resolves verified current-head repair residue before
     number: prNumber,
     title: "Verified current-head repair residue",
     isDraft: false,
-    reviewDecision: "CHANGES_REQUESTED",
+    reviewDecision: null,
     headRefOid: headSha,
     mergeStateStatus: "CLEAN",
     mergeable: "MERGEABLE",
@@ -2352,8 +2368,8 @@ test("runPreparedIssue auto-resolves verified current-head repair residue before
   });
 
   assert.doesNotMatch(message, /blocked after repeated identical review-related failure signatures/);
-  assert.deepEqual(replyCalls, threadIds);
-  assert.deepEqual(resolveCalls, threadIds);
+  assert.deepEqual(replyCalls, []);
+  assert.deepEqual(resolveCalls, []);
   const persisted = JSON.parse(await fs.readFile(fixture.stateFile, "utf8")) as SupervisorStateFile;
   const record = persisted.issues[String(issueNumber)];
   assert.equal(record.state, "ready_to_merge");
@@ -2361,10 +2377,10 @@ test("runPreparedIssue auto-resolves verified current-head repair residue before
   assert.equal(record.last_failure_context, null);
   assert.equal(record.last_failure_signature, null);
   assert.equal(record.repeated_failure_signature_count, 0);
-  assert.equal(record.last_stale_review_bot_reply_head_sha, headSha);
-  assert.equal(record.last_stale_review_bot_reply_signature, staleSignature);
-  assert.equal(record.stale_review_bot_reply_progress_keys?.length, threadIds.length);
-  assert.equal(record.stale_review_bot_resolve_progress_keys?.length, threadIds.length);
+  assert.equal(record.last_stale_review_bot_reply_head_sha, null);
+  assert.equal(record.last_stale_review_bot_reply_signature, null);
+  assert.deepEqual(record.stale_review_bot_reply_progress_keys, []);
+  assert.deepEqual(record.stale_review_bot_resolve_progress_keys, []);
 });
 
 test("runPreparedIssue preserves prepared stale-review residue eligibility before repeat-stop suppression", async () => {

--- a/src/supervisor/supervisor-lifecycle.test.ts
+++ b/src/supervisor/supervisor-lifecycle.test.ts
@@ -280,6 +280,22 @@ test("derivePullRequestLifecycleSnapshot keeps recovered Codex stale metadata re
       failure_class: null,
       remediation_target: null,
     },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run verify:pre-pr",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Verified current head addresses the recovered Connector residue.",
+        recorded_at: "2026-06-13T13:40:30Z",
+        repair_targets: ["verified_current_head_repair_review_thread_residue"],
+        processed_review_thread_ids: [`thread-recovered@${headSha}`],
+        processed_review_thread_fingerprints: [`thread-recovered@${headSha}#comment-recovered`],
+      },
+    ],
     codex_connector_review_requested_observed_at: "2026-06-13T13:34:00Z",
     codex_connector_review_requested_head_sha: headSha,
     last_recovery_reason:

--- a/src/tracked-pr-lifecycle-projection.test.ts
+++ b/src/tracked-pr-lifecycle-projection.test.ts
@@ -515,7 +515,7 @@ test("projectTrackedPrLifecycle keeps stale configured-bot classification when c
   });
 
   assert.equal(projection.nextState, "blocked");
-  assert.equal(projection.nextBlockedReason, "manual_review");
+  assert.equal(projection.nextBlockedReason, "stale_review_bot");
   assert.equal(projection.recordForState.review_follow_up_head_sha, "head-191");
   assert.equal(projection.recordForState.review_follow_up_remaining, 0);
   assert.deepEqual(projection.recordForState.processed_review_thread_ids, ["thread-1@head-191"]);

--- a/src/turn-execution-post-publication-review.test.ts
+++ b/src/turn-execution-post-publication-review.test.ts
@@ -2,8 +2,12 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "./codex-connector-valid-review-repair";
 import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./current-head-codex-repair-proof";
-import { buildPostPublicationCodexVerificationTimelineArtifacts } from "./turn-execution-post-publication-review";
 import {
+  buildPostPublicationCodexVerificationTimelineArtifacts,
+  buildPostPublicationReviewPersistence,
+} from "./turn-execution-post-publication-review";
+import {
+  createConfig,
   createPullRequest,
   createRecord,
   createReviewThread,
@@ -234,11 +238,58 @@ test("buildPostPublicationCodexVerificationTimelineArtifacts preserves no-source
   });
 
   assert.equal(artifacts?.length, 1);
-  assert.deepEqual(artifacts?.[0]?.repair_targets, ["verified_no_source_change_review_thread_residue"]);
+  assert.deepEqual(artifacts?.[0]?.repair_targets, [
+    "verified_no_source_change_review_thread_residue",
+    VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
+  ]);
   assert.deepEqual(artifacts?.[0]?.processed_review_thread_ids, [`${reviewThread.id}@${headSha}`]);
   assert.deepEqual(artifacts?.[0]?.processed_review_thread_fingerprints, [
     `${reviewThread.id}@${headSha}#comment-no-source-repair`,
   ]);
+});
+
+test("buildPostPublicationReviewPersistence records exact current-head configured local CI from Codex verification", () => {
+  const headSha = "head-local-ci-proof";
+  const reviewThread = createReviewThread({
+    id: "thread-local-ci-proof",
+    comments: {
+      nodes: [
+        {
+          id: "comment-local-ci-proof",
+          body: "P2: Verify this already-addressed finding before merge.",
+          createdAt: "2026-06-26T06:23:00Z",
+          url: "https://example.test/pr/406#discussion_local_ci",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const persistence = buildPostPublicationReviewPersistence({
+    config: createConfig({ localCiCommand: "python3 scripts/ci/repo_hygiene.py" }),
+    preRunState: "addressing_review",
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    evaluatedReviewHeadSha: headSha,
+    reviewThreadsToProcess: [reviewThread],
+    localReviewRepairContext: null,
+    preRunReviewThreads: [reviewThread],
+    postRunReviewThreads: [reviewThread],
+    codexVerificationCommand: "python3 scripts/ci/repo_hygiene.py",
+    structuredSummary: "Configured local CI passed after verifying Connector residue.",
+    workspaceStatus: { headSha, hasUncommittedChanges: false },
+    changedFilesAfterPublication: [],
+  });
+
+  assert.equal(persistence.currentHeadLocalCiPatch.latest_local_ci_result?.outcome, "passed");
+  assert.equal(persistence.currentHeadLocalCiPatch.latest_local_ci_result?.head_sha, headSha);
+  assert.equal(
+    persistence.currentHeadLocalCiPatch.latest_local_ci_result?.command,
+    "python3 scripts/ci/repo_hygiene.py",
+  );
 });
 
 test("buildPostPublicationCodexVerificationTimelineArtifacts does not mark unchanged normal turns as current-head repair proof", () => {

--- a/src/turn-execution-post-publication-review.ts
+++ b/src/turn-execution-post-publication-review.ts
@@ -7,6 +7,7 @@ import {
   latestCodexConnectorReviewCommentNode,
 } from "./codex-connector-review-policy";
 import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./current-head-codex-repair-proof";
+import { displayLocalCiCommand } from "./core/config";
 import {
   latestReviewThreadCommentFingerprint,
   processedReviewThreadFingerprintKey,
@@ -22,6 +23,7 @@ import {
 import {
   GitHubPullRequest,
   IssueRunRecord,
+  LatestLocalCiResult,
   ReviewThread,
   SupervisorConfig,
   TimelineArtifact,
@@ -207,8 +209,41 @@ export interface PostPublicationReviewPersistence {
     "processed_review_thread_ids" | "processed_review_thread_fingerprints" | "review_loop_retry_state"
   >;
   reviewFollowUpPatch: Pick<IssueRunRecord, "review_follow_up_head_sha" | "review_follow_up_remaining">;
+  currentHeadLocalCiPatch: Partial<Pick<IssueRunRecord, "latest_local_ci_result">>;
   hasVerifiedNoSourceChangeReviewThreadEvidence: boolean;
   verifiedNoSourceChangeReviewThreads: ReviewThread[];
+}
+
+function currentHeadLocalCiPatchFromCodexVerification(args: {
+  config: Pick<SupervisorConfig, "localCiCommand">;
+  currentPr: GitHubPullRequest | null;
+  codexVerificationCommand: string | null;
+  workspaceStatus: Pick<WorkspaceStatus, "hasUncommittedChanges" | "headSha">;
+  structuredSummary: string | null | undefined;
+}): Partial<Pick<IssueRunRecord, "latest_local_ci_result">> {
+  const configuredLocalCiCommand = displayLocalCiCommand(args.config.localCiCommand ?? undefined);
+  if (
+    !configuredLocalCiCommand ||
+    !args.currentPr ||
+    !args.codexVerificationCommand ||
+    args.codexVerificationCommand.trim() !== configuredLocalCiCommand ||
+    args.workspaceStatus.hasUncommittedChanges ||
+    args.workspaceStatus.headSha !== args.currentPr.headRefOid
+  ) {
+    return {};
+  }
+
+  const latestLocalCiResult: LatestLocalCiResult = {
+    outcome: "passed",
+    summary: conciseCodexVerificationSummary(args.structuredSummary) || "configured_local_ci_passed_in_codex_turn",
+    ran_at: new Date().toISOString(),
+    head_sha: args.currentPr.headRefOid,
+    execution_mode: null,
+    command: configuredLocalCiCommand,
+    failure_class: null,
+    remediation_target: null,
+  };
+  return { latest_local_ci_result: latestLocalCiResult };
 }
 
 export function buildPostPublicationReviewPersistence(args: {
@@ -222,6 +257,7 @@ export function buildPostPublicationReviewPersistence(args: {
   preRunReviewThreads: ReviewThread[];
   postRunReviewThreads: ReviewThread[];
   codexVerificationCommand: string | null;
+  structuredSummary?: string | null;
   workspaceStatus: Pick<WorkspaceStatus, "hasUncommittedChanges" | "headSha">;
   changedFilesAfterPublication: readonly string[];
 }): PostPublicationReviewPersistence {
@@ -271,6 +307,13 @@ export function buildPostPublicationReviewPersistence(args: {
   return {
     processedReviewThreadPatch,
     reviewFollowUpPatch,
+    currentHeadLocalCiPatch: currentHeadLocalCiPatchFromCodexVerification({
+      config: args.config,
+      currentPr: args.currentPr,
+      codexVerificationCommand: args.codexVerificationCommand,
+      workspaceStatus: args.workspaceStatus,
+      structuredSummary: args.structuredSummary,
+    }),
     hasVerifiedNoSourceChangeReviewThreadEvidence,
     verifiedNoSourceChangeReviewThreads,
   };
@@ -312,7 +355,10 @@ export function buildPostPublicationCodexVerificationTimelineArtifacts(args: {
   const canEmitSourceChangingReviewRepairTarget =
     args.preRunState === "addressing_review" && hasPublishedRepairChanges;
   const codexTurnVerificationRepairTargets = args.hasVerifiedNoSourceChangeReviewThreadEvidence
-    ? [VERIFIED_NO_SOURCE_CHANGE_REVIEW_THREAD_RESIDUE_TARGET]
+    ? [
+        VERIFIED_NO_SOURCE_CHANGE_REVIEW_THREAD_RESIDUE_TARGET,
+        VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
+      ]
     : canEmitSourceChangingReviewRepairTarget && hasCodexTurnVerificationReviewThreadEvidence
       ? [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET]
       : undefined;


### PR DESCRIPTION
## Summary

Implements #2389 by hardening the current-head Codex Connector repair proof contract across production, projection, recovery replay, and diagnostics.

## What changed

- Persist no-source current-head verification as both no-source residue evidence and `verified_current_head_repair_review_thread_residue` coverage when it covers review threads.
- Persist exact current-head `latest_local_ci_result` when the Codex verification command exactly matches the configured `localCiCommand`.
- Add proof rejection diagnostics for terminal manual-review churn records when malformed proof exists but projection fails.
- Add regression coverage for exact structured proof, compound-command local CI rejection, same-head manual-review replay, producer persistence, and status diagnostics.

## Root cause

#2387 added a strict evaluator, but the producer could write semantically useful verification artifacts in a shape the evaluator could not accept: no repair target on no-source verification, incomplete coverage, or compound command evidence instead of exact configured local CI evidence. Recovery then preserved the same-head churn block because proof projection failed.

## Validation

- `rtk git diff --check`
- `rtk npx tsx --test src/current-head-codex-repair-proof.test.ts src/turn-execution-post-publication-review.test.ts src/supervisor/stale-review-bot-remediation.test.ts src/recovery-blocked-issue-reconciliation.test.ts`
- `rtk npx tsx --test src/run-once-turn-execution.test.ts src/current-head-codex-repair-proof.test.ts src/turn-execution-post-publication-review.test.ts src/supervisor/stale-review-bot-remediation.test.ts src/recovery-blocked-issue-reconciliation.test.ts`
- `rtk npx tsx --test src/supervisor/replay-corpus.test.ts src/supervisor/replay-corpus-runner.test.ts src/supervisor/supervisor-execution-orchestration.test.ts`
- `rtk npx tsx --test src/family-directory-layout.test.ts src/pull-request-state-thread-reprocessing.test.ts src/supervisor/supervisor-execution-cleanup.test.ts src/supervisor/supervisor-lifecycle.test.ts src/tracked-pr-lifecycle-projection.test.ts`
- `rtk npm run build`
- `rtk npm test`
