### PR TITLE
[codex] Persist current-head verification evidence

### DIFF
--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -176,6 +176,56 @@ test("projectCurrentHeadCodexRepairProof accepts thread-scoped proof after revie
   }), []);
 });
 
+test("projectCurrentHeadCodexRepairProof rejects summary-only verification evidence", () => {
+  const headSha = "7f2ebe6039905200cf06756e8e4b55185439f52f";
+  const threads = [
+    codexThread({ id: "thread-summary-only-a", commentId: "comment-summary-only-a", severity: "P2", line: 148 }),
+    codexThread({ id: "thread-summary-only-b", commentId: "comment-summary-only-b", severity: "P2", line: 320 }),
+  ];
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "python3 scripts/ci/repo_hygiene.py",
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    last_codex_summary: [
+      "Verified live PR state on the current head and no product-code change was needed.",
+      "Tests: rtk python3 -m unittest discover; rtk python3 scripts/ci/repo_hygiene.py; rtk git diff --check",
+    ].join("\n"),
+    processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+    latest_local_ci_result: null,
+    timeline_artifacts: [],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-27T14:28:46Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "7f2ebe6039",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-27T14:28:46Z",
+  });
+
+  assert.equal(projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+  }), null);
+  assert.deepEqual(currentHeadCodexRepairProofRejectionReasons({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+  }), [
+    "current_head_repair_proof_structured_artifact_missing",
+    "current_head_repair_proof_latest_local_ci_result_missing",
+  ]);
+});
+
 test("projectCurrentHeadCodexRepairProof rejects thread-scoped no-major proof for an older reviewed commit", () => {
   const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
   const threads = [

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -54,7 +54,7 @@ import {
   listChangedTrackedFilesBetween,
   pushBranch,
 } from "./core/workspace";
-import { AgentRunner, createCodexAgentRunner } from "./supervisor/agent-runner";
+import { AgentRunner, createCodexAgentRunner, parseAgentTurnStructuredResult } from "./supervisor/agent-runner";
 import {
   executionMetricsRetentionRootPath,
   syncExecutionMetricsRunSummarySafely,
@@ -440,10 +440,9 @@ export async function executeCodexTurnPhase(
           record.state === "addressing_review" && codexSessionStarted
             ? stableSameFileCodexConnectorChurnDossierConsumptionPatch(record)
             : {};
-        const structuredResult = agentRunner.capabilities
-          .supportsStructuredResult
+        const structuredResult = agentRunner.capabilities.supportsStructuredResult
           ? turnResult.structuredResult
-          : null;
+          : parseAgentTurnStructuredResult(turnResult.supervisorMessage);
         const hintedState = structuredResult?.stateHint ?? null;
         const hintedBlockedReason = structuredResult?.blockedReason ?? null;
         const hintedFailureSignature =

--- a/src/run-once-turn-verification-evidence.ts
+++ b/src/run-once-turn-verification-evidence.ts
@@ -49,18 +49,30 @@ function hasExplicitCodexTurnVerificationCommandEvidence(value: string): boolean
     .some((candidate) => CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(candidate));
 }
 
-function codexTurnVerificationCommandEntries(value: string | null | undefined): string[] {
-  return (value ?? "")
-    .split(/[\n;]+/)
-    .map((candidate) => candidate.trim().replace(/^`+|`+$/g, "").trim())
-    .filter((candidate) => candidate.length > 0);
+function normalizeCodexTurnVerificationCommandEntry(value: string): string {
+  return value
+    .trim()
+    .replace(/^`+|`+$/g, "")
+    .replace(/^\$\s*/u, "")
+    .trim();
 }
 
-function normalizeVerificationCommandForComparison(value: string): string {
-  return value
-    .replace(/^\$\s*/u, "")
-    .replace(/^rtk\s+/u, "")
-    .trim();
+function codexTurnVerificationCommandEntries(value: string | null | undefined): string[] {
+  const normalized = normalizeCodexTurnVerificationCommandEntry(value ?? "");
+  if (!normalized) {
+    return [];
+  }
+  const splitEntries = normalized
+    .split(/[\n;]+/)
+    .map(normalizeCodexTurnVerificationCommandEntry)
+    .filter((candidate) => candidate.length > 0);
+  return [...new Set([normalized, ...splitEntries])];
+}
+
+function verificationCommandComparisonVariants(value: string): string[] {
+  const normalized = normalizeCodexTurnVerificationCommandEntry(value);
+  const withoutRtk = normalized.replace(/^rtk\s+/u, "").trim();
+  return [...new Set([normalized, withoutRtk].filter((candidate) => candidate.length > 0))];
 }
 
 export function codexTurnVerificationIncludesCommand(
@@ -71,9 +83,10 @@ export function codexTurnVerificationIncludesCommand(
   if (!expected) {
     return false;
   }
+  const expectedCommands = new Set(verificationCommandComparisonVariants(expected));
   return codexTurnVerificationCommandEntries(tests)
-    .map(normalizeVerificationCommandForComparison)
-    .some((candidate) => candidate === expected);
+    .flatMap(verificationCommandComparisonVariants)
+    .some((candidate) => expectedCommands.has(candidate));
 }
 
 function hasExplicitNegativeCodexTurnVerificationOutcome(value: string): boolean {

--- a/src/run-once-turn-verification-evidence.ts
+++ b/src/run-once-turn-verification-evidence.ts
@@ -35,6 +35,7 @@ const CODEX_TURN_VERIFICATION_COMMAND_NAMES = [
   "prettier",
   "ruff",
   "mypy",
+  "rtk",
   "gh",
   "git",
 ].join("|");
@@ -44,11 +45,35 @@ const CODEX_TURN_VERIFICATION_COMMAND_PATTERN = new RegExp(
 );
 
 function hasExplicitCodexTurnVerificationCommandEvidence(value: string): boolean {
-  return value
+  return codexTurnVerificationCommandEntries(value)
+    .some((candidate) => CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(candidate));
+}
+
+function codexTurnVerificationCommandEntries(value: string | null | undefined): string[] {
+  return (value ?? "")
     .split(/[\n;]+/)
     .map((candidate) => candidate.trim().replace(/^`+|`+$/g, "").trim())
-    .filter((candidate) => candidate.length > 0)
-    .some((candidate) => CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(candidate));
+    .filter((candidate) => candidate.length > 0);
+}
+
+function normalizeVerificationCommandForComparison(value: string): string {
+  return value
+    .replace(/^\$\s*/u, "")
+    .replace(/^rtk\s+/u, "")
+    .trim();
+}
+
+export function codexTurnVerificationIncludesCommand(
+  tests: string | null | undefined,
+  expectedCommand: string | null | undefined,
+): boolean {
+  const expected = expectedCommand?.trim();
+  if (!expected) {
+    return false;
+  }
+  return codexTurnVerificationCommandEntries(tests)
+    .map(normalizeVerificationCommandForComparison)
+    .some((candidate) => candidate === expected);
 }
 
 function hasExplicitNegativeCodexTurnVerificationOutcome(value: string): boolean {

--- a/src/turn-execution-post-publication-review.test.ts
+++ b/src/turn-execution-post-publication-review.test.ts
@@ -337,6 +337,95 @@ test("buildPostPublicationReviewPersistence records configured local CI from rtk
   );
 });
 
+test("buildPostPublicationReviewPersistence records rtk-configured local CI from exact Codex verification", () => {
+  const headSha = "head-local-ci-proof-rtk-configured";
+  const reviewThread = createReviewThread({
+    id: "thread-local-ci-proof-rtk-configured",
+    comments: {
+      nodes: [
+        {
+          id: "comment-local-ci-proof-rtk-configured",
+          body: "P2: Verify this already-addressed finding before merge.",
+          createdAt: "2026-06-28T06:24:00Z",
+          url: "https://example.test/pr/406#discussion_local_ci_rtk_configured",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const persistence = buildPostPublicationReviewPersistence({
+    config: createConfig({ localCiCommand: "rtk python3 scripts/ci/repo_hygiene.py" }),
+    preRunState: "addressing_review",
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    evaluatedReviewHeadSha: headSha,
+    reviewThreadsToProcess: [reviewThread],
+    localReviewRepairContext: null,
+    preRunReviewThreads: [reviewThread],
+    postRunReviewThreads: [reviewThread],
+    codexVerificationCommand:
+      "rtk python3 -m unittest discover; rtk python3 scripts/ci/repo_hygiene.py; rtk git diff --check",
+    structuredSummary: "Configured local CI passed after verifying Connector residue.",
+    workspaceStatus: { headSha, hasUncommittedChanges: false },
+    changedFilesAfterPublication: [],
+  });
+
+  assert.equal(persistence.currentHeadLocalCiPatch.latest_local_ci_result?.outcome, "passed");
+  assert.equal(persistence.currentHeadLocalCiPatch.latest_local_ci_result?.head_sha, headSha);
+  assert.equal(
+    persistence.currentHeadLocalCiPatch.latest_local_ci_result?.command,
+    "rtk python3 scripts/ci/repo_hygiene.py",
+  );
+});
+
+test("buildPostPublicationReviewPersistence records compound local CI from exact Codex verification", () => {
+  const headSha = "head-local-ci-proof-compound";
+  const reviewThread = createReviewThread({
+    id: "thread-local-ci-proof-compound",
+    comments: {
+      nodes: [
+        {
+          id: "comment-local-ci-proof-compound",
+          body: "P2: Verify this already-addressed finding before merge.",
+          createdAt: "2026-06-28T06:25:00Z",
+          url: "https://example.test/pr/406#discussion_local_ci_compound",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const persistence = buildPostPublicationReviewPersistence({
+    config: createConfig({ localCiCommand: "npm run lint; npm test" }),
+    preRunState: "addressing_review",
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    evaluatedReviewHeadSha: headSha,
+    reviewThreadsToProcess: [reviewThread],
+    localReviewRepairContext: null,
+    preRunReviewThreads: [reviewThread],
+    postRunReviewThreads: [reviewThread],
+    codexVerificationCommand: "npm run lint; npm test",
+    structuredSummary: "Configured local CI passed after verifying Connector residue.",
+    workspaceStatus: { headSha, hasUncommittedChanges: false },
+    changedFilesAfterPublication: [],
+  });
+
+  assert.equal(persistence.currentHeadLocalCiPatch.latest_local_ci_result?.outcome, "passed");
+  assert.equal(persistence.currentHeadLocalCiPatch.latest_local_ci_result?.head_sha, headSha);
+  assert.equal(
+    persistence.currentHeadLocalCiPatch.latest_local_ci_result?.command,
+    "npm run lint; npm test",
+  );
+});
+
 test("buildPostPublicationCodexVerificationTimelineArtifacts does not mark unchanged normal turns as current-head repair proof", () => {
   const headSha = "head-unchanged-normal-repair";
   const reviewThread = createReviewThread({

--- a/src/turn-execution-post-publication-review.test.ts
+++ b/src/turn-execution-post-publication-review.test.ts
@@ -292,6 +292,51 @@ test("buildPostPublicationReviewPersistence records exact current-head configure
   );
 });
 
+test("buildPostPublicationReviewPersistence records configured local CI from rtk-wrapped verification lists", () => {
+  const headSha = "head-local-ci-proof-list";
+  const reviewThread = createReviewThread({
+    id: "thread-local-ci-proof-list",
+    comments: {
+      nodes: [
+        {
+          id: "comment-local-ci-proof-list",
+          body: "P2: Verify this already-addressed finding before merge.",
+          createdAt: "2026-06-28T06:23:00Z",
+          url: "https://example.test/pr/406#discussion_local_ci_list",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  const persistence = buildPostPublicationReviewPersistence({
+    config: createConfig({ localCiCommand: "python3 scripts/ci/repo_hygiene.py" }),
+    preRunState: "addressing_review",
+    record: createRecord({ timeline_artifacts: [] }),
+    currentPr: createPullRequest({ headRefOid: headSha }),
+    evaluatedReviewHeadSha: headSha,
+    reviewThreadsToProcess: [reviewThread],
+    localReviewRepairContext: null,
+    preRunReviewThreads: [reviewThread],
+    postRunReviewThreads: [reviewThread],
+    codexVerificationCommand:
+      "rtk python3 -m unittest discover; rtk python3 scripts/ci/repo_hygiene.py; rtk git diff --check",
+    structuredSummary: "Configured local CI passed after verifying Connector residue.",
+    workspaceStatus: { headSha, hasUncommittedChanges: false },
+    changedFilesAfterPublication: [],
+  });
+
+  assert.equal(persistence.currentHeadLocalCiPatch.latest_local_ci_result?.outcome, "passed");
+  assert.equal(persistence.currentHeadLocalCiPatch.latest_local_ci_result?.head_sha, headSha);
+  assert.equal(
+    persistence.currentHeadLocalCiPatch.latest_local_ci_result?.command,
+    "python3 scripts/ci/repo_hygiene.py",
+  );
+});
+
 test("buildPostPublicationCodexVerificationTimelineArtifacts does not mark unchanged normal turns as current-head repair proof", () => {
   const headSha = "head-unchanged-normal-repair";
   const reviewThread = createReviewThread({

--- a/src/turn-execution-post-publication-review.ts
+++ b/src/turn-execution-post-publication-review.ts
@@ -31,6 +31,7 @@ import {
 } from "./core/types";
 import { upsertTimelineArtifact } from "./timeline-artifacts";
 import {
+  codexTurnVerificationIncludesCommand,
   conciseCodexVerificationSummary,
   conciseFailedCodexVerificationSummary,
 } from "./run-once-turn-verification-evidence";
@@ -226,7 +227,7 @@ function currentHeadLocalCiPatchFromCodexVerification(args: {
     !configuredLocalCiCommand ||
     !args.currentPr ||
     !args.codexVerificationCommand ||
-    args.codexVerificationCommand.trim() !== configuredLocalCiCommand ||
+    !codexTurnVerificationIncludesCommand(args.codexVerificationCommand, configuredLocalCiCommand) ||
     args.workspaceStatus.hasUncommittedChanges ||
     args.workspaceStatus.headSha !== args.currentPr.headRefOid
   ) {


### PR DESCRIPTION
## Summary

- parse canonical Codex turn footers from `supervisorMessage` when the runner does not expose structured results
- recognize `rtk`-wrapped verification commands and persist configured local CI evidence when the configured command appears in a verification command list
- keep summary-only verification text non-consumable while adding regression coverage for structured current-head evidence production

## Root Cause

The current-head repair proof consumer correctly refuses to trust `last_codex_summary` text by itself, but producer-side evidence persistence could miss valid no-code-change verification when the turn only exposed the canonical footer text or when the configured local CI command was run through `rtk` inside a multi-command `Tests:` line.

## Validation

- `npx tsx --test src/run-once-turn-verification-evidence.ts src/turn-execution-post-publication-review.test.ts src/current-head-codex-repair-proof.test.ts src/run-once-turn-execution.test.ts src/stale-review-bot-remediation.test.ts`
- `npm run build`
- `git diff --check`
- `npm test` with local `supervisor.config.*.json` drift temporarily stashed

Fixes #2393
