### PR TITLE
[codex] Replay current-head no-major Codex residue

### DIFF
--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -178,6 +178,18 @@ export function commitShasEqualForComparison(left: string | null | undefined, ri
   return Boolean(normalizedLeft && normalizedRight && normalizedLeft === normalizedRight);
 }
 
+export function commitShasMatchByPrefixForComparison(left: string | null | undefined, right: string | null | undefined): boolean {
+  const normalizedLeft = normalizeCommitShaForComparison(left);
+  const normalizedRight = normalizeCommitShaForComparison(right);
+  return Boolean(
+    normalizedLeft &&
+      normalizedRight &&
+      (normalizedLeft === normalizedRight ||
+        normalizedLeft.startsWith(normalizedRight) ||
+        normalizedRight.startsWith(normalizedLeft)),
+  );
+}
+
 export function commitShasDifferForComparison(left: string | null | undefined, right: string | null | undefined): boolean {
   const normalizedLeft = normalizeCommitShaForComparison(left);
   const normalizedRight = normalizeCommitShaForComparison(right);

--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -153,6 +153,7 @@ test("projectCurrentHeadCodexRepairProof accepts thread-scoped proof after revie
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "647c90b90b",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-27T00:53:12Z",
   });
 
   const proof = projectCurrentHeadCodexRepairProof({
@@ -221,6 +222,7 @@ test("projectCurrentHeadCodexRepairProof rejects thread-scoped no-major proof fo
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "dbe5e968ce",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-27T00:53:12Z",
   });
 
   assert.equal(projectCurrentHeadCodexRepairProof({
@@ -237,6 +239,65 @@ test("projectCurrentHeadCodexRepairProof rejects thread-scoped no-major proof fo
     checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
     reviewThreads: threads,
   }), ["current_head_repair_proof_repair_target_missing"]);
+});
+
+test("projectCurrentHeadCodexRepairProof rejects reviewed-current-head no-major before a later blocker", () => {
+  const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
+  const threads = [
+    codexThread({ id: "thread-after-no-major", commentId: "comment-after-no-major", severity: "P2", line: 432 }),
+  ];
+  threads[0]!.comments.nodes[0]!.createdAt = "2026-06-27T00:54:12Z";
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "python3 scripts/ci/repo_hygiene.py",
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Repo hygiene passed on current head.",
+      ran_at: "2026-06-27T00:55:00Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "python3 scripts/ci/repo_hygiene.py",
+      failure_class: null,
+      remediation_target: null,
+    },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python3 scripts/ci/repo_hygiene.py",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Rechecked unresolved review cluster; no source changes needed.",
+        recorded_at: "2026-06-27T00:55:21Z",
+        processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+        processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-27T00:54:12Z",
+    configuredBotCurrentHeadObservationSource: "review_thread_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "647c90b90b",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-27T00:53:12Z",
+  });
+
+  assert.equal(projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+  }), null);
 });
 
 test("projectCurrentHeadCodexRepairProof rejects unanchored no-major even when a separate latest reviewed commit matches", () => {

--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -149,8 +149,8 @@ test("projectCurrentHeadCodexRepairProof accepts thread-scoped proof after revie
   });
   const pr = createPullRequest({
     headRefOid: headSha,
-    configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
-    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadObservedAt: "2026-06-27T00:54:12Z",
+    configuredBotCurrentHeadObservationSource: "status_context",
     configuredBotCurrentHeadStatusState: "SUCCESS",
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "647c90b90b",
     configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-27T00:53:12Z",
@@ -287,6 +287,65 @@ test("projectCurrentHeadCodexRepairProof rejects reviewed-current-head no-major 
     configuredBotCurrentHeadObservedAt: "2026-06-27T00:54:12Z",
     configuredBotCurrentHeadObservationSource: "review_thread_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "647c90b90b",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-27T00:53:12Z",
+  });
+
+  assert.equal(projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+  }), null);
+});
+
+test("projectCurrentHeadCodexRepairProof rejects reviewed-current-head no-major before a later actionable observation", () => {
+  const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
+  const threads = [
+    codexThread({ id: "thread-before-no-major", commentId: "comment-before-no-major", severity: "P2", line: 432 }),
+  ];
+  threads[0]!.comments.nodes[0]!.createdAt = "2026-06-27T00:52:12Z";
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "python3 scripts/ci/repo_hygiene.py",
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Repo hygiene passed on current head.",
+      ran_at: "2026-06-27T00:55:00Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "python3 scripts/ci/repo_hygiene.py",
+      failure_class: null,
+      remediation_target: null,
+    },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python3 scripts/ci/repo_hygiene.py",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Rechecked unresolved review cluster; no source changes needed.",
+        recorded_at: "2026-06-27T00:55:21Z",
+        processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+        processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-27T00:54:12Z",
+    configuredBotCurrentHeadObservationSource: "review_thread_comment",
+    configuredBotCurrentHeadStatusState: null,
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "647c90b90b",
     configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-27T00:53:12Z",
   });

