### PR TITLE
[codex] Trust current-head Codex clean residue

### DIFF
--- a/src/review-handling.test.ts
+++ b/src/review-handling.test.ts
@@ -718,14 +718,62 @@ test("local review high-severity actions distinguish retry from blocked", () => 
     local_review_verified_max_severity: "high",
   });
 
-  assert.equal(localReviewHighSeverityNeedsRetry(createConfig({ localReviewHighSeverityAction: "retry" }), record, pr), true);
-  assert.equal(localReviewHighSeverityNeedsRetry(createConfig({ localReviewHighSeverityAction: "blocked" }), record, pr), false);
-  assert.equal(localReviewHighSeverityNeedsBlock(createConfig({ localReviewHighSeverityAction: "blocked" }), record, pr), true);
-  assert.equal(localReviewHighSeverityNeedsBlock(createConfig({ localReviewHighSeverityAction: "retry" }), record, pr), false);
+  assert.equal(
+    localReviewHighSeverityNeedsRetry(
+      createConfig({ localReviewEnabled: true, localReviewHighSeverityAction: "retry" }),
+      record,
+      pr,
+    ),
+    true,
+  );
+  assert.equal(
+    localReviewHighSeverityNeedsRetry(
+      createConfig({ localReviewEnabled: true, localReviewHighSeverityAction: "blocked" }),
+      record,
+      pr,
+    ),
+    false,
+  );
+  assert.equal(
+    localReviewHighSeverityNeedsBlock(
+      createConfig({ localReviewEnabled: true, localReviewHighSeverityAction: "blocked" }),
+      record,
+      pr,
+    ),
+    true,
+  );
+  assert.equal(
+    localReviewHighSeverityNeedsBlock(
+      createConfig({ localReviewEnabled: true, localReviewHighSeverityAction: "retry" }),
+      record,
+      pr,
+    ),
+    false,
+  );
+  assert.equal(
+    localReviewHighSeverityNeedsRetry(
+      createConfig({ localReviewEnabled: false, localReviewHighSeverityAction: "retry" }),
+      record,
+      pr,
+    ),
+    false,
+  );
+  assert.equal(
+    localReviewHighSeverityNeedsBlock(
+      createConfig({ localReviewEnabled: false, localReviewHighSeverityAction: "blocked" }),
+      record,
+      pr,
+    ),
+    false,
+  );
 });
 
 test("localReviewHighSeverityNeedsRetry only escalates verifier-confirmed high findings", () => {
-  const config = createConfig({ localReviewPolicy: "block_ready", localReviewHighSeverityAction: "retry" });
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_ready",
+    localReviewHighSeverityAction: "retry",
+  });
   const pr = createPullRequest();
 
   assert.equal(
@@ -754,7 +802,11 @@ test("localReviewHighSeverityNeedsRetry only escalates verifier-confirmed high f
 });
 
 test("localReviewHighSeverityNeedsRetry keeps current-head fix-blocked retries behind review gates", () => {
-  const config = createConfig({ localReviewPolicy: "block_merge", localReviewHighSeverityAction: "retry" });
+  const config = createConfig({
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    localReviewHighSeverityAction: "retry",
+  });
   const record = createRecord({
     local_review_head_sha: "deadbeef",
     local_review_verified_max_severity: "high",

--- a/src/review-handling.ts
+++ b/src/review-handling.ts
@@ -308,6 +308,7 @@ export function localReviewHighSeverityNeedsRetry(
   pr: Pick<GitHubPullRequest, "headRefOid" | "reviewDecision">,
 ): boolean {
   return (
+    config.localReviewEnabled &&
     config.localReviewPolicy !== "advisory" &&
     record.local_review_head_sha === pr.headRefOid &&
     record.local_review_verified_max_severity === "high" &&
@@ -472,6 +473,7 @@ export function localReviewHighSeverityNeedsBlock(
   pr: GitHubPullRequest,
 ): boolean {
   return (
+    config.localReviewEnabled &&
     config.localReviewPolicy !== "advisory" &&
     record.local_review_head_sha === pr.headRefOid &&
     record.local_review_verified_max_severity === "high" &&

--- a/src/supervisor/stale-review-bot-classification-policy.ts
+++ b/src/supervisor/stale-review-bot-classification-policy.ts
@@ -66,6 +66,7 @@ export interface StaleReviewBotClassificationPolicyArgs {
   hasUnprocessedMustFix: boolean;
   verificationEvidenceSummary: string | null;
   noMajorSignalEvidence: string | null;
+  currentHeadCleanCommentResidueEvidence: string | null;
   deterministicProbeEvidence: string | null;
   hasMarkedNoSourceChangeRepair: boolean;
   verifiedNoSourceChangeRepair: boolean;
@@ -145,6 +146,13 @@ function classifyCodexReviewBotPolicy(
       return {
         classification: "actionable_current_diff",
         summary: STALE_REVIEW_BOT_SUMMARY,
+      };
+    }
+    if (args.currentHeadCleanCommentResidueEvidence) {
+      return {
+        classification: "verified_no_source_change_pending_thread_resolution",
+        summary: VERIFIED_NO_SOURCE_CHANGE_SUMMARY,
+        verificationEvidenceSummary: args.currentHeadCleanCommentResidueEvidence,
       };
     }
     if (!args.verificationEvidenceSummary) {

--- a/src/supervisor/stale-review-bot-classification-policy.ts
+++ b/src/supervisor/stale-review-bot-classification-policy.ts
@@ -148,7 +148,7 @@ function classifyCodexReviewBotPolicy(
         summary: STALE_REVIEW_BOT_SUMMARY,
       };
     }
-    if (args.currentHeadCleanCommentResidueEvidence) {
+    if (args.currentHeadCleanCommentResidueEvidence && args.cleanMergeState) {
       return {
         classification: "verified_no_source_change_pending_thread_resolution",
         summary: VERIFIED_NO_SOURCE_CHANGE_SUMMARY,

--- a/src/supervisor/stale-review-bot-classification-policy.ts
+++ b/src/supervisor/stale-review-bot-classification-policy.ts
@@ -148,10 +148,18 @@ function classifyCodexReviewBotPolicy(
         summary: STALE_REVIEW_BOT_SUMMARY,
       };
     }
+    const verifiedCurrentHeadRepair =
+      args.hasExplicitCurrentHeadRepairVerification ||
+      args.hasCurrentHeadRepairCheckVerification ||
+      (!args.hasMarkedNoSourceChangeRepair && args.repairAttemptCount > 0);
     if (args.currentHeadCleanCommentResidueEvidence && args.cleanMergeState) {
       return {
-        classification: "verified_no_source_change_pending_thread_resolution",
-        summary: VERIFIED_NO_SOURCE_CHANGE_SUMMARY,
+        classification: verifiedCurrentHeadRepair
+          ? "verified_current_head_repair_pending_thread_resolution"
+          : "verified_no_source_change_pending_thread_resolution",
+        summary: verifiedCurrentHeadRepair
+          ? VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY
+          : VERIFIED_NO_SOURCE_CHANGE_SUMMARY,
         verificationEvidenceSummary: args.currentHeadCleanCommentResidueEvidence,
       };
     }
@@ -160,10 +168,6 @@ function classifyCodexReviewBotPolicy(
         missingProbeReason: "current_head_verification_evidence_missing",
       });
     }
-    const verifiedCurrentHeadRepair =
-      args.hasExplicitCurrentHeadRepairVerification ||
-      args.hasCurrentHeadRepairCheckVerification ||
-      (!args.hasMarkedNoSourceChangeRepair && args.repairAttemptCount > 0);
     if (!args.noMajorSignalEvidence) {
       if (args.deterministicProbeEvidence && args.allMustFixRepairResidueThreadsAreP2) {
         return {

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -2305,6 +2305,127 @@ test("buildStaleReviewBotRemediation treats later current-head Codex clean comme
   assert.equal(diagnostics?.repeatStopExhausted, "no");
 });
 
+test("buildStaleReviewBotRemediation lets fresh clean comments supersede stale blocking top-level reviews", () => {
+  const headSha = "e1104394b13abbd7dbf2a7f8f0d1f3ce9a0ff123";
+  const thread = createReviewThread({
+    id: "thread-before-clean",
+    path: "scripts/evaluate_dataset.py",
+    line: 1763,
+    comments: {
+      nodes: [
+        {
+          id: "comment-before-clean",
+          body: "P2: Earlier must-fix finding before the clean comment.",
+          createdAt: "2026-06-29T15:54:04Z",
+          url: "https://example.test/pr/137#discussion_before_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-before-clean`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-06-29T15:55:00Z",
+    configuredBotLatestReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "verified_no_source_change_pending_thread_resolution");
+  assert.equal(
+    remediation?.verificationEvidenceSummary,
+    "codex_current_head_clean_comment:reviewed_commit=e1104394b1:observed_at=2026-06-29T17:14:09Z:discounted_threads=1",
+  );
+});
+
+test("buildStaleReviewBotRemediation keeps blocking top-level reviews newer than clean comments blocking", () => {
+  const headSha = "e1104394b13abbd7dbf2a7f8f0d1f3ce9a0ff123";
+  const thread = createReviewThread({
+    id: "thread-before-clean",
+    path: "scripts/evaluate_dataset.py",
+    line: 1763,
+    comments: {
+      nodes: [
+        {
+          id: "comment-before-clean",
+          body: "P2: Earlier must-fix finding before the clean comment.",
+          createdAt: "2026-06-29T15:54:04Z",
+          url: "https://example.test/pr/137#discussion_before_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-before-clean`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-06-29T17:20:00Z",
+    configuredBotLatestReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
 test("buildStaleReviewBotRemediation does not trust clean comments before later Codex findings", () => {
   const headSha = "6fd42b1c0efb902736bca43f2489ad14fe20f163";
   const thread = createReviewThread({

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -550,7 +550,7 @@ test("buildStaleReviewBotRemediation requires no-source artifacts to cover every
         {
           id: "comment-uncovered-no-source-thread",
           body: "P2: Keep query export behavior covered by focused verification.",
-          createdAt: "2026-06-06T02:09:00Z",
+          createdAt: "2026-06-06T02:05:00Z",
           url: "https://example.test/pr/2261#discussion_uncovered",
           author: {
             login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
@@ -2199,7 +2199,7 @@ test("buildStaleReviewBotRemediation treats later current-head Codex clean comme
         nodes: [
           {
             id: "comment-evaluate-dataset",
-            body: "P1: Earlier current-head finding that was superseded by the later clean Codex review.",
+            body: "P2: Earlier current-head finding that was superseded by the later clean Codex review.",
             createdAt: "2026-06-29T13:26:35Z",
             url: `https://example.test/pr/${prNumber}#discussion_r3492030463`,
             author: {
@@ -2303,6 +2303,134 @@ test("buildStaleReviewBotRemediation treats later current-head Codex clean comme
   assert.equal(diagnostics?.verifiedStaleResidueThreads, 2);
   assert.equal(diagnostics?.missingVerificationEvidenceThreads, 0);
   assert.equal(diagnostics?.repeatStopExhausted, "no");
+});
+
+test("buildStaleReviewBotRemediation keeps P1 clean comment residue on the scoped proof path", () => {
+  const headSha = "e1104394b172f8ae88a871f32441e7a16c0f973c";
+  const thread = createReviewThread({
+    id: "thread-p1-before-clean",
+    path: "scripts/evaluate_dataset.py",
+    line: 1593,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p1-before-clean",
+          body: "P1: Earlier current-head finding that requires scoped proof despite the later clean Codex review.",
+          createdAt: "2026-06-29T13:26:35Z",
+          url: "https://example.test/pr/137#discussion_p1_before_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-p1-before-clean`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
+test("buildStaleReviewBotRemediation accepts follow-up-only local review with clean comment residue proof", () => {
+  const headSha = "e1104394b172f8ae88a871f32441e7a16c0f973c";
+  const thread = createReviewThread({
+    id: "thread-follow-up-before-clean",
+    path: "docs/gmp08-acceptance-evaluation.md",
+    line: 11,
+    comments: {
+      nodes: [
+        {
+          id: "comment-follow-up-before-clean",
+          body: "P2: Earlier follow-up-only residue before the clean Codex review.",
+          createdAt: "2026-06-29T15:54:04Z",
+          url: "https://example.test/pr/137#discussion_follow_up_before_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+  });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    local_review_head_sha: headSha,
+    local_review_findings_count: 2,
+    local_review_recommendation: "changes_requested",
+    pre_merge_evaluation_outcome: "follow_up_eligible",
+    pre_merge_follow_up_count: 2,
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-follow-up-before-clean`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "verified_no_source_change_pending_thread_resolution");
+  assert.equal(
+    remediation?.verificationEvidenceSummary,
+    "codex_current_head_clean_comment:reviewed_commit=e1104394b1:observed_at=2026-06-29T17:14:09Z:discounted_threads=1",
+  );
 });
 
 test("buildStaleReviewBotRemediation lets fresh clean comments supersede stale blocking top-level reviews", () => {
@@ -2612,6 +2740,8 @@ test("buildStaleReviewBotRemediation does not treat clean comments before later 
     last_head_sha: headSha,
     blocked_reason: "stale_review_bot",
     repair_attempt_count: 1,
+    codex_connector_review_requested_observed_at: "2026-06-29T17:08:34Z",
+    codex_connector_review_requested_head_sha: headSha,
     processed_review_thread_ids: [`${p2Thread.id}@${headSha}`, `${p3Thread.id}@${headSha}`],
     processed_review_thread_fingerprints: [
       `${p2Thread.id}@${headSha}#comment-p2-before-clean`,
@@ -2627,6 +2757,8 @@ test("buildStaleReviewBotRemediation does not treat clean comments before later 
     configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
     configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
     configuredBotCurrentHeadStatusState: "SUCCESS",
+    codexConnectorReviewRequestedAt: "2026-06-29T17:08:34Z",
+    codexConnectorReviewRequestedHeadSha: headSha,
     configuredBotTopLevelReviewStrength: null,
     configuredBotLatestReviewedCommitSha: "f476344b5d",
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "f476344b5d",

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -34,6 +34,7 @@ function policy(overrides: Partial<StaleReviewBotClassificationPolicyArgs> = {})
     hasUnprocessedMustFix: false,
     verificationEvidenceSummary: null,
     noMajorSignalEvidence: null,
+    currentHeadCleanCommentResidueEvidence: null,
     deterministicProbeEvidence: null,
     hasMarkedNoSourceChangeRepair: false,
     verifiedNoSourceChangeRepair: false,
@@ -90,6 +91,21 @@ test("classifyStaleReviewBotRemediationPolicy accepts explicit P2 repair evidenc
       classification: "verified_current_head_repair_pending_thread_resolution",
       summary: "verified_current_head_repair_configured_bot_thread_resolution_pending",
       verificationEvidenceSummary: "focused_verifier_passed",
+    },
+  );
+});
+
+test("classifyStaleReviewBotRemediationPolicy accepts current-head Codex clean comment residue evidence", () => {
+  assert.deepEqual(
+    policy({
+      currentHeadCleanCommentResidueEvidence:
+        "codex_current_head_clean_comment:reviewed_commit=head-44:observed_at=2026-06-29T17:14:09Z:discounted_threads=12",
+    }),
+    {
+      classification: "verified_no_source_change_pending_thread_resolution",
+      summary: "verified_no_source_change_configured_bot_thread_resolution_pending",
+      verificationEvidenceSummary:
+        "codex_current_head_clean_comment:reviewed_commit=head-44:observed_at=2026-06-29T17:14:09Z:discounted_threads=12",
     },
   );
 });
@@ -2136,6 +2152,183 @@ test("buildStaleReviewBotRemediation ignores unprocessed outdated Codex threads 
 
   assert.equal(remediation?.classification, "unknown_needs_operator");
   assert.equal(remediation?.codexCurrentHeadReviewState, "observed");
+  assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
+test("buildStaleReviewBotRemediation treats later current-head Codex clean comment as residue proof", () => {
+  const issueNumber = 2397;
+  const prNumber = 137;
+  const headSha = "e1104394b172f8ae88a871f32441e7a16c0f973c";
+  const currentThreads = [
+    createReviewThread({
+      id: "thread-evaluate-dataset",
+      path: "scripts/evaluate_dataset.py",
+      line: 1593,
+      comments: {
+        nodes: [
+          {
+            id: "comment-evaluate-dataset",
+            body: "P1: Earlier current-head finding that was superseded by the later clean Codex review.",
+            createdAt: "2026-06-29T13:26:35Z",
+            url: `https://example.test/pr/${prNumber}#discussion_r3492030463`,
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+    createReviewThread({
+      id: "thread-gmp-report",
+      path: "docs/gmp08-acceptance-evaluation.md",
+      line: 11,
+      comments: {
+        nodes: [
+          {
+            id: "comment-gmp-report",
+            body: "P2: Earlier report finding that was superseded by the later clean Codex review.",
+            createdAt: "2026-06-29T15:54:04Z",
+            url: `https://example.test/pr/${prNumber}#discussion_r3493003675`,
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    issue_number: issueNumber,
+    state: "blocked",
+    pr_number: prNumber,
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    processed_review_thread_ids: currentThreads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: [
+      `thread-evaluate-dataset@${headSha}#comment-evaluate-dataset`,
+      `thread-gmp-report@${headSha}#comment-gmp-report`,
+    ],
+    last_failure_context: {
+      category: "manual",
+      summary: "Current-head Codex residue remained unresolved after a clean current-head comment.",
+      signature: currentThreads.map((thread) => `stalled-bot:${thread.id}`).join("|"),
+      command: null,
+      details: currentThreads.map(
+        (thread) =>
+          `reviewer=${CODEX_CONNECTOR_REVIEW_BOT_LOGIN} file=${thread.path} line=${thread.line} processed_on_current_head=yes`,
+      ),
+      url: `https://example.test/pr/${prNumber}#discussion_r3492030463`,
+      updated_at: "2026-06-29T17:14:48Z",
+    },
+    codex_connector_review_requested_observed_at: "2026-06-29T17:08:34Z",
+    codex_connector_review_requested_head_sha: headSha,
+    pre_merge_must_fix_count: 0,
+    pre_merge_manual_review_count: 0,
+    pre_merge_follow_up_count: 0,
+  });
+  const pr = createPullRequest({
+    number: prNumber,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    codexConnectorReviewRequestedAt: "2026-06-29T17:08:34Z",
+    codexConnectorReviewRequestedHeadSha: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+  const checks = [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass" as const, workflow: "CI" }];
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads: currentThreads,
+  });
+  const diagnostics = buildStaleReviewBotThreadDiagnostics({
+    config,
+    record,
+    pr,
+    checks,
+    reviewThreads: currentThreads,
+    remediation,
+  });
+
+  assert.equal(remediation?.classification, "verified_no_source_change_pending_thread_resolution");
+  assert.equal(remediation?.codexCurrentHeadReviewState, "observed");
+  assert.equal(remediation?.missingProbeReason, null);
+  assert.equal(
+    remediation?.verificationEvidenceSummary,
+    "codex_current_head_clean_comment:reviewed_commit=e1104394b1:observed_at=2026-06-29T17:14:09Z:discounted_threads=2",
+  );
+  assert.equal(diagnostics?.verifiedStaleResidueThreads, 2);
+  assert.equal(diagnostics?.missingVerificationEvidenceThreads, 0);
+  assert.equal(diagnostics?.repeatStopExhausted, "no");
+});
+
+test("buildStaleReviewBotRemediation does not trust clean comments before later Codex findings", () => {
+  const headSha = "6fd42b1c0efb902736bca43f2489ad14fe20f163";
+  const thread = createReviewThread({
+    id: "thread-later-finding",
+    path: "scripts/evaluate_dataset.py",
+    line: 1763,
+    comments: {
+      nodes: [
+        {
+          id: "comment-later-finding",
+          body: "P2: Later finding after the clean comment must still block.",
+          createdAt: "2026-06-29T17:20:00Z",
+          url: "https://example.test/pr/137#discussion_later",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-later-finding`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "6fd42b1c0e",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "6fd42b1c0e",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
   assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
 });
 

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -2626,6 +2626,132 @@ test("buildStaleReviewBotRemediation honors current-head high-severity local-rev
   assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
 });
 
+test("buildStaleReviewBotRemediation honors current-head high-severity local-review retry gates", () => {
+  const headSha = "e1104394b172f8ae88a871f32441e7a16c0f973c";
+  const thread = createReviewThread({
+    id: "thread-high-severity-retry-before-clean",
+    path: "scripts/evaluate_dataset.py",
+    line: 1593,
+    comments: {
+      nodes: [
+        {
+          id: "comment-high-severity-retry-before-clean",
+          body: "P2: Earlier finding before a high-severity local-review retry gate.",
+          createdAt: "2026-06-29T15:54:04Z",
+          url: "https://example.test/pr/137#discussion_high_severity_retry_before_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    localReviewHighSeverityAction: "retry",
+  });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    local_review_head_sha: headSha,
+    local_review_verified_max_severity: "high",
+    pre_merge_evaluation_outcome: "manual_review_blocked",
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-high-severity-retry-before-clean`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
+test("buildStaleReviewBotRemediation requires clean comments to satisfy the active review wait", () => {
+  const headSha = "e1104394b172f8ae88a871f32441e7a16c0f973c";
+  const thread = createReviewThread({
+    id: "thread-wait-after-clean",
+    path: "docs/gmp08-acceptance-evaluation.md",
+    line: 11,
+    comments: {
+      nodes: [
+        {
+          id: "comment-wait-after-clean",
+          body: "P2: Earlier residue before the wait was re-armed after the clean Codex review.",
+          createdAt: "2026-06-29T15:54:04Z",
+          url: "https://example.test/pr/137#discussion_wait_after_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    review_wait_started_at: "2026-06-29T17:20:00Z",
+    review_wait_head_sha: headSha,
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-wait-after-clean`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
 test("buildStaleReviewBotRemediation honors human review decision blockers", () => {
   const headSha = "e1104394b172f8ae88a871f32441e7a16c0f973c";
   const thread = createReviewThread({

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -2457,7 +2457,8 @@ test("buildStaleReviewBotRemediation ignores stale disabled local review fields 
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
     localReviewEnabled: false,
-    localReviewPolicy: "advisory",
+    localReviewPolicy: "block_merge",
+    localReviewHighSeverityAction: "blocked",
   });
   const record = createRecord({
     issue_number: 2397,
@@ -2465,10 +2466,11 @@ test("buildStaleReviewBotRemediation ignores stale disabled local review fields 
     pr_number: 137,
     last_head_sha: headSha,
     blocked_reason: "stale_review_bot",
-    local_review_head_sha: "old-head",
+    local_review_head_sha: headSha,
     local_review_degraded: true,
     local_review_findings_count: 2,
     local_review_recommendation: "changes_requested",
+    local_review_verified_max_severity: "high",
     pre_merge_evaluation_outcome: "fix_blocked",
     pre_merge_must_fix_count: 2,
     pre_merge_manual_review_count: 1,
@@ -2582,6 +2584,7 @@ test("buildStaleReviewBotRemediation honors current-head high-severity local-rev
   });
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localReviewEnabled: true,
     localReviewPolicy: "block_merge",
     localReviewHighSeverityAction: "blocked",
   });

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -110,6 +110,21 @@ test("classifyStaleReviewBotRemediationPolicy accepts current-head Codex clean c
   );
 });
 
+test("classifyStaleReviewBotRemediationPolicy requires clean merge state for clean comment residue evidence", () => {
+  assert.deepEqual(
+    policy({
+      cleanMergeState: false,
+      currentHeadCleanCommentResidueEvidence:
+        "codex_current_head_clean_comment:reviewed_commit=head-44:observed_at=2026-06-29T17:14:09Z:discounted_threads=12",
+    }),
+    {
+      classification: "unknown_needs_operator",
+      summary: "code_or_ci_green_but_review_thread_metadata_unresolved",
+      missingProbeReason: "current_head_verification_evidence_missing",
+    },
+  );
+});
+
 test("buildStaleReviewBotThreadDiagnostics reports current-head repair proof local CI shape mismatches", () => {
   const headSha = "head-proof-diagnostics";
   const thread = createReviewThread({

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -2433,6 +2433,258 @@ test("buildStaleReviewBotRemediation accepts follow-up-only local review with cl
   );
 });
 
+test("buildStaleReviewBotRemediation ignores stale disabled local review fields with clean comment residue proof", () => {
+  const headSha = "e1104394b172f8ae88a871f32441e7a16c0f973c";
+  const thread = createReviewThread({
+    id: "thread-disabled-local-before-clean",
+    path: "docs/gmp08-acceptance-evaluation.md",
+    line: 11,
+    comments: {
+      nodes: [
+        {
+          id: "comment-disabled-local-before-clean",
+          body: "P2: Earlier stale local-review residue before the clean Codex review.",
+          createdAt: "2026-06-29T15:54:04Z",
+          url: "https://example.test/pr/137#discussion_disabled_local_before_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localReviewEnabled: false,
+    localReviewPolicy: "advisory",
+  });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    local_review_head_sha: "old-head",
+    local_review_degraded: true,
+    local_review_findings_count: 2,
+    local_review_recommendation: "changes_requested",
+    pre_merge_evaluation_outcome: "fix_blocked",
+    pre_merge_must_fix_count: 2,
+    pre_merge_manual_review_count: 1,
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-disabled-local-before-clean`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "verified_no_source_change_pending_thread_resolution");
+});
+
+test("buildStaleReviewBotRemediation fails closed for same-second clean comments and Codex findings", () => {
+  const headSha = "e1104394b172f8ae88a871f32441e7a16c0f973c";
+  const thread = createReviewThread({
+    id: "thread-same-second-clean",
+    path: "scripts/evaluate_dataset.py",
+    line: 1593,
+    comments: {
+      nodes: [
+        {
+          id: "comment-same-second-clean",
+          body: "P2: Same-second finding must not be covered by the clean Codex review.",
+          createdAt: "2026-06-29T17:14:09Z",
+          url: "https://example.test/pr/137#discussion_same_second_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-same-second-clean`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
+test("buildStaleReviewBotRemediation honors current-head high-severity local-review blockers", () => {
+  const headSha = "e1104394b172f8ae88a871f32441e7a16c0f973c";
+  const thread = createReviewThread({
+    id: "thread-high-severity-before-clean",
+    path: "scripts/evaluate_dataset.py",
+    line: 1593,
+    comments: {
+      nodes: [
+        {
+          id: "comment-high-severity-before-clean",
+          body: "P2: Earlier finding before a blocked high-severity local review.",
+          createdAt: "2026-06-29T15:54:04Z",
+          url: "https://example.test/pr/137#discussion_high_severity_before_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localReviewPolicy: "block_merge",
+    localReviewHighSeverityAction: "blocked",
+  });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    local_review_head_sha: headSha,
+    local_review_verified_max_severity: "high",
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-high-severity-before-clean`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
+test("buildStaleReviewBotRemediation honors human review decision blockers", () => {
+  const headSha = "e1104394b172f8ae88a871f32441e7a16c0f973c";
+  const thread = createReviewThread({
+    id: "thread-human-review-before-clean",
+    path: "scripts/evaluate_dataset.py",
+    line: 1593,
+    comments: {
+      nodes: [
+        {
+          id: "comment-human-review-before-clean",
+          body: "P2: Earlier finding before an outstanding human review decision.",
+          createdAt: "2026-06-29T15:54:04Z",
+          url: "https://example.test/pr/137#discussion_human_review_before_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+  });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-human-review-before-clean`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    reviewDecision: "REVIEW_REQUIRED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "e1104394b1",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
 test("buildStaleReviewBotRemediation lets fresh clean comments supersede stale blocking top-level reviews", () => {
   const headSha = "e1104394b13abbd7dbf2a7f8f0d1f3ce9a0ff123";
   const thread = createReviewThread({

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -110,6 +110,22 @@ test("classifyStaleReviewBotRemediationPolicy accepts current-head Codex clean c
   );
 });
 
+test("classifyStaleReviewBotRemediationPolicy preserves repair classification for clean comment residue", () => {
+  assert.deepEqual(
+    policy({
+      repairAttemptCount: 1,
+      currentHeadCleanCommentResidueEvidence:
+        "codex_current_head_clean_comment:reviewed_commit=head-44:observed_at=2026-06-29T17:14:09Z:discounted_threads=12",
+    }),
+    {
+      classification: "verified_current_head_repair_pending_thread_resolution",
+      summary: "verified_current_head_repair_configured_bot_thread_resolution_pending",
+      verificationEvidenceSummary:
+        "codex_current_head_clean_comment:reviewed_commit=head-44:observed_at=2026-06-29T17:14:09Z:discounted_threads=12",
+    },
+  );
+});
+
 test("classifyStaleReviewBotRemediationPolicy requires clean merge state for clean comment residue evidence", () => {
   assert.deepEqual(
     policy({
@@ -2345,6 +2361,168 @@ test("buildStaleReviewBotRemediation does not trust clean comments before later 
 
   assert.equal(remediation?.classification, "unknown_needs_operator");
   assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
+test("buildStaleReviewBotRemediation does not trust clean comments before later P3 Codex findings", () => {
+  const headSha = "f476344b5dc0f449bc87c024574ea4f284189e8c";
+  const p2Thread = createReviewThread({
+    id: "thread-p2-before-clean",
+    path: "scripts/evaluate_dataset.py",
+    line: 1763,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p2-before-clean",
+          body: "P2: Earlier must-fix finding before the clean comment.",
+          createdAt: "2026-06-29T13:20:00Z",
+          url: "https://example.test/pr/137#discussion_p2_before_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const p3Thread = createReviewThread({
+    id: "thread-p3-after-clean",
+    path: "docs/gmp08-acceptance-evaluation.md",
+    line: 22,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p3-after-clean",
+          body: "P3: Later advisory finding after the clean comment.",
+          createdAt: "2026-06-29T17:20:00Z",
+          url: "https://example.test/pr/137#discussion_p3_after_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    processed_review_thread_ids: [`${p2Thread.id}@${headSha}`, `${p3Thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [
+      `${p2Thread.id}@${headSha}#comment-p2-before-clean`,
+      `${p3Thread.id}@${headSha}#comment-p3-after-clean`,
+    ],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "f476344b5d",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "f476344b5d",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [p2Thread, p3Thread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
+test("buildStaleReviewBotRemediation does not treat clean comments before later P3 Codex findings as no-major evidence", () => {
+  const headSha = "f476344b5dc0f449bc87c024574ea4f284189e8c";
+  const p2Thread = createReviewThread({
+    id: "thread-p2-before-clean",
+    path: "scripts/evaluate_dataset.py",
+    line: 1763,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p2-before-clean",
+          body: "P2: Earlier must-fix finding before the clean comment.",
+          createdAt: "2026-06-29T13:20:00Z",
+          url: "https://example.test/pr/137#discussion_p2_before_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const p3Thread = createReviewThread({
+    id: "thread-p3-after-clean",
+    path: "docs/gmp08-acceptance-evaluation.md",
+    line: 22,
+    comments: {
+      nodes: [
+        {
+          id: "comment-p3-after-clean",
+          body: "P3: Later advisory finding after the clean comment.",
+          createdAt: "2026-06-29T17:20:00Z",
+          url: "https://example.test/pr/137#discussion_p3_after_clean",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    repair_attempt_count: 1,
+    processed_review_thread_ids: [`${p2Thread.id}@${headSha}`, `${p3Thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [
+      `${p2Thread.id}@${headSha}#comment-p2-before-clean`,
+      `${p3Thread.id}@${headSha}#comment-p3-after-clean`,
+    ],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotLatestReviewedCommitSha: "f476344b5d",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "f476344b5d",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [p2Thread, p3Thread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.verificationEvidenceSummary, "current_head_checks_passed:Minimal checks");
+  assert.equal(remediation?.missingProbeReason, "current_head_codex_no_major_signal_missing");
 });
 
 test("buildStaleReviewBotRemediation does not trust clean comments when merge state is not clean", () => {

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -2301,7 +2301,7 @@ test("buildStaleReviewBotRemediation does not trust clean comments before later 
     state: "blocked",
     pr_number: 137,
     last_head_sha: headSha,
-    blocked_reason: "manual_review",
+    blocked_reason: "stale_review_bot",
     processed_review_thread_ids: [`${thread.id}@${headSha}`],
     processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-later-finding`],
   });
@@ -2317,6 +2317,195 @@ test("buildStaleReviewBotRemediation does not trust clean comments before later 
     configuredBotTopLevelReviewStrength: null,
     configuredBotLatestReviewedCommitSha: "6fd42b1c0e",
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "6fd42b1c0e",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
+test("buildStaleReviewBotRemediation does not trust clean comments when merge state is not clean", () => {
+  const headSha = "13d9f6eba849ce0e8facd37fbfe5d3d6969f80de";
+  const thread = createReviewThread({
+    id: "thread-blocked-merge",
+    path: "scripts/evaluate_dataset.py",
+    line: 1593,
+    comments: {
+      nodes: [
+        {
+          id: "comment-blocked-merge",
+          body: "P2: Finding must not be discounted while merge state is blocked.",
+          createdAt: "2026-06-29T13:26:35Z",
+          url: "https://example.test/pr/137#discussion_blocked_merge",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-blocked-merge`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "13d9f6eba8",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "unknown_needs_operator");
+  assert.equal(remediation?.missingProbeReason, "current_head_verification_evidence_missing");
+});
+
+test("buildStaleReviewBotRemediation does not trust clean comments after human replies on a Codex thread", () => {
+  const headSha = "56e2d73eb2655c75d4c09f1a9517b7e8bc39ad6d";
+  const thread = createReviewThread({
+    id: "thread-human-reply",
+    path: "scripts/evaluate_dataset.py",
+    line: 1593,
+    comments: {
+      nodes: [
+        {
+          id: "comment-human-reply-codex",
+          body: "P2: Finding must not be discounted after a human reply.",
+          createdAt: "2026-06-29T13:26:35Z",
+          url: "https://example.test/pr/137#discussion_human_reply",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+        {
+          id: "comment-human-reply-human",
+          body: "This thread still needs a human decision.",
+          createdAt: "2026-06-29T17:18:00Z",
+          url: "https://example.test/pr/137#discussion_human_reply_followup",
+          author: {
+            login: "reviewer-human",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({ reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN] });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "stale_review_bot",
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-human-reply-codex`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "56e2d73eb2",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+  });
+
+  assert.equal(remediation?.classification, "unresolved_work");
+  assert.equal(remediation?.missingProbeReason, null);
+});
+
+test("buildStaleReviewBotRemediation does not trust clean comments before required pre-merge evaluation", () => {
+  const headSha = "946046250d7a8ca70526b578f7227fa495eec29b";
+  const thread = createReviewThread({
+    id: "thread-missing-premerge",
+    path: "scripts/evaluate_dataset.py",
+    line: 1593,
+    comments: {
+      nodes: [
+        {
+          id: "comment-missing-premerge",
+          body: "P2: Finding must not be discounted before block-merge local review runs.",
+          createdAt: "2026-06-29T13:26:35Z",
+          url: "https://example.test/pr/137#discussion_missing_premerge",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+  });
+  const record = createRecord({
+    issue_number: 2397,
+    state: "blocked",
+    pr_number: 137,
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    local_review_head_sha: headSha,
+    local_review_findings_count: 0,
+    local_review_recommendation: "ready",
+    pre_merge_evaluation_outcome: null,
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-missing-premerge`],
+  });
+  const pr = createPullRequest({
+    number: 137,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-06-29T17:10:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-06-29T17:14:09Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotTopLevelReviewStrength: null,
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "946046250d",
     configuredBotCurrentHeadCodexSuccessObservedAt: "2026-06-29T17:14:09Z",
   });
 

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -2,6 +2,7 @@ import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread,
 import {
   hasProcessedReviewThread,
   latestReviewThreadCommentFingerprint,
+  localReviewBlocksMerge,
   processedReviewThreadFingerprintKey,
   processedReviewThreadKey,
   reviewLoopRetryBudgetExhaustedForThread,
@@ -21,6 +22,7 @@ import {
 import {
   configuredBotReviewFollowUpState,
   configuredBotReviewThreads,
+  latestReviewCommentAuthorIsAllowedBot,
   manualReviewThreads,
   nonActionableConfiguredBotReviewThreads,
   pendingBotReviewThreads,
@@ -835,8 +837,11 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
 }
 
 function hasLocalOrPreMergeBlockers(
+  config: SupervisorConfig,
   record: Pick<
     IssueRunRecord,
+    | "local_review_head_sha"
+    | "local_review_recommendation"
     | "local_review_degraded"
     | "local_review_findings_count"
     | "pre_merge_evaluation_outcome"
@@ -844,8 +849,10 @@ function hasLocalOrPreMergeBlockers(
     | "pre_merge_manual_review_count"
     | "pre_merge_follow_up_count"
   >,
+  pr: GitHubPullRequest,
 ): boolean {
   return Boolean(
+    localReviewBlocksMerge(config, record, pr) ||
     record.local_review_degraded ||
       record.local_review_findings_count > 0 ||
       (record.pre_merge_must_fix_count ?? 0) > 0 ||
@@ -874,7 +881,10 @@ function currentHeadCodexCleanCommentResidueEvidence(args: {
   if (args.pr.configuredBotTopLevelReviewStrength === "blocking") {
     return null;
   }
-  if (hasLocalOrPreMergeBlockers(args.record)) {
+  if (!hasCleanMergeState(args.pr)) {
+    return null;
+  }
+  if (hasLocalOrPreMergeBlockers(args.config, args.record, args.pr)) {
     return null;
   }
   if (!hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads)) {
@@ -885,6 +895,7 @@ function currentHeadCodexCleanCommentResidueEvidence(args: {
       (thread) =>
         thread.isResolved ||
         thread.isOutdated ||
+        !latestReviewCommentAuthorIsAllowedBot(args.config, thread) ||
         !hasCodexConnectorFindingReviewComment(thread),
     )
   ) {

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -14,7 +14,7 @@ import {
   codexConnectorMustFixReviewThreads,
   commitShasEqualForComparison,
   evaluateCodexConnectorConvergencePolicy,
-  hasCodexConnectorFindingReviewComment,
+  latestCodexConnectorReviewCommentNode,
   latestCodexConnectorReviewCommentFingerprint,
   latestCodexConnectorPSeverity,
   latestCodexConnectorReviewComment,
@@ -22,6 +22,7 @@ import {
 import {
   configuredBotReviewFollowUpState,
   configuredBotReviewThreads,
+  latestReviewComment,
   latestReviewCommentAuthorIsAllowedBot,
   manualReviewThreads,
   nonActionableConfiguredBotReviewThreads,
@@ -851,6 +852,10 @@ function hasLocalOrPreMergeBlockers(
   >,
   pr: GitHubPullRequest,
 ): boolean {
+  const explicitPreMergeBlocker =
+    record.pre_merge_evaluation_outcome === "fix_blocked" ||
+    record.pre_merge_evaluation_outcome === "manual_review_blocked" ||
+    record.pre_merge_evaluation_outcome === "follow_up_eligible";
   return Boolean(
     localReviewBlocksMerge(config, record, pr) ||
     record.local_review_degraded ||
@@ -858,8 +863,20 @@ function hasLocalOrPreMergeBlockers(
       (record.pre_merge_must_fix_count ?? 0) > 0 ||
       (record.pre_merge_manual_review_count ?? 0) > 0 ||
       (record.pre_merge_follow_up_count ?? 0) > 0 ||
-      (record.pre_merge_evaluation_outcome &&
-        record.pre_merge_evaluation_outcome !== "mergeable"),
+      explicitPreMergeBlocker,
+  );
+}
+
+function latestCommentIsConfiguredCodexFinding(config: SupervisorConfig, thread: ReviewThread): boolean {
+  if (!latestReviewCommentAuthorIsAllowedBot(config, thread)) {
+    return false;
+  }
+  const latestComment = latestReviewComment(thread);
+  const latestCodexFindingComment = latestCodexConnectorReviewCommentNode(thread);
+  return Boolean(
+    latestComment &&
+      latestCodexFindingComment &&
+      latestComment.id === latestCodexFindingComment.id,
   );
 }
 
@@ -895,8 +912,7 @@ function currentHeadCodexCleanCommentResidueEvidence(args: {
       (thread) =>
         thread.isResolved ||
         thread.isOutdated ||
-        !latestReviewCommentAuthorIsAllowedBot(args.config, thread) ||
-        !hasCodexConnectorFindingReviewComment(thread),
+        !latestCommentIsConfiguredCodexFinding(args.config, thread),
     )
   ) {
     return null;

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -916,6 +916,27 @@ function hasFreshCurrentHeadCodexSuccessReviewedCurrentConfiguredFindings(args: 
   );
 }
 
+function hasCurrentBlockingTopLevelReviewAfterCodexSuccess(
+  pr: Pick<
+    GitHubPullRequest,
+    | "configuredBotTopLevelReviewStrength"
+    | "configuredBotTopLevelReviewSubmittedAt"
+    | "configuredBotCurrentHeadCodexSuccessObservedAt"
+  >,
+): boolean {
+  if (pr.configuredBotTopLevelReviewStrength !== "blocking") {
+    return false;
+  }
+
+  const topLevelReviewSubmittedAt = validTimestamp(pr.configuredBotTopLevelReviewSubmittedAt);
+  const successObservedAt = validTimestamp(pr.configuredBotCurrentHeadCodexSuccessObservedAt);
+  if (!topLevelReviewSubmittedAt || !successObservedAt) {
+    return true;
+  }
+
+  return Date.parse(topLevelReviewSubmittedAt) >= Date.parse(successObservedAt);
+}
+
 function currentHeadCodexCleanCommentResidueEvidence(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -931,9 +952,6 @@ function currentHeadCodexCleanCommentResidueEvidence(args: {
   if (args.mustFixReviewThreads.length === 0 || args.currentConfiguredThreads.length === 0) {
     return null;
   }
-  if (args.pr.configuredBotTopLevelReviewStrength === "blocking") {
-    return null;
-  }
   if (!hasCleanMergeState(args.pr)) {
     return null;
   }
@@ -947,6 +965,9 @@ function currentHeadCodexCleanCommentResidueEvidence(args: {
       currentConfiguredThreads: args.currentConfiguredThreads,
     })
   ) {
+    return null;
+  }
+  if (hasCurrentBlockingTopLevelReviewAfterCodexSuccess(args.pr)) {
     return null;
   }
   if (

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -3,10 +3,14 @@ import {
   hasProcessedReviewThread,
   latestReviewThreadCommentFingerprint,
   localReviewBlocksMerge,
+  localReviewDegradedNeedsBlock,
+  localReviewHighSeverityNeedsBlock,
+  localReviewRequiresManualReview,
   processedReviewThreadFingerprintKey,
   processedReviewThreadKey,
   reviewLoopRetryBudgetExhaustedForThread,
 } from "../review-handling";
+import { reviewDecisionBlocksCurrentHeadRepairProjection } from "../review-decision-blocking-policy";
 import {
   clusterConfiguredBotReviewThreads,
 } from "../codex-connector-review-churn";
@@ -855,6 +859,7 @@ function hasLocalOrPreMergeBlockers(
     | "local_review_recommendation"
     | "local_review_degraded"
     | "local_review_findings_count"
+    | "local_review_verified_max_severity"
     | "pre_merge_evaluation_outcome"
     | "pre_merge_must_fix_count"
     | "pre_merge_manual_review_count"
@@ -862,15 +867,34 @@ function hasLocalOrPreMergeBlockers(
   >,
   pr: GitHubPullRequest,
 ): boolean {
-  const preMergeBlocker =
-    record.pre_merge_evaluation_outcome === "fix_blocked" ||
-    record.pre_merge_evaluation_outcome === "manual_review_blocked";
   return Boolean(
-    localReviewBlocksMerge(config, record, pr) ||
-    record.local_review_degraded ||
-      (record.pre_merge_must_fix_count ?? 0) > 0 ||
-      (record.pre_merge_manual_review_count ?? 0) > 0 ||
-      preMergeBlocker,
+    localReviewRequiresManualReview(config, record, pr) ||
+    localReviewDegradedNeedsBlock(config, record, pr) ||
+    localReviewHighSeverityNeedsBlock(config, record, pr) ||
+    localReviewBlocksMerge(config, record, pr),
+  );
+}
+
+function humanReviewDecisionBlocksCleanCommentResidue(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+  reviewThreads: ReviewThread[],
+): boolean {
+  return reviewDecisionBlocksCurrentHeadRepairProjection({
+    humanReviewBlocksMerge: Boolean(config.humanReviewBlocksMerge),
+    manualThreadCount: manualReviewThreads(config, reviewThreads).length,
+    pr,
+  });
+}
+
+function reviewDecisionBlocksCleanCommentResidue(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+  reviewThreads: ReviewThread[],
+): boolean {
+  return (
+    humanReviewDecisionBlocksCleanCommentResidue(config, pr, reviewThreads) ||
+    hasCurrentBlockingTopLevelReviewAfterCodexSuccess(pr)
   );
 }
 
@@ -902,7 +926,7 @@ function latestCurrentConfiguredCodexFindingObservedAt(reviewThreads: ReviewThre
 
 function observedAtCoversCurrentConfiguredCodexFindings(observedAt: string, currentConfiguredThreads: ReviewThread[]): boolean {
   const latestCurrentFindingObservedAt = latestCurrentConfiguredCodexFindingObservedAt(currentConfiguredThreads);
-  return !latestCurrentFindingObservedAt || Date.parse(observedAt) >= Date.parse(latestCurrentFindingObservedAt);
+  return !latestCurrentFindingObservedAt || Date.parse(observedAt) > Date.parse(latestCurrentFindingObservedAt);
 }
 
 function hasFreshCurrentHeadCodexSuccessReviewedCurrentConfiguredFindings(args: {
@@ -970,7 +994,7 @@ function currentHeadCodexCleanCommentResidueEvidence(args: {
   ) {
     return null;
   }
-  if (hasCurrentBlockingTopLevelReviewAfterCodexSuccess(args.pr)) {
+  if (reviewDecisionBlocksCleanCommentResidue(args.config, args.pr, args.reviewThreads)) {
     return null;
   }
   if (

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -13,6 +13,7 @@ import {
   codexConnectorMustFixReviewThreads,
   commitShasEqualForComparison,
   evaluateCodexConnectorConvergencePolicy,
+  hasCodexConnectorFindingReviewComment,
   latestCodexConnectorReviewCommentFingerprint,
   latestCodexConnectorPSeverity,
   latestCodexConnectorReviewComment,
@@ -833,6 +834,74 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
   return "codex_pr_success_comment_after_current_head_request";
 }
 
+function hasLocalOrPreMergeBlockers(
+  record: Pick<
+    IssueRunRecord,
+    | "local_review_degraded"
+    | "local_review_findings_count"
+    | "pre_merge_evaluation_outcome"
+    | "pre_merge_must_fix_count"
+    | "pre_merge_manual_review_count"
+    | "pre_merge_follow_up_count"
+  >,
+): boolean {
+  return Boolean(
+    record.local_review_degraded ||
+      record.local_review_findings_count > 0 ||
+      (record.pre_merge_must_fix_count ?? 0) > 0 ||
+      (record.pre_merge_manual_review_count ?? 0) > 0 ||
+      (record.pre_merge_follow_up_count ?? 0) > 0 ||
+      (record.pre_merge_evaluation_outcome &&
+        record.pre_merge_evaluation_outcome !== "mergeable"),
+  );
+}
+
+function currentHeadCodexCleanCommentResidueEvidence(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  reviewThreads: ReviewThread[];
+  currentConfiguredThreads: ReviewThread[];
+  mustFixReviewThreads: ReviewThread[];
+}): string | null {
+  const providerKinds = configuredReviewProviderKinds(args.config);
+  if (providerKinds.length === 0 || providerKinds.some((kind) => kind !== "codex")) {
+    return null;
+  }
+  if (args.mustFixReviewThreads.length === 0 || args.currentConfiguredThreads.length === 0) {
+    return null;
+  }
+  if (args.pr.configuredBotTopLevelReviewStrength === "blocking") {
+    return null;
+  }
+  if (hasLocalOrPreMergeBlockers(args.record)) {
+    return null;
+  }
+  if (!hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads)) {
+    return null;
+  }
+  if (
+    args.currentConfiguredThreads.some(
+      (thread) =>
+        thread.isResolved ||
+        thread.isOutdated ||
+        !hasCodexConnectorFindingReviewComment(thread),
+    )
+  ) {
+    return null;
+  }
+  if (args.mustFixReviewThreads.some((thread) => latestCodexConnectorPSeverity(thread) === "P0")) {
+    return null;
+  }
+
+  return [
+    "codex_current_head_clean_comment",
+    `reviewed_commit=${args.pr.configuredBotCurrentHeadCodexSuccessReviewedCommitSha ?? "unknown"}`,
+    `observed_at=${args.pr.configuredBotCurrentHeadCodexSuccessObservedAt ?? "unknown"}`,
+    `discounted_threads=${args.mustFixReviewThreads.length}`,
+  ].join(":");
+}
+
 function classifyCodexMetadataOnly(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -845,6 +914,14 @@ function classifyCodexMetadataOnly(args: {
   const currentConfiguredThreads = configuredThreads.filter((thread) => !thread.isOutdated);
   const policy = evaluateCodexConnectorConvergencePolicy(args.config, args.pr, args.reviewThreads);
   const mustFixReviewThreads = codexConnectorMustFixReviewThreads(args.reviewThreads);
+  const currentHeadCleanCommentResidueEvidence = currentHeadCodexCleanCommentResidueEvidence({
+    config: args.config,
+    record: args.record,
+    pr: args.pr,
+    reviewThreads: args.reviewThreads,
+    currentConfiguredThreads,
+    mustFixReviewThreads,
+  });
   const hasMarkedNoSourceChangeRepair = hasCurrentHeadMarkedNoSourceChangeCodexTurnVerification(
     args.record,
     args.pr,
@@ -890,6 +967,7 @@ function classifyCodexMetadataOnly(args: {
       pr: args.pr,
       reviewThreads: args.reviewThreads,
     }),
+    currentHeadCleanCommentResidueEvidence,
     deterministicProbeEvidence: deterministicRepairProbeEvidence({
       reviewThreads: args.reviewThreads,
       repositoryFileContents: args.repositoryFileContents,
@@ -935,6 +1013,7 @@ function classifyRemediation(args: {
       hasUnprocessedMustFix: false,
       verificationEvidenceSummary: null,
       noMajorSignalEvidence: null,
+      currentHeadCleanCommentResidueEvidence: null,
       deterministicProbeEvidence: null,
       hasMarkedNoSourceChangeRepair: false,
       verifiedNoSourceChangeRepair: false,
@@ -976,6 +1055,7 @@ function classifyRemediation(args: {
     hasUnprocessedMustFix: false,
     verificationEvidenceSummary: null,
     noMajorSignalEvidence: null,
+    currentHeadCleanCommentResidueEvidence: null,
     deterministicProbeEvidence: null,
     hasMarkedNoSourceChangeRepair: false,
     verifiedNoSourceChangeRepair: false,

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -807,12 +807,11 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
   reviewThreads: ReviewThread[];
   currentConfiguredThreads: ReviewThread[];
 }): string | null {
+  const successObservedAt = validTimestamp(args.pr.configuredBotCurrentHeadCodexSuccessObservedAt);
   if (
-    hasFreshCurrentHeadCodexSuccessReviewedCurrentConfiguredFindings({
-      pr: args.pr,
-      reviewThreads: args.reviewThreads,
-      currentConfiguredThreads: args.currentConfiguredThreads,
-    })
+    successObservedAt &&
+    hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads) &&
+    observedAtCoversCurrentConfiguredCodexFindings(successObservedAt, args.currentConfiguredThreads)
   ) {
     return "codex_pr_success_comment_reviewed_current_head";
   }
@@ -841,6 +840,10 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
     return null;
   }
 
+  if (!observedAtCoversCurrentConfiguredCodexFindings(observedAt, args.currentConfiguredThreads)) {
+    return null;
+  }
+
   return "codex_pr_success_comment_after_current_head_request";
 }
 
@@ -859,18 +862,15 @@ function hasLocalOrPreMergeBlockers(
   >,
   pr: GitHubPullRequest,
 ): boolean {
-  const explicitPreMergeBlocker =
+  const preMergeBlocker =
     record.pre_merge_evaluation_outcome === "fix_blocked" ||
-    record.pre_merge_evaluation_outcome === "manual_review_blocked" ||
-    record.pre_merge_evaluation_outcome === "follow_up_eligible";
+    record.pre_merge_evaluation_outcome === "manual_review_blocked";
   return Boolean(
     localReviewBlocksMerge(config, record, pr) ||
     record.local_review_degraded ||
-      record.local_review_findings_count > 0 ||
       (record.pre_merge_must_fix_count ?? 0) > 0 ||
       (record.pre_merge_manual_review_count ?? 0) > 0 ||
-      (record.pre_merge_follow_up_count ?? 0) > 0 ||
-      explicitPreMergeBlocker,
+      preMergeBlocker,
   );
 }
 
@@ -900,6 +900,11 @@ function latestCurrentConfiguredCodexFindingObservedAt(reviewThreads: ReviewThre
   }, null);
 }
 
+function observedAtCoversCurrentConfiguredCodexFindings(observedAt: string, currentConfiguredThreads: ReviewThread[]): boolean {
+  const latestCurrentFindingObservedAt = latestCurrentConfiguredCodexFindingObservedAt(currentConfiguredThreads);
+  return !latestCurrentFindingObservedAt || Date.parse(observedAt) >= Date.parse(latestCurrentFindingObservedAt);
+}
+
 function hasFreshCurrentHeadCodexSuccessReviewedCurrentConfiguredFindings(args: {
   pr: Parameters<typeof hasFreshCurrentHeadCodexSuccessReviewedCommit>[0];
   reviewThreads: ReviewThread[];
@@ -909,10 +914,8 @@ function hasFreshCurrentHeadCodexSuccessReviewedCurrentConfiguredFindings(args: 
     return false;
   }
   const successObservedAt = validTimestamp(args.pr.configuredBotCurrentHeadCodexSuccessObservedAt);
-  const latestCurrentFindingObservedAt = latestCurrentConfiguredCodexFindingObservedAt(args.currentConfiguredThreads);
   return Boolean(
-    successObservedAt &&
-      (!latestCurrentFindingObservedAt || Date.parse(successObservedAt) >= Date.parse(latestCurrentFindingObservedAt)),
+    successObservedAt && observedAtCoversCurrentConfiguredCodexFindings(successObservedAt, args.currentConfiguredThreads),
   );
 }
 
@@ -980,7 +983,7 @@ function currentHeadCodexCleanCommentResidueEvidence(args: {
   ) {
     return null;
   }
-  if (args.mustFixReviewThreads.some((thread) => latestCodexConnectorPSeverity(thread) === "P0")) {
+  if (!allCodexConnectorRepairResidueThreadsAreP2(args.mustFixReviewThreads)) {
     return null;
   }
 

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -5,6 +5,7 @@ import {
   localReviewBlocksMerge,
   localReviewDegradedNeedsBlock,
   localReviewHighSeverityNeedsBlock,
+  localReviewHighSeverityNeedsRetry,
   localReviewRequiresManualReview,
   processedReviewThreadFingerprintKey,
   processedReviewThreadKey,
@@ -39,6 +40,7 @@ import {
   projectCurrentHeadCodexRepairProof,
 } from "../current-head-codex-repair-proof";
 import { currentHeadPassingNonReviewChecks } from "../local-ci-policy";
+import { currentHeadTimestampSatisfiesActiveWait } from "../pull-request-state-current-head-policy";
 import {
   buildCodexConnectorStillValidReviewRepairTargets,
   type CodexConnectorValidReviewRepairTarget,
@@ -794,7 +796,10 @@ function hasCurrentHeadSuccessSignal(
 function currentHeadCodexNoMajorSignalEvidence(args: {
   record: Pick<
     IssueRunRecord,
-    "codex_connector_review_requested_observed_at" | "codex_connector_review_requested_head_sha"
+    | "codex_connector_review_requested_observed_at"
+    | "codex_connector_review_requested_head_sha"
+    | "review_wait_started_at"
+    | "review_wait_head_sha"
   >;
   pr: Pick<
     GitHubPullRequest,
@@ -815,6 +820,7 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
   if (
     successObservedAt &&
     hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads) &&
+    currentHeadTimestampSatisfiesActiveWait(args.record, args.pr, successObservedAt) &&
     observedAtCoversCurrentConfiguredCodexFindings(successObservedAt, args.currentConfiguredThreads)
   ) {
     return "codex_pr_success_comment_reviewed_current_head";
@@ -870,8 +876,22 @@ function hasLocalOrPreMergeBlockers(
   return Boolean(
     localReviewRequiresManualReview(config, record, pr) ||
     localReviewDegradedNeedsBlock(config, record, pr) ||
-    (config.localReviewEnabled && localReviewHighSeverityNeedsBlock(config, record, pr)) ||
+    localReviewHighSeverityBlocksCleanCommentResidue(config, record, pr) ||
     localReviewBlocksMerge(config, record, pr),
+  );
+}
+
+function localReviewHighSeverityBlocksCleanCommentResidue(
+  config: SupervisorConfig,
+  record: Pick<
+    IssueRunRecord,
+    "local_review_head_sha" | "local_review_verified_max_severity" | "pre_merge_evaluation_outcome"
+  >,
+  pr: GitHubPullRequest,
+): boolean {
+  return (
+    localReviewHighSeverityNeedsRetry(config, record, pr) ||
+    (config.localReviewEnabled && localReviewHighSeverityNeedsBlock(config, record, pr))
   );
 }
 
@@ -929,8 +949,9 @@ function observedAtCoversCurrentConfiguredCodexFindings(observedAt: string, curr
   return !latestCurrentFindingObservedAt || Date.parse(observedAt) > Date.parse(latestCurrentFindingObservedAt);
 }
 
-function hasFreshCurrentHeadCodexSuccessReviewedCurrentConfiguredFindings(args: {
+function hasFreshCurrentHeadCodexSuccessAfterActiveWaitReviewedCurrentConfiguredFindings(args: {
   pr: Parameters<typeof hasFreshCurrentHeadCodexSuccessReviewedCommit>[0];
+  record: Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha">;
   reviewThreads: ReviewThread[];
   currentConfiguredThreads: ReviewThread[];
 }): boolean {
@@ -939,7 +960,9 @@ function hasFreshCurrentHeadCodexSuccessReviewedCurrentConfiguredFindings(args: 
   }
   const successObservedAt = validTimestamp(args.pr.configuredBotCurrentHeadCodexSuccessObservedAt);
   return Boolean(
-    successObservedAt && observedAtCoversCurrentConfiguredCodexFindings(successObservedAt, args.currentConfiguredThreads),
+    successObservedAt &&
+      currentHeadTimestampSatisfiesActiveWait(args.record, args.pr, successObservedAt) &&
+      observedAtCoversCurrentConfiguredCodexFindings(successObservedAt, args.currentConfiguredThreads),
   );
 }
 
@@ -986,8 +1009,9 @@ function currentHeadCodexCleanCommentResidueEvidence(args: {
     return null;
   }
   if (
-    !hasFreshCurrentHeadCodexSuccessReviewedCurrentConfiguredFindings({
+    !hasFreshCurrentHeadCodexSuccessAfterActiveWaitReviewedCurrentConfiguredFindings({
       pr: args.pr,
+      record: args.record,
       reviewThreads: args.reviewThreads,
       currentConfiguredThreads: args.currentConfiguredThreads,
     })

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -870,7 +870,7 @@ function hasLocalOrPreMergeBlockers(
   return Boolean(
     localReviewRequiresManualReview(config, record, pr) ||
     localReviewDegradedNeedsBlock(config, record, pr) ||
-    localReviewHighSeverityNeedsBlock(config, record, pr) ||
+    (config.localReviewEnabled && localReviewHighSeverityNeedsBlock(config, record, pr)) ||
     localReviewBlocksMerge(config, record, pr),
   );
 }

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -805,8 +805,15 @@ function currentHeadCodexNoMajorSignalEvidence(args: {
     | "configuredBotCurrentHeadCodexSuccessObservedAt"
   >;
   reviewThreads: ReviewThread[];
+  currentConfiguredThreads: ReviewThread[];
 }): string | null {
-  if (hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads)) {
+  if (
+    hasFreshCurrentHeadCodexSuccessReviewedCurrentConfiguredFindings({
+      pr: args.pr,
+      reviewThreads: args.reviewThreads,
+      currentConfiguredThreads: args.currentConfiguredThreads,
+    })
+  ) {
     return "codex_pr_success_comment_reviewed_current_head";
   }
   if (!hasCurrentHeadSuccessSignal(args.pr)) {
@@ -880,6 +887,35 @@ function latestCommentIsConfiguredCodexFinding(config: SupervisorConfig, thread:
   );
 }
 
+function latestCurrentConfiguredCodexFindingObservedAt(reviewThreads: ReviewThread[]): string | null {
+  return reviewThreads.reduce<string | null>((latestObservedAt, thread) => {
+    const observedAt = validTimestamp(latestCodexConnectorReviewCommentNode(thread)?.createdAt);
+    if (!observedAt) {
+      return latestObservedAt;
+    }
+    if (!latestObservedAt || Date.parse(observedAt) > Date.parse(latestObservedAt)) {
+      return observedAt;
+    }
+    return latestObservedAt;
+  }, null);
+}
+
+function hasFreshCurrentHeadCodexSuccessReviewedCurrentConfiguredFindings(args: {
+  pr: Parameters<typeof hasFreshCurrentHeadCodexSuccessReviewedCommit>[0];
+  reviewThreads: ReviewThread[];
+  currentConfiguredThreads: ReviewThread[];
+}): boolean {
+  if (!hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads)) {
+    return false;
+  }
+  const successObservedAt = validTimestamp(args.pr.configuredBotCurrentHeadCodexSuccessObservedAt);
+  const latestCurrentFindingObservedAt = latestCurrentConfiguredCodexFindingObservedAt(args.currentConfiguredThreads);
+  return Boolean(
+    successObservedAt &&
+      (!latestCurrentFindingObservedAt || Date.parse(successObservedAt) >= Date.parse(latestCurrentFindingObservedAt)),
+  );
+}
+
 function currentHeadCodexCleanCommentResidueEvidence(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
@@ -904,7 +940,13 @@ function currentHeadCodexCleanCommentResidueEvidence(args: {
   if (hasLocalOrPreMergeBlockers(args.config, args.record, args.pr)) {
     return null;
   }
-  if (!hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads)) {
+  if (
+    !hasFreshCurrentHeadCodexSuccessReviewedCurrentConfiguredFindings({
+      pr: args.pr,
+      reviewThreads: args.reviewThreads,
+      currentConfiguredThreads: args.currentConfiguredThreads,
+    })
+  ) {
     return null;
   }
   if (
@@ -993,6 +1035,7 @@ function classifyCodexMetadataOnly(args: {
       record: args.record,
       pr: args.pr,
       reviewThreads: args.reviewThreads,
+      currentConfiguredThreads,
     }),
     currentHeadCleanCommentResidueEvidence,
     deterministicProbeEvidence: deterministicRepairProbeEvidence({

--- a/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
@@ -1541,7 +1541,7 @@ test("status --why distinguishes codex verified current-head repair residue from
 
   assert.match(
     status,
-    /^stale_review_bot_remediation issue=#399 pr=#499 reason=stale_review_bot code_ci=green current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f3 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/499#discussion_r399 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\.;codex_pr_success_comment_after_current_head_request summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
+    /^stale_review_bot_remediation issue=#399 pr=#499 reason=stale_review_bot code_ci=green current_head_sha=76060523f803ebe25832cb2c355aaaa9530502f3 processed_on_current_head=yes classification=verified_current_head_repair_pending_thread_resolution codex_current_head_review_state=observed review_thread_url=https:\/\/example\.test\/pr\/499#discussion_r399 manual_next_step=resolve_verified_repaired_configured_bot_threads_then_rerun_supervisor verification_evidence=Focused_verifier_passed_after_the_repair_commit\. summary=verified_current_head_repair_configured_bot_thread_resolution_pending$/m,
   );
   assert.doesNotMatch(status, /classification=verified_no_source_change_pending_thread_resolution/);
 });

--- a/src/supervisor/supervisor-failure-context.test.ts
+++ b/src/supervisor/supervisor-failure-context.test.ts
@@ -369,6 +369,7 @@ test("inferFailureContext preserves stalled diagnostics for legacy repeat-stop C
 
 test("inferFailureContext returns local review blocker context", () => {
   const config = createConfig({
+    localReviewEnabled: true,
     localReviewPolicy: "block_ready",
     localReviewHighSeverityAction: "blocked",
   });


### PR DESCRIPTION
## Summary
- add a guarded stale-residue proof for reviewed-current-head Codex no-major comments
- keep the proof Codex-only and fail closed for later findings, local/pre-merge blockers, P0 findings, human/unconfigured threads, and non-clean PR states
- add regression coverage for the VeriDoc #137 shape and the later-finding negative case

## Verification
- npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts
- npm run build
- git diff --check
- npx tsx --test src/supervisor/supervisor-diagnostics-explain-stale-review-bot.test.ts src/supervisor/supervisor-status-report.test.ts src/current-head-codex-repair-proof.test.ts
- npm test