--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -152,7 +152,7 @@ test("projectCurrentHeadCodexRepairProof accepts thread-scoped proof after revie
     configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
-    configuredBotCurrentHeadObservationReviewedCommitSha: "647c90b90b",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "647c90b90b",
   });
 
   const proof = projectCurrentHeadCodexRepairProof({
@@ -220,7 +220,7 @@ test("projectCurrentHeadCodexRepairProof rejects thread-scoped no-major proof fo
     configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
-    configuredBotCurrentHeadObservationReviewedCommitSha: "dbe5e968ce",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "dbe5e968ce",
   });
 
   assert.equal(projectCurrentHeadCodexRepairProof({
@@ -284,7 +284,7 @@ test("projectCurrentHeadCodexRepairProof rejects unanchored no-major even when a
     configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
-    configuredBotCurrentHeadObservationReviewedCommitSha: null,
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: null,
     configuredBotLatestReviewedCommitSha: "647c90b90b",
   });
 

--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -343,9 +343,10 @@ test("projectCurrentHeadCodexRepairProof rejects reviewed-current-head no-major 
   });
   const pr = createPullRequest({
     headRefOid: headSha,
-    configuredBotCurrentHeadObservedAt: "2026-06-27T00:54:12Z",
-    configuredBotCurrentHeadObservationSource: "review_thread_comment",
+    configuredBotCurrentHeadObservedAt: "2026-06-27T00:55:12Z",
+    configuredBotCurrentHeadObservationSource: "status_context",
     configuredBotCurrentHeadStatusState: null,
+    configuredBotCurrentHeadActionableObservedAt: "2026-06-27T00:54:12Z",
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "647c90b90b",
     configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-27T00:53:12Z",
   });

--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -106,6 +106,139 @@ test("projectCurrentHeadCodexRepairProof accepts structured P1 residue proof wit
   assert.equal(proof?.currentConfiguredThreadCount, 2);
 });
 
+test("projectCurrentHeadCodexRepairProof accepts thread-scoped proof after reviewed-current-head no-major without request marker", () => {
+  const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
+  const threads = [
+    codexThread({ id: "thread-no-major-a", commentId: "comment-no-major-a", severity: "P2", line: 432 }),
+    codexThread({ id: "thread-no-major-b", commentId: "comment-no-major-b", severity: "P2", line: 757 }),
+  ];
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "python3 scripts/ci/repo_hygiene.py",
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Repo hygiene passed on current head.",
+      ran_at: "2026-06-27T00:50:00Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "python3 scripts/ci/repo_hygiene.py",
+      failure_class: null,
+      remediation_target: null,
+    },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python3 scripts/ci/repo_hygiene.py",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Rechecked unresolved review cluster; no source changes needed.",
+        recorded_at: "2026-06-27T00:50:21Z",
+        processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+        processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotLatestReviewedCommitSha: "647c90b90b",
+  });
+
+  const proof = projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+  });
+
+  assert.equal(proof?.source, "thread_scoped_verification_artifact");
+  assert.equal(proof?.localVerificationEvidenceSource, "latest_local_ci_result");
+  assert.match(proof?.summary ?? "", /codex_no_major_support=codex_pr_success_comment_reviewed_current_head/);
+  assert.deepEqual(currentHeadCodexRepairProofRejectionReasons({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+  }), []);
+});
+
+test("projectCurrentHeadCodexRepairProof rejects thread-scoped no-major proof for an older reviewed commit", () => {
+  const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
+  const threads = [
+    codexThread({ id: "thread-old-no-major", commentId: "comment-old-no-major", severity: "P2", line: 432 }),
+  ];
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "python3 scripts/ci/repo_hygiene.py",
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Repo hygiene passed on current head.",
+      ran_at: "2026-06-27T00:50:00Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "python3 scripts/ci/repo_hygiene.py",
+      failure_class: null,
+      remediation_target: null,
+    },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python3 scripts/ci/repo_hygiene.py",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Rechecked unresolved review cluster; no source changes needed.",
+        recorded_at: "2026-06-27T00:50:21Z",
+        processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+        processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotLatestReviewedCommitSha: "dbe5e968ce",
+  });
+
+  assert.equal(projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+  }), null);
+  assert.deepEqual(currentHeadCodexRepairProofRejectionReasons({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+  }), ["current_head_repair_proof_repair_target_missing"]);
+});
+
 test("projectCurrentHeadCodexRepairProof rejects compound-command artifacts without exact local CI evidence", () => {
   const headSha = "f9e584d660a4ae175a9b72980e2dcc83d9d86413";
   const threads = [

--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -152,7 +152,7 @@ test("projectCurrentHeadCodexRepairProof accepts thread-scoped proof after revie
     configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
-    configuredBotLatestReviewedCommitSha: "647c90b90b",
+    configuredBotCurrentHeadObservationReviewedCommitSha: "647c90b90b",
   });
 
   const proof = projectCurrentHeadCodexRepairProof({
@@ -220,7 +220,7 @@ test("projectCurrentHeadCodexRepairProof rejects thread-scoped no-major proof fo
     configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
-    configuredBotLatestReviewedCommitSha: "dbe5e968ce",
+    configuredBotCurrentHeadObservationReviewedCommitSha: "dbe5e968ce",
   });
 
   assert.equal(projectCurrentHeadCodexRepairProof({
@@ -237,6 +237,64 @@ test("projectCurrentHeadCodexRepairProof rejects thread-scoped no-major proof fo
     checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
     reviewThreads: threads,
   }), ["current_head_repair_proof_repair_target_missing"]);
+});
+
+test("projectCurrentHeadCodexRepairProof rejects unanchored no-major even when a separate latest reviewed commit matches", () => {
+  const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
+  const threads = [
+    codexThread({ id: "thread-unanchored-no-major", commentId: "comment-unanchored-no-major", severity: "P2", line: 432 }),
+  ];
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "python3 scripts/ci/repo_hygiene.py",
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Repo hygiene passed on current head.",
+      ran_at: "2026-06-27T00:50:00Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "python3 scripts/ci/repo_hygiene.py",
+      failure_class: null,
+      remediation_target: null,
+    },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python3 scripts/ci/repo_hygiene.py",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Rechecked unresolved review cluster; no source changes needed.",
+        recorded_at: "2026-06-27T00:50:21Z",
+        processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+        processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadObservationReviewedCommitSha: null,
+    configuredBotLatestReviewedCommitSha: "647c90b90b",
+  });
+
+  assert.equal(projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+  }), null);
 });
 
 test("projectCurrentHeadCodexRepairProof rejects compound-command artifacts without exact local CI evidence", () => {

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -316,6 +316,7 @@ type CurrentHeadCodexSuccessFacts = Pick<
   | "headRefOid"
   | "configuredBotCurrentHeadObservedAt"
   | "configuredBotCurrentHeadObservationSource"
+  | "configuredBotCurrentHeadActionableObservedAt"
   | "configuredBotCurrentHeadCodexSuccessReviewedCommitSha"
   | "configuredBotCurrentHeadCodexSuccessObservedAt"
 >;
@@ -345,7 +346,11 @@ export function hasFreshCurrentHeadCodexSuccessReviewedCommit(
   if (!successObservedAt) {
     return false;
   }
-  if (laterCurrentHeadObservationInvalidatesCodexSuccess(pr, successObservedAt)) {
+  const latestActionableObservedAt = validTimestamp(pr.configuredBotCurrentHeadActionableObservedAt);
+  if (latestActionableObservedAt && Date.parse(successObservedAt) < Date.parse(latestActionableObservedAt)) {
+    return false;
+  }
+  if (!latestActionableObservedAt && laterCurrentHeadObservationInvalidatesCodexSuccess(pr, successObservedAt)) {
     return false;
   }
   const latestMustFixObservedAt = validTimestamp(latestCodexConnectorMustFixReviewCommentObservedAt(reviewThreads));
@@ -367,6 +372,7 @@ function currentHeadNoMajorSupportSummary(
     | "codexConnectorReviewRequestedHeadSha"
     | "configuredBotCurrentHeadObservedAt"
     | "configuredBotCurrentHeadObservationSource"
+    | "configuredBotCurrentHeadActionableObservedAt"
     | "configuredBotCurrentHeadCodexSuccessReviewedCommitSha"
     | "configuredBotCurrentHeadCodexSuccessObservedAt"
   >,

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -311,6 +311,50 @@ export function latestCodexConnectorMustFixReviewCommentObservedAt(reviewThreads
   return latest?.observedAt ?? null;
 }
 
+type CurrentHeadCodexSuccessFacts = Pick<
+  GitHubPullRequest,
+  | "headRefOid"
+  | "configuredBotCurrentHeadObservedAt"
+  | "configuredBotCurrentHeadObservationSource"
+  | "configuredBotCurrentHeadCodexSuccessReviewedCommitSha"
+  | "configuredBotCurrentHeadCodexSuccessObservedAt"
+>;
+
+function laterCurrentHeadObservationInvalidatesCodexSuccess(
+  pr: CurrentHeadCodexSuccessFacts,
+  successObservedAt: string,
+): boolean {
+  const observedAt = validTimestamp(pr.configuredBotCurrentHeadObservedAt);
+  if (!observedAt || Date.parse(successObservedAt) >= Date.parse(observedAt)) {
+    return false;
+  }
+  return (
+    pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment" &&
+    pr.configuredBotCurrentHeadObservationSource !== "status_context"
+  );
+}
+
+export function hasFreshCurrentHeadCodexSuccessReviewedCommit(
+  pr: CurrentHeadCodexSuccessFacts,
+  reviewThreads: ReviewThread[],
+): boolean {
+  if (!commitShasMatchByPrefixForComparison(pr.configuredBotCurrentHeadCodexSuccessReviewedCommitSha, pr.headRefOid)) {
+    return false;
+  }
+  const successObservedAt = validTimestamp(pr.configuredBotCurrentHeadCodexSuccessObservedAt);
+  if (!successObservedAt) {
+    return false;
+  }
+  if (laterCurrentHeadObservationInvalidatesCodexSuccess(pr, successObservedAt)) {
+    return false;
+  }
+  const latestMustFixObservedAt = validTimestamp(latestCodexConnectorMustFixReviewCommentObservedAt(reviewThreads));
+  if (latestMustFixObservedAt && Date.parse(successObservedAt) < Date.parse(latestMustFixObservedAt)) {
+    return false;
+  }
+  return true;
+}
+
 function currentHeadNoMajorSupportSummary(
   record: Pick<
     IssueRunRecord,
@@ -332,15 +376,7 @@ function currentHeadNoMajorSupportSummary(
   if (!observedAt) {
     return null;
   }
-  if (commitShasMatchByPrefixForComparison(pr.configuredBotCurrentHeadCodexSuccessReviewedCommitSha, pr.headRefOid)) {
-    const successObservedAt = validTimestamp(pr.configuredBotCurrentHeadCodexSuccessObservedAt);
-    if (!successObservedAt) {
-      return null;
-    }
-    const latestMustFixObservedAt = validTimestamp(latestCodexConnectorMustFixReviewCommentObservedAt(reviewThreads));
-    if (latestMustFixObservedAt && Date.parse(successObservedAt) < Date.parse(latestMustFixObservedAt)) {
-      return null;
-    }
+  if (hasFreshCurrentHeadCodexSuccessReviewedCommit(pr, reviewThreads)) {
     return "codex_pr_success_comment_reviewed_current_head";
   }
   if (pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment") {

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -307,7 +307,7 @@ function currentHeadNoMajorSupportSummary(
     | "codexConnectorReviewRequestedHeadSha"
     | "configuredBotCurrentHeadObservedAt"
     | "configuredBotCurrentHeadObservationSource"
-    | "configuredBotLatestReviewedCommitSha"
+    | "configuredBotCurrentHeadObservationReviewedCommitSha"
   >,
 ): string | null {
   if (pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment") {
@@ -317,7 +317,7 @@ function currentHeadNoMajorSupportSummary(
   if (!observedAt) {
     return null;
   }
-  if (commitShasMatchByPrefixForComparison(pr.configuredBotLatestReviewedCommitSha, pr.headRefOid)) {
+  if (commitShasMatchByPrefixForComparison(pr.configuredBotCurrentHeadObservationReviewedCommitSha, pr.headRefOid)) {
     return "codex_pr_success_comment_reviewed_current_head";
   }
   const requestedAt =

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -4,6 +4,7 @@ import {
   commitShasMatchByPrefixForComparison,
   hasCodexConnectorFindingReviewComment,
   latestCodexConnectorReviewComment,
+  latestCodexConnectorReviewCommentNode,
   latestCodexConnectorPSeverity,
 } from "./codex-connector-review-policy";
 import { displayLocalCiCommand } from "./core/config";
@@ -295,6 +296,21 @@ function validTimestamp(value: string | null | undefined): string | null {
   return value;
 }
 
+export function latestCodexConnectorMustFixReviewCommentObservedAt(reviewThreads: ReviewThread[]): string | null {
+  let latest: { observedAt: string; observedAtMs: number } | null = null;
+  for (const thread of codexConnectorMustFixReviewThreads(reviewThreads)) {
+    const comment = latestCodexConnectorReviewCommentNode(thread);
+    const observedAtMs = Date.parse(comment?.createdAt ?? "");
+    if (!comment || Number.isNaN(observedAtMs)) {
+      continue;
+    }
+    if (!latest || observedAtMs >= latest.observedAtMs) {
+      latest = { observedAt: comment.createdAt, observedAtMs };
+    }
+  }
+  return latest?.observedAt ?? null;
+}
+
 function currentHeadNoMajorSupportSummary(
   record: Pick<
     IssueRunRecord,
@@ -308,13 +324,23 @@ function currentHeadNoMajorSupportSummary(
     | "configuredBotCurrentHeadObservedAt"
     | "configuredBotCurrentHeadObservationSource"
     | "configuredBotCurrentHeadCodexSuccessReviewedCommitSha"
+    | "configuredBotCurrentHeadCodexSuccessObservedAt"
   >,
+  reviewThreads: ReviewThread[],
 ): string | null {
   const observedAt = validTimestamp(pr.configuredBotCurrentHeadObservedAt);
   if (!observedAt) {
     return null;
   }
   if (commitShasMatchByPrefixForComparison(pr.configuredBotCurrentHeadCodexSuccessReviewedCommitSha, pr.headRefOid)) {
+    const successObservedAt = validTimestamp(pr.configuredBotCurrentHeadCodexSuccessObservedAt);
+    if (!successObservedAt) {
+      return null;
+    }
+    const latestMustFixObservedAt = validTimestamp(latestCodexConnectorMustFixReviewCommentObservedAt(reviewThreads));
+    if (latestMustFixObservedAt && Date.parse(successObservedAt) < Date.parse(latestMustFixObservedAt)) {
+      return null;
+    }
     return "codex_pr_success_comment_reviewed_current_head";
   }
   if (pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment") {
@@ -396,7 +422,7 @@ export function projectCurrentHeadCodexRepairProof(args: {
   }
 
   const currentThreads = currentConfiguredBotThreads(args.config, args.reviewThreads);
-  const noMajorSupport = currentHeadNoMajorSupportSummary(args.record, args.pr);
+  const noMajorSupport = currentHeadNoMajorSupportSummary(args.record, args.pr, currentThreads);
   const p1ProofAllowed = noMajorSupport !== null;
   const repairResidueThreads = currentRepairResidueThreads(currentThreads, p1ProofAllowed);
   if (
@@ -548,7 +574,7 @@ export function currentHeadCodexRepairProofRejectionReasons(args: {
   }
 
   const currentThreads = currentConfiguredBotThreads(args.config, args.reviewThreads);
-  const noMajorSupport = currentHeadNoMajorSupportSummary(args.record, args.pr);
+  const noMajorSupport = currentHeadNoMajorSupportSummary(args.record, args.pr, currentThreads);
   const p1ProofAllowed = noMajorSupport !== null;
   const repairResidueThreads = currentRepairResidueThreads(currentThreads, p1ProofAllowed);
   if (!repairResidueThreads) {

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -307,18 +307,18 @@ function currentHeadNoMajorSupportSummary(
     | "codexConnectorReviewRequestedHeadSha"
     | "configuredBotCurrentHeadObservedAt"
     | "configuredBotCurrentHeadObservationSource"
-    | "configuredBotCurrentHeadObservationReviewedCommitSha"
+    | "configuredBotCurrentHeadCodexSuccessReviewedCommitSha"
   >,
 ): string | null {
-  if (pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment") {
-    return null;
-  }
   const observedAt = validTimestamp(pr.configuredBotCurrentHeadObservedAt);
   if (!observedAt) {
     return null;
   }
-  if (commitShasMatchByPrefixForComparison(pr.configuredBotCurrentHeadObservationReviewedCommitSha, pr.headRefOid)) {
+  if (commitShasMatchByPrefixForComparison(pr.configuredBotCurrentHeadCodexSuccessReviewedCommitSha, pr.headRefOid)) {
     return "codex_pr_success_comment_reviewed_current_head";
+  }
+  if (pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment") {
+    return null;
   }
   const requestedAt =
     validTimestamp(record.codex_connector_review_requested_observed_at) ??

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -1,6 +1,7 @@
 import {
   codexConnectorMustFixReviewThreads,
   commitShasEqualForComparison,
+  commitShasMatchByPrefixForComparison,
   hasCodexConnectorFindingReviewComment,
   latestCodexConnectorReviewComment,
   latestCodexConnectorPSeverity,
@@ -306,6 +307,7 @@ function currentHeadNoMajorSupportSummary(
     | "codexConnectorReviewRequestedHeadSha"
     | "configuredBotCurrentHeadObservedAt"
     | "configuredBotCurrentHeadObservationSource"
+    | "configuredBotLatestReviewedCommitSha"
   >,
 ): string | null {
   if (pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment") {
@@ -314,6 +316,9 @@ function currentHeadNoMajorSupportSummary(
   const observedAt = validTimestamp(pr.configuredBotCurrentHeadObservedAt);
   if (!observedAt) {
     return null;
+  }
+  if (commitShasMatchByPrefixForComparison(pr.configuredBotLatestReviewedCommitSha, pr.headRefOid)) {
+    return "codex_pr_success_comment_reviewed_current_head";
   }
   const requestedAt =
     validTimestamp(record.codex_connector_review_requested_observed_at) ??

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -361,8 +361,8 @@ export function applyConfiguredBotReviewSummary(
     codexConnectorReviewRequestCommentUrl: summary?.codexConnectorReviewRequest?.commentUrl ?? null,
     configuredBotCurrentHeadObservedAt: summary?.currentHeadObservedAt ?? null,
     configuredBotCurrentHeadObservationSource: summary?.currentHeadObservationSource ?? null,
-    configuredBotCurrentHeadObservationReviewedCommitSha:
-      summary?.currentHeadObservationReviewedCommitSha ?? null,
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha:
+      summary?.currentHeadCodexSuccessReviewedCommitSha ?? null,
     configuredBotCurrentHeadStatusState: summary?.currentHeadStatusState ?? null,
     configuredBotLatestReviewedCommitSha: summary?.latestReviewedCommitSha ?? null,
     currentHeadCiGreenAt: summary?.currentHeadCiGreenAt ?? null,

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -361,6 +361,7 @@ export function applyConfiguredBotReviewSummary(
     codexConnectorReviewRequestCommentUrl: summary?.codexConnectorReviewRequest?.commentUrl ?? null,
     configuredBotCurrentHeadObservedAt: summary?.currentHeadObservedAt ?? null,
     configuredBotCurrentHeadObservationSource: summary?.currentHeadObservationSource ?? null,
+    configuredBotCurrentHeadActionableObservedAt: summary?.currentHeadActionableObservedAt ?? null,
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha:
       summary?.currentHeadCodexSuccessReviewedCommitSha ?? null,
     configuredBotCurrentHeadCodexSuccessObservedAt: summary?.currentHeadCodexSuccessObservedAt ?? null,

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -361,6 +361,8 @@ export function applyConfiguredBotReviewSummary(
     codexConnectorReviewRequestCommentUrl: summary?.codexConnectorReviewRequest?.commentUrl ?? null,
     configuredBotCurrentHeadObservedAt: summary?.currentHeadObservedAt ?? null,
     configuredBotCurrentHeadObservationSource: summary?.currentHeadObservationSource ?? null,
+    configuredBotCurrentHeadObservationReviewedCommitSha:
+      summary?.currentHeadObservationReviewedCommitSha ?? null,
     configuredBotCurrentHeadStatusState: summary?.currentHeadStatusState ?? null,
     configuredBotLatestReviewedCommitSha: summary?.latestReviewedCommitSha ?? null,
     currentHeadCiGreenAt: summary?.currentHeadCiGreenAt ?? null,

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -363,6 +363,7 @@ export function applyConfiguredBotReviewSummary(
     configuredBotCurrentHeadObservationSource: summary?.currentHeadObservationSource ?? null,
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha:
       summary?.currentHeadCodexSuccessReviewedCommitSha ?? null,
+    configuredBotCurrentHeadCodexSuccessObservedAt: summary?.currentHeadCodexSuccessObservedAt ?? null,
     configuredBotCurrentHeadStatusState: summary?.currentHeadStatusState ?? null,
     configuredBotLatestReviewedCommitSha: summary?.latestReviewedCommitSha ?? null,
     currentHeadCiGreenAt: summary?.currentHeadCiGreenAt ?? null,

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -1377,6 +1377,46 @@ test("buildConfiguredBotReviewSummary preserves Codex success reviewed commit af
   assert.equal(summary.currentHeadCodexSuccessObservedAt, "2026-06-27T00:53:12Z");
 });
 
+test("buildConfiguredBotReviewSummary preserves actionable observations hidden by later status contexts", () => {
+  const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [
+      {
+        authorLogin: "chatgpt-codex-connector[bot]",
+        createdAt: "2026-06-27T00:53:12Z",
+        body: "Codex Review: Didn't find any major issues. :tada:\n\n**Reviewed commit:** `647c90b90b`",
+      },
+      {
+        authorLogin: "chatgpt-codex-connector[bot]",
+        createdAt: "2026-06-27T00:54:12Z",
+        body: "P2: This current-head issue should be fixed.",
+      },
+    ],
+    statusContexts: [
+      {
+        creatorLogin: "chatgpt-codex-connector[bot]",
+        context: "Codex Review",
+        description: "Codex review finished.",
+        state: "SUCCESS",
+        createdAt: "2026-06-27T00:55:12Z",
+        commitOid: headSha,
+      },
+    ],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector"], headSha);
+
+  assert.equal(summary.currentHeadObservedAt, "2026-06-27T00:55:12Z");
+  assert.equal(summary.currentHeadObservationSource, "status_context");
+  assert.equal(summary.currentHeadActionableObservedAt, "2026-06-27T00:54:12Z");
+  assert.equal(summary.currentHeadCodexSuccessReviewedCommitSha, "647c90b90b");
+  assert.equal(summary.currentHeadCodexSuccessObservedAt, "2026-06-27T00:53:12Z");
+});
+
 test("buildConfiguredBotReviewSummary rejects stale reviewed-commit Codex Connector no-major issue comments", () => {
   const facts: CopilotReviewLifecycleFacts = {
     reviewRequests: [],

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -1312,6 +1312,62 @@ test("buildConfiguredBotReviewSummary recognizes live Codex Connector no-major-i
   });
 });
 
+test("buildConfiguredBotReviewSummary anchors Codex Connector no-major issue comments to reviewed commits", () => {
+  const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [
+      {
+        authorLogin: "chatgpt-codex-connector[bot]",
+        createdAt: "2026-06-27T00:52:12Z",
+        body: "Codex Review: Didn't find any major issues. :tada:\n\n**Reviewed commit:** `dbe5e968ce`",
+      },
+      {
+        authorLogin: "chatgpt-codex-connector[bot]",
+        createdAt: "2026-06-27T00:53:12Z",
+        body: "Codex Review: Didn't find any major issues. :tada:\n\n**Reviewed commit:** `647c90b90b`",
+      },
+    ],
+    statusContexts: [],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector"], headSha);
+
+  assert.equal(summary.currentHeadObservedAt, "2026-06-27T00:53:12Z");
+  assert.equal(summary.currentHeadObservationSource, "codex_pr_success_comment");
+  assert.equal(summary.latestReviewedCommitSha, "647c90b90b");
+});
+
+test("buildConfiguredBotReviewSummary rejects stale reviewed-commit Codex Connector no-major issue comments", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [
+      {
+        authorLogin: "chatgpt-codex-connector[bot]",
+        createdAt: "2026-06-27T00:53:12Z",
+        body: "Codex Review: Didn't find any major issues. :tada:\n\n**Reviewed commit:** `dbe5e968ce`",
+      },
+    ],
+    statusContexts: [],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(
+    facts,
+    ["chatgpt-codex-connector"],
+    "647c90b90b820cb17b83d2d80b5dddd3e789028b",
+  );
+
+  assert.equal(summary.currentHeadObservedAt, null);
+  assert.equal(summary.currentHeadObservationSource, null);
+  assert.equal(summary.latestReviewedCommitSha, "dbe5e968ce");
+});
+
 test("buildConfiguredBotReviewSummary rejects non-success and non-configured PR conversation comments as Codex Connector observations", () => {
   const facts: CopilotReviewLifecycleFacts = {
     reviewRequests: [],

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -1338,6 +1338,7 @@ test("buildConfiguredBotReviewSummary anchors Codex Connector no-major issue com
 
   assert.equal(summary.currentHeadObservedAt, "2026-06-27T00:53:12Z");
   assert.equal(summary.currentHeadObservationSource, "codex_pr_success_comment");
+  assert.equal(summary.currentHeadObservationReviewedCommitSha, "647c90b90b");
   assert.equal(summary.latestReviewedCommitSha, "647c90b90b");
 });
 
@@ -1365,6 +1366,7 @@ test("buildConfiguredBotReviewSummary rejects stale reviewed-commit Codex Connec
 
   assert.equal(summary.currentHeadObservedAt, null);
   assert.equal(summary.currentHeadObservationSource, null);
+  assert.equal(summary.currentHeadObservationReviewedCommitSha, null);
   assert.equal(summary.latestReviewedCommitSha, "dbe5e968ce");
 });
 

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -1338,8 +1338,41 @@ test("buildConfiguredBotReviewSummary anchors Codex Connector no-major issue com
 
   assert.equal(summary.currentHeadObservedAt, "2026-06-27T00:53:12Z");
   assert.equal(summary.currentHeadObservationSource, "codex_pr_success_comment");
-  assert.equal(summary.currentHeadObservationReviewedCommitSha, "647c90b90b");
+  assert.equal(summary.currentHeadCodexSuccessReviewedCommitSha, "647c90b90b");
   assert.equal(summary.latestReviewedCommitSha, "647c90b90b");
+});
+
+test("buildConfiguredBotReviewSummary preserves Codex success reviewed commit after later current-head observations", () => {
+  const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [
+      {
+        authorLogin: "chatgpt-codex-connector[bot]",
+        createdAt: "2026-06-27T00:53:12Z",
+        body: "Codex Review: Didn't find any major issues. :tada:\n\n**Reviewed commit:** `647c90b90b`",
+      },
+    ],
+    statusContexts: [
+      {
+        creatorLogin: "chatgpt-codex-connector[bot]",
+        context: "Codex Review",
+        description: "Codex review finished.",
+        state: "SUCCESS",
+        createdAt: "2026-06-27T00:54:12Z",
+        commitOid: headSha,
+      },
+    ],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector"], headSha);
+
+  assert.equal(summary.currentHeadObservedAt, "2026-06-27T00:54:12Z");
+  assert.equal(summary.currentHeadObservationSource, "status_context");
+  assert.equal(summary.currentHeadCodexSuccessReviewedCommitSha, "647c90b90b");
 });
 
 test("buildConfiguredBotReviewSummary rejects stale reviewed-commit Codex Connector no-major issue comments", () => {
@@ -1366,7 +1399,7 @@ test("buildConfiguredBotReviewSummary rejects stale reviewed-commit Codex Connec
 
   assert.equal(summary.currentHeadObservedAt, null);
   assert.equal(summary.currentHeadObservationSource, null);
-  assert.equal(summary.currentHeadObservationReviewedCommitSha, null);
+  assert.equal(summary.currentHeadCodexSuccessReviewedCommitSha, null);
   assert.equal(summary.latestReviewedCommitSha, "dbe5e968ce");
 });
 

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -1339,6 +1339,7 @@ test("buildConfiguredBotReviewSummary anchors Codex Connector no-major issue com
   assert.equal(summary.currentHeadObservedAt, "2026-06-27T00:53:12Z");
   assert.equal(summary.currentHeadObservationSource, "codex_pr_success_comment");
   assert.equal(summary.currentHeadCodexSuccessReviewedCommitSha, "647c90b90b");
+  assert.equal(summary.currentHeadCodexSuccessObservedAt, "2026-06-27T00:53:12Z");
   assert.equal(summary.latestReviewedCommitSha, "647c90b90b");
 });
 
@@ -1373,6 +1374,7 @@ test("buildConfiguredBotReviewSummary preserves Codex success reviewed commit af
   assert.equal(summary.currentHeadObservedAt, "2026-06-27T00:54:12Z");
   assert.equal(summary.currentHeadObservationSource, "status_context");
   assert.equal(summary.currentHeadCodexSuccessReviewedCommitSha, "647c90b90b");
+  assert.equal(summary.currentHeadCodexSuccessObservedAt, "2026-06-27T00:53:12Z");
 });
 
 test("buildConfiguredBotReviewSummary rejects stale reviewed-commit Codex Connector no-major issue comments", () => {
@@ -1400,6 +1402,7 @@ test("buildConfiguredBotReviewSummary rejects stale reviewed-commit Codex Connec
   assert.equal(summary.currentHeadObservedAt, null);
   assert.equal(summary.currentHeadObservationSource, null);
   assert.equal(summary.currentHeadCodexSuccessReviewedCommitSha, null);
+  assert.equal(summary.currentHeadCodexSuccessObservedAt, null);
   assert.equal(summary.latestReviewedCommitSha, "dbe5e968ce");
 });
 

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -548,8 +548,20 @@ function inferConfiguredBotOnlyChangesRequestedReview(
 }
 
 function reviewedCommitFromBody(body: string | null | undefined): string | null {
-  const match = body?.match(/\bReviewed commit:\s*([0-9a-f]{7,40})\b/i);
+  const match = body?.match(/\bReviewed commit:\*{0,2}\s*`?([0-9a-f]{7,40})\b/i);
   return match?.[1] ?? null;
+}
+
+function commitShaMatchesByPrefix(left: string | null | undefined, right: string | null | undefined): boolean {
+  const normalizedLeft = left?.trim().toLowerCase();
+  const normalizedRight = right?.trim().toLowerCase();
+  return Boolean(
+    normalizedLeft &&
+      normalizedRight &&
+      (normalizedLeft === normalizedRight ||
+        normalizedLeft.startsWith(normalizedRight) ||
+        normalizedRight.startsWith(normalizedLeft)),
+  );
 }
 
 function inferLatestConfiguredBotReviewedCommitSha(
@@ -580,6 +592,33 @@ function inferLatestConfiguredBotReviewedCommitSha(
 
     if (!latest || submittedAtMs >= latest.submittedAtMs) {
       latest = { submittedAtMs, reviewedCommitSha };
+    }
+  }
+
+  if (hasConfiguredCodexConnectorLogin(configuredReviewBots)) {
+    for (const comment of facts.issueComments) {
+      const authorLogin = normalizeLogin(comment.authorLogin);
+      if (
+        !authorLogin ||
+        !isCodexConnectorLogin(authorLogin) ||
+        !isCodexConnectorPrSuccessCommentText(comment.body)
+      ) {
+        continue;
+      }
+
+      const submittedAtMs = parseTimestamp(comment.createdAt);
+      if (submittedAtMs === 0) {
+        continue;
+      }
+
+      const reviewedCommitSha = reviewedCommitFromBody(comment.body);
+      if (!reviewedCommitSha) {
+        continue;
+      }
+
+      if (!latest || submittedAtMs >= latest.submittedAtMs) {
+        latest = { submittedAtMs, reviewedCommitSha };
+      }
     }
   }
 
@@ -646,6 +685,10 @@ function inferConfiguredBotCurrentHeadObservation(
         isCodexConnectorLogin(authorLogin) &&
         isCodexConnectorPrSuccessCommentText(comment.body)
       ) {
+        const reviewedCommitSha = reviewedCommitFromBody(comment.body);
+        if (reviewedCommitSha && !commitShaMatchesByPrefix(reviewedCommitSha, normalizedCurrentHeadOid)) {
+          continue;
+        }
         currentHeadObservations.push({ observedAt: comment.createdAt, source: "codex_pr_success_comment" });
       }
     }

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -79,6 +79,7 @@ export interface ConfiguredBotReviewSummary {
   codexConnectorReviewRequest?: CodexConnectorReviewRequestObservation | null;
   currentHeadObservedAt: string | null;
   currentHeadObservationSource: ConfiguredBotCurrentHeadObservationSource;
+  currentHeadObservationReviewedCommitSha?: string | null;
   currentHeadStatusState: string | null;
   latestReviewedCommitSha: string | null;
   currentHeadCiGreenAt: string | null;
@@ -629,18 +630,26 @@ function inferConfiguredBotCurrentHeadObservation(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
   currentHeadOid: string | null | undefined,
-): { observedAt: string | null; source: ConfiguredBotCurrentHeadObservationSource } {
+): {
+  observedAt: string | null;
+  source: ConfiguredBotCurrentHeadObservationSource;
+  reviewedCommitSha: string | null;
+} {
   const normalizedCurrentHeadOid = currentHeadOid?.trim();
   if (!normalizedCurrentHeadOid) {
-    return { observedAt: null, source: null };
+    return { observedAt: null, source: null, reviewedCommitSha: null };
   }
 
   const configuredReviewBots = new Set(normalizeReviewBotLogins(reviewBotLogins));
   if (configuredReviewBots.size === 0) {
-    return { observedAt: null, source: null };
+    return { observedAt: null, source: null, reviewedCommitSha: null };
   }
 
-  const currentHeadObservations: Array<{ observedAt: string | null | undefined; source: NonNullable<ConfiguredBotCurrentHeadObservationSource> }> = [];
+  const currentHeadObservations: Array<{
+    observedAt: string | null | undefined;
+    source: NonNullable<ConfiguredBotCurrentHeadObservationSource>;
+    reviewedCommitSha?: string | null;
+  }> = [];
   for (const review of facts.reviews) {
     const authorLogin = normalizeLogin(review.authorLogin);
     if (
@@ -689,19 +698,24 @@ function inferConfiguredBotCurrentHeadObservation(
         if (reviewedCommitSha && !commitShaMatchesByPrefix(reviewedCommitSha, normalizedCurrentHeadOid)) {
           continue;
         }
-        currentHeadObservations.push({ observedAt: comment.createdAt, source: "codex_pr_success_comment" });
+        currentHeadObservations.push({
+          observedAt: comment.createdAt,
+          source: "codex_pr_success_comment",
+          reviewedCommitSha,
+        });
       }
     }
   }
 
   const latestStrongCurrentHeadObservedAt = latestTimestamp(currentHeadObservations.map((observation) => observation.observedAt));
   if (!latestStrongCurrentHeadObservedAt) {
-    return { observedAt: null, source: null };
+    return { observedAt: null, source: null, reviewedCommitSha: null };
   }
-  const latestStrongCurrentHeadObservationSource =
+  const latestStrongCurrentHeadObservation =
     currentHeadObservations
       .filter((observation) => observation.observedAt === latestStrongCurrentHeadObservedAt)
-      .at(-1)?.source ?? null;
+      .at(-1) ?? null;
+  const latestStrongCurrentHeadObservationSource = latestStrongCurrentHeadObservation?.source ?? null;
 
   const latestStrongCurrentHeadObservedAtMs = parseTimestamp(latestStrongCurrentHeadObservedAt);
   const weaklyAnchoredCodeRabbitCommentTimes = facts.comments.flatMap((comment) => {
@@ -733,6 +747,10 @@ function inferConfiguredBotCurrentHeadObservation(
   return {
     observedAt: latestObservedAt,
     source: latestObservedAt === latestStrongCurrentHeadObservedAt ? latestStrongCurrentHeadObservationSource : "review_thread_comment",
+    reviewedCommitSha:
+      latestObservedAt === latestStrongCurrentHeadObservedAt
+        ? latestStrongCurrentHeadObservation?.reviewedCommitSha ?? null
+        : null,
   };
 }
 
@@ -927,6 +945,10 @@ export function buildConfiguredBotReviewSummary(
   Object.defineProperty(summary, "latestReviewedCommitSha", {
     enumerable: false,
     value: inferLatestConfiguredBotReviewedCommitSha(facts, reviewBotLogins),
+  });
+  Object.defineProperty(summary, "currentHeadObservationReviewedCommitSha", {
+    enumerable: false,
+    value: currentHeadObservation.reviewedCommitSha,
   });
   return summary;
 }

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -80,6 +80,7 @@ export interface ConfiguredBotReviewSummary {
   currentHeadObservedAt: string | null;
   currentHeadObservationSource: ConfiguredBotCurrentHeadObservationSource;
   currentHeadCodexSuccessReviewedCommitSha?: string | null;
+  currentHeadCodexSuccessObservedAt?: string | null;
   currentHeadStatusState: string | null;
   latestReviewedCommitSha: string | null;
   currentHeadCiGreenAt: string | null;
@@ -744,11 +745,11 @@ function inferConfiguredBotCurrentHeadObservation(
   };
 }
 
-function inferCurrentHeadCodexSuccessReviewedCommitSha(
+function inferCurrentHeadCodexSuccessObservation(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
   currentHeadOid: string | null | undefined,
-): string | null {
+): { observedAt: string; reviewedCommitSha: string } | null {
   const normalizedCurrentHeadOid = currentHeadOid?.trim();
   if (!normalizedCurrentHeadOid) {
     return null;
@@ -759,7 +760,7 @@ function inferCurrentHeadCodexSuccessReviewedCommitSha(
     return null;
   }
 
-  let latest: { createdAtMs: number; reviewedCommitSha: string } | null = null;
+  let latest: { createdAt: string; createdAtMs: number; reviewedCommitSha: string } | null = null;
   for (const comment of facts.issueComments) {
     const authorLogin = normalizeLogin(comment.authorLogin);
     if (
@@ -781,11 +782,16 @@ function inferCurrentHeadCodexSuccessReviewedCommitSha(
     }
 
     if (!latest || createdAtMs >= latest.createdAtMs) {
-      latest = { createdAtMs, reviewedCommitSha: reviewedCommitSha! };
+      latest = { createdAt: comment.createdAt!, createdAtMs, reviewedCommitSha: reviewedCommitSha! };
     }
   }
 
-  return latest?.reviewedCommitSha ?? null;
+  return latest
+    ? {
+        observedAt: latest.createdAt,
+        reviewedCommitSha: latest.reviewedCommitSha,
+      }
+    : null;
 }
 
 function inferConfiguredBotCurrentHeadStatusState(
@@ -956,6 +962,11 @@ export function buildConfiguredBotReviewSummary(
   codexConnectorReviewRequestIdentity?: CodexConnectorReviewRequestIdentity | null,
 ): ConfiguredBotReviewSummary {
   const currentHeadObservation = inferConfiguredBotCurrentHeadObservation(facts, reviewBotLogins, currentHeadOid);
+  const currentHeadCodexSuccessObservation = inferCurrentHeadCodexSuccessObservation(
+    facts,
+    reviewBotLogins,
+    currentHeadOid,
+  );
   const topLevelReview = inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins);
   Object.defineProperty(topLevelReview, "configuredBotOnlyChangesRequestedReview", {
     enumerable: false,
@@ -982,7 +993,11 @@ export function buildConfiguredBotReviewSummary(
   });
   Object.defineProperty(summary, "currentHeadCodexSuccessReviewedCommitSha", {
     enumerable: false,
-    value: inferCurrentHeadCodexSuccessReviewedCommitSha(facts, reviewBotLogins, currentHeadOid),
+    value: currentHeadCodexSuccessObservation?.reviewedCommitSha ?? null,
+  });
+  Object.defineProperty(summary, "currentHeadCodexSuccessObservedAt", {
+    enumerable: false,
+    value: currentHeadCodexSuccessObservation?.observedAt ?? null,
   });
   return summary;
 }

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -79,6 +79,7 @@ export interface ConfiguredBotReviewSummary {
   codexConnectorReviewRequest?: CodexConnectorReviewRequestObservation | null;
   currentHeadObservedAt: string | null;
   currentHeadObservationSource: ConfiguredBotCurrentHeadObservationSource;
+  currentHeadActionableObservedAt?: string | null;
   currentHeadCodexSuccessReviewedCommitSha?: string | null;
   currentHeadCodexSuccessObservedAt?: string | null;
   currentHeadStatusState: string | null;
@@ -794,6 +795,67 @@ function inferCurrentHeadCodexSuccessObservation(
     : null;
 }
 
+function inferConfiguredBotCurrentHeadActionableObservedAt(
+  facts: CopilotReviewLifecycleFacts,
+  reviewBotLogins: string[],
+  currentHeadOid: string | null | undefined,
+  currentHeadCodexSuccessObservedAt: string | null | undefined,
+): string | null {
+  const normalizedCurrentHeadOid = currentHeadOid?.trim();
+  if (!normalizedCurrentHeadOid) {
+    return null;
+  }
+
+  const configuredReviewBots = new Set(normalizeReviewBotLogins(reviewBotLogins));
+  if (configuredReviewBots.size === 0) {
+    return null;
+  }
+
+  const currentHeadActionableTimes: string[] = [];
+  for (const review of facts.reviews) {
+    const authorLogin = normalizeLogin(review.authorLogin);
+    if (
+      authorLogin &&
+      configuredReviewBots.has(authorLogin) &&
+      review.commitOid === normalizedCurrentHeadOid &&
+      isActionableTopLevelReview(review) &&
+      review.submittedAt
+    ) {
+      currentHeadActionableTimes.push(review.submittedAt);
+    }
+  }
+
+  for (const comment of facts.comments) {
+    const authorLogin = normalizeLogin(comment.authorLogin);
+    if (
+      authorLogin &&
+      configuredReviewBots.has(authorLogin) &&
+      comment.originalCommitOid === normalizedCurrentHeadOid &&
+      comment.createdAt
+    ) {
+      currentHeadActionableTimes.push(comment.createdAt);
+    }
+  }
+
+  const successObservedAtMs = parseTimestamp(currentHeadCodexSuccessObservedAt);
+  if (successObservedAtMs !== 0) {
+    for (const comment of facts.issueComments) {
+      const authorLogin = normalizeLogin(comment.authorLogin);
+      if (
+        authorLogin &&
+        configuredReviewBots.has(authorLogin) &&
+        hasActionableReviewText(comment.body) &&
+        parseTimestamp(comment.createdAt) >= successObservedAtMs &&
+        comment.createdAt
+      ) {
+        currentHeadActionableTimes.push(comment.createdAt);
+      }
+    }
+  }
+
+  return latestTimestamp(currentHeadActionableTimes);
+}
+
 function inferConfiguredBotCurrentHeadStatusState(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
@@ -967,6 +1029,12 @@ export function buildConfiguredBotReviewSummary(
     reviewBotLogins,
     currentHeadOid,
   );
+  const currentHeadActionableObservedAt = inferConfiguredBotCurrentHeadActionableObservedAt(
+    facts,
+    reviewBotLogins,
+    currentHeadOid,
+    currentHeadCodexSuccessObservation?.observedAt ?? null,
+  );
   const topLevelReview = inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins);
   Object.defineProperty(topLevelReview, "configuredBotOnlyChangesRequestedReview", {
     enumerable: false,
@@ -990,6 +1058,10 @@ export function buildConfiguredBotReviewSummary(
   Object.defineProperty(summary, "latestReviewedCommitSha", {
     enumerable: false,
     value: inferLatestConfiguredBotReviewedCommitSha(facts, reviewBotLogins),
+  });
+  Object.defineProperty(summary, "currentHeadActionableObservedAt", {
+    enumerable: false,
+    value: currentHeadActionableObservedAt,
   });
   Object.defineProperty(summary, "currentHeadCodexSuccessReviewedCommitSha", {
     enumerable: false,

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -79,7 +79,7 @@ export interface ConfiguredBotReviewSummary {
   codexConnectorReviewRequest?: CodexConnectorReviewRequestObservation | null;
   currentHeadObservedAt: string | null;
   currentHeadObservationSource: ConfiguredBotCurrentHeadObservationSource;
-  currentHeadObservationReviewedCommitSha?: string | null;
+  currentHeadCodexSuccessReviewedCommitSha?: string | null;
   currentHeadStatusState: string | null;
   latestReviewedCommitSha: string | null;
   currentHeadCiGreenAt: string | null;
@@ -633,22 +633,20 @@ function inferConfiguredBotCurrentHeadObservation(
 ): {
   observedAt: string | null;
   source: ConfiguredBotCurrentHeadObservationSource;
-  reviewedCommitSha: string | null;
 } {
   const normalizedCurrentHeadOid = currentHeadOid?.trim();
   if (!normalizedCurrentHeadOid) {
-    return { observedAt: null, source: null, reviewedCommitSha: null };
+    return { observedAt: null, source: null };
   }
 
   const configuredReviewBots = new Set(normalizeReviewBotLogins(reviewBotLogins));
   if (configuredReviewBots.size === 0) {
-    return { observedAt: null, source: null, reviewedCommitSha: null };
+    return { observedAt: null, source: null };
   }
 
   const currentHeadObservations: Array<{
     observedAt: string | null | undefined;
     source: NonNullable<ConfiguredBotCurrentHeadObservationSource>;
-    reviewedCommitSha?: string | null;
   }> = [];
   for (const review of facts.reviews) {
     const authorLogin = normalizeLogin(review.authorLogin);
@@ -698,18 +696,14 @@ function inferConfiguredBotCurrentHeadObservation(
         if (reviewedCommitSha && !commitShaMatchesByPrefix(reviewedCommitSha, normalizedCurrentHeadOid)) {
           continue;
         }
-        currentHeadObservations.push({
-          observedAt: comment.createdAt,
-          source: "codex_pr_success_comment",
-          reviewedCommitSha,
-        });
+        currentHeadObservations.push({ observedAt: comment.createdAt, source: "codex_pr_success_comment" });
       }
     }
   }
 
   const latestStrongCurrentHeadObservedAt = latestTimestamp(currentHeadObservations.map((observation) => observation.observedAt));
   if (!latestStrongCurrentHeadObservedAt) {
-    return { observedAt: null, source: null, reviewedCommitSha: null };
+    return { observedAt: null, source: null };
   }
   const latestStrongCurrentHeadObservation =
     currentHeadObservations
@@ -747,11 +741,51 @@ function inferConfiguredBotCurrentHeadObservation(
   return {
     observedAt: latestObservedAt,
     source: latestObservedAt === latestStrongCurrentHeadObservedAt ? latestStrongCurrentHeadObservationSource : "review_thread_comment",
-    reviewedCommitSha:
-      latestObservedAt === latestStrongCurrentHeadObservedAt
-        ? latestStrongCurrentHeadObservation?.reviewedCommitSha ?? null
-        : null,
   };
+}
+
+function inferCurrentHeadCodexSuccessReviewedCommitSha(
+  facts: CopilotReviewLifecycleFacts,
+  reviewBotLogins: string[],
+  currentHeadOid: string | null | undefined,
+): string | null {
+  const normalizedCurrentHeadOid = currentHeadOid?.trim();
+  if (!normalizedCurrentHeadOid) {
+    return null;
+  }
+
+  const configuredReviewBots = new Set(normalizeReviewBotLogins(reviewBotLogins));
+  if (!hasConfiguredCodexConnectorLogin(configuredReviewBots)) {
+    return null;
+  }
+
+  let latest: { createdAtMs: number; reviewedCommitSha: string } | null = null;
+  for (const comment of facts.issueComments) {
+    const authorLogin = normalizeLogin(comment.authorLogin);
+    if (
+      !authorLogin ||
+      !isCodexConnectorLogin(authorLogin) ||
+      !isCodexConnectorPrSuccessCommentText(comment.body)
+    ) {
+      continue;
+    }
+
+    const reviewedCommitSha = reviewedCommitFromBody(comment.body);
+    if (!commitShaMatchesByPrefix(reviewedCommitSha, normalizedCurrentHeadOid)) {
+      continue;
+    }
+
+    const createdAtMs = parseTimestamp(comment.createdAt);
+    if (createdAtMs === 0) {
+      continue;
+    }
+
+    if (!latest || createdAtMs >= latest.createdAtMs) {
+      latest = { createdAtMs, reviewedCommitSha: reviewedCommitSha! };
+    }
+  }
+
+  return latest?.reviewedCommitSha ?? null;
 }
 
 function inferConfiguredBotCurrentHeadStatusState(
@@ -946,9 +980,9 @@ export function buildConfiguredBotReviewSummary(
     enumerable: false,
     value: inferLatestConfiguredBotReviewedCommitSha(facts, reviewBotLogins),
   });
-  Object.defineProperty(summary, "currentHeadObservationReviewedCommitSha", {
+  Object.defineProperty(summary, "currentHeadCodexSuccessReviewedCommitSha", {
     enumerable: false,
-    value: currentHeadObservation.reviewedCommitSha,
+    value: inferCurrentHeadCodexSuccessReviewedCommitSha(facts, reviewBotLogins, currentHeadOid),
   });
   return summary;
 }

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -40,7 +40,7 @@ export interface GitHubPullRequest {
   codexConnectorReviewRequestCommentUrl?: string | null;
   configuredBotCurrentHeadObservedAt?: string | null;
   configuredBotCurrentHeadObservationSource?: string | null;
-  configuredBotCurrentHeadObservationReviewedCommitSha?: string | null;
+  configuredBotCurrentHeadCodexSuccessReviewedCommitSha?: string | null;
   configuredBotCurrentHeadStatusState?: string | null;
   configuredBotLatestReviewedCommitSha?: string | null;
   currentHeadCiGreenAt?: string | null;

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -41,6 +41,7 @@ export interface GitHubPullRequest {
   configuredBotCurrentHeadObservedAt?: string | null;
   configuredBotCurrentHeadObservationSource?: string | null;
   configuredBotCurrentHeadCodexSuccessReviewedCommitSha?: string | null;
+  configuredBotCurrentHeadCodexSuccessObservedAt?: string | null;
   configuredBotCurrentHeadStatusState?: string | null;
   configuredBotLatestReviewedCommitSha?: string | null;
   currentHeadCiGreenAt?: string | null;

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -40,6 +40,7 @@ export interface GitHubPullRequest {
   codexConnectorReviewRequestCommentUrl?: string | null;
   configuredBotCurrentHeadObservedAt?: string | null;
   configuredBotCurrentHeadObservationSource?: string | null;
+  configuredBotCurrentHeadObservationReviewedCommitSha?: string | null;
   configuredBotCurrentHeadStatusState?: string | null;
   configuredBotLatestReviewedCommitSha?: string | null;
   currentHeadCiGreenAt?: string | null;

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -40,6 +40,7 @@ export interface GitHubPullRequest {
   codexConnectorReviewRequestCommentUrl?: string | null;
   configuredBotCurrentHeadObservedAt?: string | null;
   configuredBotCurrentHeadObservationSource?: string | null;
+  configuredBotCurrentHeadActionableObservedAt?: string | null;
   configuredBotCurrentHeadCodexSuccessReviewedCommitSha?: string | null;
   configuredBotCurrentHeadCodexSuccessObservedAt?: string | null;
   configuredBotCurrentHeadStatusState?: string | null;

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -3389,7 +3389,7 @@ test("reconcileRecoverableBlockedIssueStates replays reviewed-current-head no-ma
     configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
-    configuredBotCurrentHeadObservationReviewedCommitSha: "647c90b90b",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "647c90b90b",
   });
 
   let saveCalls = 0;

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -3336,9 +3336,17 @@ test("reconcileRecoverableBlockedIssueStates replays reviewed-current-head no-ma
       headRefOid: headSha,
       unresolvedReviewThreadIds: [threadId],
       unresolvedReviewThreadFingerprints: [`${threadId}#${commentId}`],
+      codexConnectorReviewChurnProgress: {
+        currentHeadSha: headSha,
+        currentEffectiveMustFixCount: 1,
+        dominantFile: "apps/web/index.html",
+        dominantFilePercent: 100,
+        clusterCategorySignature: "async_response",
+        representativeThreadIds: [threadId],
+      },
     }),
     last_tracked_pr_progress_summary:
-      "manual_review_preserved=codex_connector_churn_unresolved_configured_bot_threads",
+      "no_progress_clustered_codex_churn current_effective_must_fix=1",
     last_tracked_pr_repeat_failure_decision: "stop_no_progress",
     processed_review_thread_ids: [`${threadId}@${headSha}`],
     processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
@@ -3390,6 +3398,7 @@ test("reconcileRecoverableBlockedIssueStates replays reviewed-current-head no-ma
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "647c90b90b",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-27T00:53:12Z",
   });
 
   let saveCalls = 0;

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -3312,6 +3312,143 @@ test("reconcileRecoverableBlockedIssueStates replays accepted current-head repai
   ]);
 });
 
+test("reconcileRecoverableBlockedIssueStates replays reviewed-current-head no-major over unresolved inline residue", async () => {
+  const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
+  const threadId = "thread-current-line-residue";
+  const commentId = "comment-current-line-residue";
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    localCiCommand: "python3 scripts/ci/repo_hygiene.py",
+    staleConfiguredBotReviewPolicy: "reply_and_resolve",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const original = createRecord({
+    issue_number: 80,
+    state: "blocked",
+    blocked_reason: "manual_review",
+    pr_number: 93,
+    last_head_sha: headSha,
+    last_error:
+      "Clustered Codex Connector churn made no progress; inspect dominant file apps/web/index.html with current effective must-fix count 12 before restarting the loop.",
+    last_failure_signature: "codex-review-churn:P2:apps/web/index.html",
+    repeated_failure_signature_count: 3,
+    last_tracked_pr_progress_summary:
+      "manual_review_preserved=codex_connector_churn_unresolved_configured_bot_threads",
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    processed_review_thread_ids: [`${threadId}@${headSha}`],
+    processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
+    latest_local_ci_result: {
+      outcome: "passed",
+      summary: "Repo hygiene passed on current head.",
+      ran_at: "2026-06-27T00:50:00Z",
+      head_sha: headSha,
+      execution_mode: "shell",
+      command: "python3 scripts/ci/repo_hygiene.py",
+      failure_class: null,
+      remediation_target: null,
+    },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python3 scripts/ci/repo_hygiene.py",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Rechecked unresolved review cluster; no product-code changes needed.",
+        recorded_at: "2026-06-27T00:50:21Z",
+        processed_review_thread_ids: [`${threadId}@${headSha}`],
+        processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
+      },
+    ],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+  const issue = createIssue({
+    number: 80,
+    title: "MVP-10: add local API auth role checks",
+    updatedAt: "2026-06-27T00:55:00Z",
+  });
+  const pr = createPullRequest({
+    number: 93,
+    title: "MVP-10: add local API auth role checks",
+    url: "https://example.test/pr/93",
+    headRefName: "codex/issue-80",
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    currentHeadCiGreenAt: "2026-06-27T00:30:24Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotLatestReviewedCommitSha: "647c90b90b",
+  });
+
+  let saveCalls = 0;
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [
+        createReviewThread({
+          id: threadId,
+          path: "apps/web/index.html",
+          line: 757,
+          comments: {
+            nodes: [{
+              id: commentId,
+              body: "P2: Ignore stale job responses after credential changes.",
+              createdAt: "2026-06-27T00:20:00Z",
+              url: "https://example.test/pr/93#discussion_current_line_residue",
+              author: { login: "chatgpt-codex-connector", typeName: "Bot" },
+            }],
+          },
+        }),
+      ],
+    },
+    {
+      touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return {
+          ...current,
+          ...patch,
+          updated_at: "2026-06-27T00:56:00Z",
+        };
+      },
+      async save(): Promise<void> {
+        saveCalls += 1;
+      },
+    },
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["80"];
+  assert.equal(updated.state, "ready_to_merge");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.provider_success_head_sha, headSha);
+  assert.ok(updated.provider_success_observed_at);
+  assert.equal(updated.last_tracked_pr_repeat_failure_decision, null);
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    `tracked_pr_lifecycle_recovered: resumed issue #80 from blocked to ready_to_merge using fresh tracked PR #93 facts at head ${headSha}`,
+  ]);
+});
+
 test("reconcileRecoverableBlockedIssueStates ignores human replies when comparing same-head Codex Connector churn guidance", async () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector"],

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -3330,8 +3330,13 @@ test("reconcileRecoverableBlockedIssueStates replays reviewed-current-head no-ma
     last_head_sha: headSha,
     last_error:
       "Clustered Codex Connector churn made no progress; inspect dominant file apps/web/index.html with current effective must-fix count 12 before restarting the loop.",
-    last_failure_signature: "codex-review-churn:P2:apps/web/index.html",
+    last_failure_signature: threadId,
     repeated_failure_signature_count: 3,
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: headSha,
+      unresolvedReviewThreadIds: [threadId],
+      unresolvedReviewThreadFingerprints: [`${threadId}#${commentId}`],
+    }),
     last_tracked_pr_progress_summary:
       "manual_review_preserved=codex_connector_churn_unresolved_configured_bot_threads",
     last_tracked_pr_repeat_failure_decision: "stop_no_progress",
@@ -3384,7 +3389,7 @@ test("reconcileRecoverableBlockedIssueStates replays reviewed-current-head no-ma
     configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
-    configuredBotLatestReviewedCommitSha: "647c90b90b",
+    configuredBotCurrentHeadObservationReviewedCommitSha: "647c90b90b",
   });
 
   let saveCalls = 0;

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -636,6 +636,7 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
       });
       const shouldKeepCodexConnectorChurnBlockQuiescent =
         !staleLocalManualReviewResidueRecovery &&
+        !sameHeadCurrentHeadRepairProofRecovery &&
         shouldKeepCodexConnectorManualReviewChurnBlockQuiescent({
           record,
           effectiveReviewThreads: effectiveCurrentCodexConnectorReviewThreads,
@@ -654,6 +655,7 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
       }
       if (
         !staleLocalManualReviewResidueRecovery &&
+        !sameHeadCurrentHeadRepairProofRecovery &&
         shouldPreserveCodexConnectorManualReviewChurnBlock({
           record,
           effectiveReviewThreads: effectiveCurrentCodexConnectorReviewThreads,

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -614,8 +614,13 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
           checks,
           reviewThreads,
         }) !== null;
-      const recoverySuppression = staleLocalManualReviewResidueRecovery
-        ? { shouldSuppress: false, progressSummary: "stale_local_blocker_recovered=outdated_configured_bot_residue" }
+      const recoverySuppression = staleLocalManualReviewResidueRecovery || sameHeadCurrentHeadRepairProofRecovery
+        ? {
+            shouldSuppress: false,
+            progressSummary: staleLocalManualReviewResidueRecovery
+              ? "stale_local_blocker_recovered=outdated_configured_bot_residue"
+              : "same_head_current_head_repair_proof_recovered",
+          }
         : suppressSameHeadNoProgressReviewThreadRecovery(
           record,
           trackedPullRequest,

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -44,6 +44,7 @@ import {
 import {
   hasCodexConnectorFindingReviewComment,
 } from "./codex-connector-review-policy";
+import { projectCurrentHeadCodexRepairProof } from "./current-head-codex-repair-proof";
 import {
   buildPreservedCodexConnectorManualReviewChurnPatch,
   buildPreservedCodexConnectorManualReviewChurnReason,
@@ -476,12 +477,24 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         isReviewSignalProjectedState &&
         isCurrentHeadReviewSignalRequestTimeout(projection.copilotReviewTimeoutPatch) &&
         hasOnlyOutdatedConfiguredBotResidue(config, reviewThreads);
+      const sameHeadCurrentHeadRepairProofRecovery =
+        externalProgressEvidence === null &&
+        record.last_head_sha === trackedPullRequest.headRefOid &&
+        projection.nextState !== "blocked" &&
+        projectCurrentHeadCodexRepairProof({
+          config,
+          record: projection.recordForState,
+          pr: trackedPullRequest,
+          checks,
+          reviewThreads,
+        }) !== null;
       const sameHeadProviderSuccessRecovery =
         externalProgressEvidence === null &&
         record.last_head_sha === trackedPullRequest.headRefOid &&
         projection.nextState !== "blocked" &&
         projection.mergeLatencyVisibilityPatch.provider_success_head_sha === trackedPullRequest.headRefOid &&
-        (reviewThreads.filter((thread) => !thread.isResolved).length === 0 ||
+        (sameHeadCurrentHeadRepairProofRecovery ||
+          reviewThreads.filter((thread) => !thread.isResolved).length === 0 ||
           hasOnlyOutdatedConfiguredBotResidue(config, reviewThreads));
       if (
         !externalProgressEvidence &&
@@ -589,6 +602,18 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
         nextState !== "blocked" &&
         hasOnlyOutdatedConfiguredBotResidue(config, reviewThreads);
+      const sameHeadCurrentHeadRepairProofRecovery =
+        record.blocked_reason === "manual_review" &&
+        record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
+        record.last_head_sha === trackedPullRequest.headRefOid &&
+        nextState !== "blocked" &&
+        projectCurrentHeadCodexRepairProof({
+          config,
+          record: projection.recordForState,
+          pr: trackedPullRequest,
+          checks,
+          reviewThreads,
+        }) !== null;
       const recoverySuppression = staleLocalManualReviewResidueRecovery
         ? { shouldSuppress: false, progressSummary: "stale_local_blocker_recovered=outdated_configured_bot_residue" }
         : suppressSameHeadNoProgressReviewThreadRecovery(
@@ -774,6 +799,11 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         patch.last_tracked_pr_repeat_failure_decision = null;
         patch.processed_review_thread_ids = [];
         patch.processed_review_thread_fingerprints = [];
+      }
+      if (sameHeadCurrentHeadRepairProofRecovery) {
+        patch.last_tracked_pr_progress_snapshot = null;
+        patch.last_tracked_pr_progress_summary = null;
+        patch.last_tracked_pr_repeat_failure_decision = null;
       }
       const recoveryEvent = staleLocalManualReviewResidueRecovery
         ? buildRecoveryEvent(

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -324,7 +324,7 @@ test("buildStaleReviewBotRemediation accepts reviewed-current-head no-major with
     configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
-    configuredBotCurrentHeadObservationReviewedCommitSha: "647c90b90b",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "647c90b90b",
   });
 
   const remediation = buildStaleReviewBotRemediation({

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -325,6 +325,7 @@ test("buildStaleReviewBotRemediation accepts reviewed-current-head no-major with
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "647c90b90b",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-27T00:53:12Z",
   });
 
   const remediation = buildStaleReviewBotRemediation({

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -321,9 +321,9 @@ test("buildStaleReviewBotRemediation accepts reviewed-current-head no-major with
   const record = createRecord(scenario.recordPatch);
   const pr = createPullRequest({
     ...scenario.pullRequestPatch,
-    configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
-    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
-    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadObservedAt: "2026-06-27T00:54:12Z",
+    configuredBotCurrentHeadObservationSource: "status_context",
+    configuredBotCurrentHeadStatusState: null,
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "647c90b90b",
     configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-27T00:53:12Z",
   });

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -324,7 +324,7 @@ test("buildStaleReviewBotRemediation accepts reviewed-current-head no-major with
     configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
-    configuredBotLatestReviewedCommitSha: "647c90b90b",
+    configuredBotCurrentHeadObservationReviewedCommitSha: "647c90b90b",
   });
 
   const remediation = buildStaleReviewBotRemediation({

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -295,6 +295,54 @@ test("buildStaleReviewBotRemediation classifies same-head Codex no-major comment
   assert.equal(diagnostics?.currentHeadSuccess, "yes");
 });
 
+test("buildStaleReviewBotRemediation accepts reviewed-current-head no-major without request marker", () => {
+  const issueNumber = 80;
+  const prNumber = 93;
+  const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "thread-current-line-residue",
+    commentId: "comment-current-line-residue",
+    path: "apps/web/index.html",
+    line: 757,
+    severity: "P2",
+    commentBody: "P2: Ignore stale job responses after credential changes.",
+    discussionUrl: "https://example.test/pr/93#discussion_current_line_residue",
+    verifiedRepair: {
+      summary: "Rechecked unresolved review cluster; no product-code changes needed.",
+      ranAt: "2026-06-27T00:50:21Z",
+      command: "python3 scripts/ci/repo_hygiene.py",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord(scenario.recordPatch);
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadObservedAt: "2026-06-27T00:53:12Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotLatestReviewedCommitSha: "647c90b90b",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+  });
+
+  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
+  assert.equal(remediation?.codexCurrentHeadReviewState, "observed");
+  assert.match(
+    remediation?.verificationEvidenceSummary ?? "",
+    /codex_no_major_support=codex_pr_success_comment_reviewed_current_head/u,
+  );
+});
+
 test("buildStaleReviewBotRemediation classifies marked codex_turn evidence as no-source residue", () => {
   const issueNumber = 492;
   const prNumber = 498;

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -791,7 +791,7 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
     | "configuredBotCurrentHeadObservedAt"
     | "configuredBotCurrentHeadObservationSource"
     | "configuredBotCurrentHeadStatusState"
-    | "configuredBotLatestReviewedCommitSha"
+    | "configuredBotCurrentHeadObservationReviewedCommitSha"
   >;
 }): string | null {
   if (
@@ -806,7 +806,7 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
     return null;
   }
 
-  if (commitShasMatchByPrefixForComparison(args.pr.configuredBotLatestReviewedCommitSha, args.pr.headRefOid)) {
+  if (commitShasMatchByPrefixForComparison(args.pr.configuredBotCurrentHeadObservationReviewedCommitSha, args.pr.headRefOid)) {
     return "codex_pr_success_comment_reviewed_current_head";
   }
 

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -12,6 +12,7 @@ import {
 import {
   codexConnectorMustFixReviewThreads,
   commitShasEqualForComparison,
+  commitShasMatchByPrefixForComparison,
   evaluateCodexConnectorConvergencePolicy,
   latestCodexConnectorReviewCommentFingerprint,
   latestCodexConnectorPSeverity,
@@ -790,6 +791,7 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
     | "configuredBotCurrentHeadObservedAt"
     | "configuredBotCurrentHeadObservationSource"
     | "configuredBotCurrentHeadStatusState"
+    | "configuredBotLatestReviewedCommitSha"
   >;
 }): string | null {
   if (
@@ -802,6 +804,10 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
   const observedAt = validTimestamp(args.pr.configuredBotCurrentHeadObservedAt);
   if (!observedAt) {
     return null;
+  }
+
+  if (commitShasMatchByPrefixForComparison(args.pr.configuredBotLatestReviewedCommitSha, args.pr.headRefOid)) {
+    return "codex_pr_success_comment_reviewed_current_head";
   }
 
   const requestedAt =

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -28,6 +28,7 @@ import {
 import { configuredReviewProviderKinds } from "../core/review-providers";
 import {
   currentHeadCodexRepairProofRejectionReasons,
+  latestCodexConnectorMustFixReviewCommentObservedAt,
   projectCurrentHeadCodexRepairProof,
 } from "../current-head-codex-repair-proof";
 import { currentHeadPassingNonReviewChecks } from "../local-ci-policy";
@@ -792,7 +793,9 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
     | "configuredBotCurrentHeadObservationSource"
     | "configuredBotCurrentHeadStatusState"
     | "configuredBotCurrentHeadCodexSuccessReviewedCommitSha"
+    | "configuredBotCurrentHeadCodexSuccessObservedAt"
   >;
+  reviewThreads: ReviewThread[];
 }): string | null {
   if (
     !hasCurrentHeadSuccessSignal(args.pr)
@@ -806,6 +809,16 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
   }
 
   if (commitShasMatchByPrefixForComparison(args.pr.configuredBotCurrentHeadCodexSuccessReviewedCommitSha, args.pr.headRefOid)) {
+    const successObservedAt = validTimestamp(args.pr.configuredBotCurrentHeadCodexSuccessObservedAt);
+    if (!successObservedAt) {
+      return null;
+    }
+    const latestMustFixObservedAt = validTimestamp(
+      latestCodexConnectorMustFixReviewCommentObservedAt(args.reviewThreads),
+    );
+    if (latestMustFixObservedAt && Date.parse(successObservedAt) < Date.parse(latestMustFixObservedAt)) {
+      return null;
+    }
     return "codex_pr_success_comment_reviewed_current_head";
   }
   if (args.pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment") {
@@ -883,6 +896,7 @@ function classifyCodexMetadataOnly(args: {
     noMajorSignalEvidence: currentHeadCodexNoMajorSignalEvidence({
       record: args.record,
       pr: args.pr,
+      reviewThreads: args.reviewThreads,
     }),
     deterministicProbeEvidence: deterministicRepairProbeEvidence({
       reviewThreads: args.reviewThreads,

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -28,7 +28,7 @@ import {
 import { configuredReviewProviderKinds } from "../core/review-providers";
 import {
   currentHeadCodexRepairProofRejectionReasons,
-  latestCodexConnectorMustFixReviewCommentObservedAt,
+  hasFreshCurrentHeadCodexSuccessReviewedCommit,
   projectCurrentHeadCodexRepairProof,
 } from "../current-head-codex-repair-proof";
 import { currentHeadPassingNonReviewChecks } from "../local-ci-policy";
@@ -228,9 +228,14 @@ function codexConnectorCurrentHeadReviewState(args: {
   config: SupervisorConfig | null;
   record: IssueRunRecord;
   pr: GitHubPullRequest;
+  reviewThreads: ReviewThread[];
 }): "observed" | "requested" | "missing" | "not_applicable" {
   if (!args.config || !configuredReviewProviderKinds(args.config).includes("codex")) {
     return "not_applicable";
+  }
+
+  if (hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads)) {
+    return "observed";
   }
 
   if (
@@ -797,29 +802,16 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
   >;
   reviewThreads: ReviewThread[];
 }): string | null {
-  if (
-    !hasCurrentHeadSuccessSignal(args.pr)
-  ) {
+  if (hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads)) {
+    return "codex_pr_success_comment_reviewed_current_head";
+  }
+  if (!hasCurrentHeadSuccessSignal(args.pr)) {
     return null;
   }
 
   const observedAt = validTimestamp(args.pr.configuredBotCurrentHeadObservedAt);
   if (!observedAt) {
     return null;
-  }
-
-  if (commitShasMatchByPrefixForComparison(args.pr.configuredBotCurrentHeadCodexSuccessReviewedCommitSha, args.pr.headRefOid)) {
-    const successObservedAt = validTimestamp(args.pr.configuredBotCurrentHeadCodexSuccessObservedAt);
-    if (!successObservedAt) {
-      return null;
-    }
-    const latestMustFixObservedAt = validTimestamp(
-      latestCodexConnectorMustFixReviewCommentObservedAt(args.reviewThreads),
-    );
-    if (latestMustFixObservedAt && Date.parse(successObservedAt) < Date.parse(latestMustFixObservedAt)) {
-      return null;
-    }
-    return "codex_pr_success_comment_reviewed_current_head";
   }
   if (args.pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment") {
     return null;
@@ -1046,6 +1038,7 @@ export function buildStaleReviewBotRemediation(args: {
       config: args.config ?? null,
       record: args.record,
       pr: args.pr,
+      reviewThreads: args.reviewThreads ?? [],
     })
     : "not_applicable";
 

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -791,11 +791,10 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
     | "configuredBotCurrentHeadObservedAt"
     | "configuredBotCurrentHeadObservationSource"
     | "configuredBotCurrentHeadStatusState"
-    | "configuredBotCurrentHeadObservationReviewedCommitSha"
+    | "configuredBotCurrentHeadCodexSuccessReviewedCommitSha"
   >;
 }): string | null {
   if (
-    args.pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment" ||
     !hasCurrentHeadSuccessSignal(args.pr)
   ) {
     return null;
@@ -806,8 +805,11 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
     return null;
   }
 
-  if (commitShasMatchByPrefixForComparison(args.pr.configuredBotCurrentHeadObservationReviewedCommitSha, args.pr.headRefOid)) {
+  if (commitShasMatchByPrefixForComparison(args.pr.configuredBotCurrentHeadCodexSuccessReviewedCommitSha, args.pr.headRefOid)) {
     return "codex_pr_success_comment_reviewed_current_head";
+  }
+  if (args.pr.configuredBotCurrentHeadObservationSource !== "codex_pr_success_comment") {
+    return null;
   }
 
   const requestedAt =

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -12,7 +12,6 @@ import {
 import {
   codexConnectorMustFixReviewThreads,
   commitShasEqualForComparison,
-  commitShasMatchByPrefixForComparison,
   evaluateCodexConnectorConvergencePolicy,
   latestCodexConnectorReviewCommentFingerprint,
   latestCodexConnectorPSeverity,
@@ -797,6 +796,7 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
     | "configuredBotCurrentHeadObservedAt"
     | "configuredBotCurrentHeadObservationSource"
     | "configuredBotCurrentHeadStatusState"
+    | "configuredBotCurrentHeadActionableObservedAt"
     | "configuredBotCurrentHeadCodexSuccessReviewedCommitSha"
     | "configuredBotCurrentHeadCodexSuccessObservedAt"
   >;


### PR DESCRIPTION
## Summary

Implements #2391 by treating a Codex Connector top-level no-major comment as current-head repair support when its `Reviewed commit` matches the PR head, even if unresolved same-provider inline residue still appears in `reviewThreads`.

## What changed

- Anchor Codex Connector PR conversation no-major comments to `Reviewed commit` when present, accepting abbreviated current-head SHAs and rejecting stale reviewed commits.
- Persist the latest reviewed commit from Codex no-major issue comments so downstream policy can distinguish reviewed-current-head support from older comments.
- Allow current-head repair proof and stale-review remediation to use reviewed-current-head no-major support without requiring a supervisor-authored review-request marker.
- Let blocked tracked PR recovery clear same-head `manual_review` churn latch metadata when accepted current-head repair proof supersedes unresolved inline residue.
- Add regression coverage for reviewed-current-head no-major acceptance, stale reviewed-commit rejection, stale-remediation diagnostics, and blocked recovery replay.

## Root cause

After #2389, the proof evaluator could replay structured or thread-scoped verification only when the no-major signal was tied to a supervisor review request. PR conversation no-major comments from Codex carry their own reviewed commit, but that commit was not used as the proof anchor. The supervisor could observe the current-head comment while still preserving `manual_review` because unresolved inline threads remained visible.

## Validation

- `rtk git diff --check`
- `rtk npx tsx --test src/github/github-review-signals.test.ts src/current-head-codex-repair-proof.test.ts src/supervisor/stale-review-bot-remediation.test.ts src/recovery-blocked-issue-reconciliation.test.ts`
- `rtk npm run build`
- `rtk npx tsx --test src/pull-request-state-policy.test.ts src/pull-request-state-codex-residue-policy.test.ts src/tracked-pr-lifecycle-projection.test.ts src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts src/supervisor/supervisor-diagnostics-stale-review-bot-status.test.ts`
- `rtk npm test`