### PR TITLE
Recover current-head Codex proof from terminal manual review

### DIFF
--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -71,6 +71,17 @@ test("projectCurrentHeadCodexRepairProof accepts structured P1 residue proof wit
       {
         type: "verification_result",
         gate: "codex_turn",
+        command: "npm run build",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Earlier generic build passed before the focused current-head probe.",
+        recorded_at: "2026-07-01T06:51:00Z",
+      },
+      {
+        type: "verification_result",
+        gate: "codex_turn",
         command: "python3 scripts/ci/repo_hygiene.py",
         head_sha: headSha,
         outcome: "passed",
@@ -174,6 +185,229 @@ test("projectCurrentHeadCodexRepairProof accepts thread-scoped proof after revie
     checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
     reviewThreads: threads,
   }), []);
+});
+
+test("projectCurrentHeadCodexRepairProof accepts record-scoped processed evidence with current-head clean comment", () => {
+  const headSha = "74d44b0a48f7b65fbcc9361a6509727c3ba987dc";
+  const threads = [
+    codexThread({ id: "thread-current-clean-a", commentId: "comment-current-clean-a", severity: "P1", line: 494 }),
+    codexThread({ id: "thread-current-clean-b", commentId: "comment-current-clean-b", severity: "P2", line: 826 }),
+  ];
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "python3 -m pytest tests/test_desktop_api_auth.py tests/test_poc_web_api.py -q",
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    codex_connector_review_requested_observed_at: "2026-07-01T06:41:26Z",
+    codex_connector_review_requested_head_sha: headSha,
+    processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python3 -m pytest tests/test_desktop_api_auth.py tests/test_poc_web_api.py -q",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head probe covered the stale Connector findings.",
+        recorded_at: "2026-07-01T06:52:31Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    currentHeadCiGreenAt: "2026-07-01T06:52:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-07-01T06:50:19Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "74d44b0a48",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-01T06:50:19Z",
+  });
+
+  const proof = projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+    allowRecordProcessedThreadEvidence: true,
+  });
+
+  assert.equal(proof?.source, "record_processed_thread_evidence");
+  assert.equal(proof?.localVerificationEvidenceSource, "scoped_repair_timeline_artifact_with_non_review_checks");
+  assert.equal(proof?.processedThreadEvidenceCount, 4);
+  assert.match(proof?.summary ?? "", /codex_no_major_support=codex_pr_success_comment_reviewed_current_head/);
+});
+
+test("projectCurrentHeadCodexRepairProof rejects record-scoped proof before latest thread comments", () => {
+  const headSha = "74d44b0a48f7b65fbcc9361a6509727c3ba987dc";
+  const threads = [
+    codexThread({ id: "thread-old-proof-a", commentId: "comment-old-proof-a", severity: "P2", line: 494 }),
+  ];
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run build",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "This pass predates the latest Connector finding.",
+        recorded_at: "2026-06-26T06:19:00Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    configuredBotCurrentHeadObservedAt: "2026-07-01T06:50:19Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "74d44b0a48",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-01T06:50:19Z",
+  });
+
+  const proof = projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+    allowRecordProcessedThreadEvidence: true,
+  });
+
+  assert.equal(proof, null);
+});
+
+test("projectCurrentHeadCodexRepairProof requires record evidence for outdated P1 coverage threads", () => {
+  const headSha = "74d44b0a48f7b65fbcc9361a6509727c3ba987dc";
+  const currentThread = codexThread({
+    id: "thread-current-p2",
+    commentId: "comment-current-p2",
+    severity: "P2",
+    line: 494,
+  });
+  const outdatedP1Thread = {
+    ...codexThread({
+      id: "thread-outdated-p1",
+      commentId: "comment-outdated-p1",
+      severity: "P1",
+      line: 826,
+    }),
+    isOutdated: true,
+  };
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    processed_review_thread_ids: [`${currentThread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [
+      `${currentThread.id}@${headSha}#${currentThread.comments.nodes[0]!.id}`,
+    ],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run build",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head probe covered only the current thread.",
+        recorded_at: "2026-07-01T06:52:31Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    configuredBotCurrentHeadObservedAt: "2026-07-01T06:50:19Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "74d44b0a48",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-01T06:50:19Z",
+  });
+
+  assert.equal(projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [currentThread, outdatedP1Thread],
+    allowRecordProcessedThreadEvidence: true,
+  }), null);
+});
+
+test("projectCurrentHeadCodexRepairProof rejects no-source artifacts for record-scoped repair proof", () => {
+  const headSha = "74d44b0a48f7b65fbcc9361a6509727c3ba987dc";
+  const threads = [
+    codexThread({ id: "thread-no-source-proof", commentId: "comment-no-source-proof", severity: "P2", line: 494 }),
+  ];
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    processed_review_thread_ids: threads.map((thread) => `${thread.id}@${headSha}`),
+    processed_review_thread_fingerprints: threads.map((thread) => `${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`),
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run build",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "No-source revalidation belongs to the no-source auto-resolve path.",
+        recorded_at: "2026-07-01T06:52:31Z",
+        repair_targets: ["verified_no_source_change_review_thread_residue"],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    configuredBotCurrentHeadObservedAt: "2026-07-01T06:50:19Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "74d44b0a48",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-01T06:50:19Z",
+  });
+
+  assert.equal(projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: threads,
+    allowRecordProcessedThreadEvidence: true,
+  }), null);
 });
 
 test("projectCurrentHeadCodexRepairProof rejects summary-only verification evidence", () => {

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -36,6 +36,7 @@ export const VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET =
 export type CurrentHeadCodexRepairProofSource =
   | "structured_artifact"
   | "thread_scoped_verification_artifact"
+  | "record_processed_thread_evidence"
   | "legacy_processed_thread_evidence";
 
 export interface CurrentHeadCodexRepairProofProjection {
@@ -88,6 +89,20 @@ function currentHeadCodexTurnVerificationArtifact(
       artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") !== true &&
       repairArtifactCoversCurrentThreads(artifact, pr, currentThreads),
   ) ?? null;
+}
+
+function currentHeadPassedCodexTurnArtifacts(
+  record: Pick<IssueRunRecord, "timeline_artifacts">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): TimelineArtifact[] {
+  return (record.timeline_artifacts ?? []).filter(
+    (artifact) =>
+      artifact.type === "verification_result" &&
+      artifact.gate === "codex_turn" &&
+      artifact.outcome === "passed" &&
+      artifact.head_sha === pr.headRefOid &&
+      artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") !== true,
+  );
 }
 
 function currentHeadThreadScopedVerificationArtifacts(
@@ -458,6 +473,7 @@ export function projectCurrentHeadCodexRepairProof(args: {
   pr: GitHubPullRequest;
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
+  allowRecordProcessedThreadEvidence?: boolean;
 }): CurrentHeadCodexRepairProofProjection | null {
   if (!projectionSafetyGatesPass(args)) {
     return null;
@@ -566,6 +582,55 @@ export function projectCurrentHeadCodexRepairProof(args: {
     };
   }
 
+  const recordProcessedThreadEvidenceCount = headScopedProcessedThreadEvidenceCount(args.record, args.pr);
+  if (
+    args.allowRecordProcessedThreadEvidence === true &&
+    noMajorSupport &&
+    recordProcessedThreadEvidenceCount > 0 &&
+    proofCoverageThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
+  ) {
+    const recordScopedProof = currentHeadPassedCodexTurnArtifacts(args.record, args.pr)
+      .filter((artifact) =>
+        proofCoverageThreads.every((thread) => latestReviewThreadCommentPredatesArtifact(thread, artifact))
+      )
+      .map((artifact) => {
+        const localVerificationEvidence = configuredLocalCiRequired
+          ? currentHeadLocalVerificationEvidence({
+              config: args.config,
+              record: args.record,
+              pr: args.pr,
+              checks: args.checks,
+              scopedTimelineArtifact: artifact,
+            })
+          : null;
+        if (configuredLocalCiRequired && !localVerificationEvidence) {
+          return null;
+        }
+        return {
+          artifact,
+          localVerificationEvidence,
+        };
+      })
+      .find((proof): proof is {
+        artifact: TimelineArtifact;
+        localVerificationEvidence: CurrentHeadLocalVerificationEvidence | null;
+      } => proof !== null);
+    if (recordScopedProof) {
+      return {
+        source: "record_processed_thread_evidence",
+        summary: formatThreadScopedVerificationSummary({
+          artifact: recordScopedProof.artifact,
+          localVerificationEvidence: recordScopedProof.localVerificationEvidence,
+          noMajorSupport,
+        }),
+        localVerificationEvidenceSource: recordScopedProof.localVerificationEvidence?.source ?? null,
+        localVerificationEvidenceSummary: recordScopedProof.localVerificationEvidence?.summary ?? null,
+        processedThreadEvidenceCount: recordProcessedThreadEvidenceCount,
+        currentConfiguredThreadCount: repairResidueThreads.length,
+      };
+    }
+  }
+
   const unscopedLocalVerificationEvidence = configuredLocalCiRequired
     ? currentHeadLocalVerificationEvidence({
         config: args.config,
@@ -579,7 +644,7 @@ export function projectCurrentHeadCodexRepairProof(args: {
     return null;
   }
 
-  const processedThreadEvidenceCount = headScopedProcessedThreadEvidenceCount(args.record, args.pr);
+  const processedThreadEvidenceCount = recordProcessedThreadEvidenceCount;
   if (processedThreadEvidenceCount === 0) {
     return null;
   }

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -3463,6 +3463,526 @@ test("reconcileRecoverableBlockedIssueStates replays reviewed-current-head no-ma
   ]);
 });
 
+test("reconcileRecoverableBlockedIssueStates persists current-head clean proof after terminal manual review", async () => {
+  const headSha = "74d44b0a48f7b65fbcc9361a6509727c3ba987dc";
+  const threadA = "PRRT_kwDOTAxt0M6Ndr2b";
+  const threadB = "PRRT_kwDOTAxt0M6NeErE";
+  const command = "python3 -m pytest tests/test_desktop_api_auth.py tests/test_poc_web_api.py -q";
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    localCiCommand: command,
+    staleConfiguredBotReviewPolicy: "reply_only",
+  });
+  const original = createRecord({
+    issue_number: 147,
+    state: "blocked",
+    blocked_reason: "manual_review",
+    pr_number: 156,
+    last_head_sha: headSha,
+    last_error:
+      "2 configured bot review thread(s) remain unresolved after processing on the current head without measurable progress and now require manual attention.",
+    last_failure_signature: threadA,
+    repeated_failure_signature_count: 3,
+    last_tracked_pr_progress_snapshot: JSON.stringify({
+      headRefOid: headSha,
+      mergeStateStatus: "CLEAN",
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotTopLevelReviewStrength: null,
+      configuredBotTopLevelReviewSubmittedAt: null,
+      checks: ["Minimal checks:pass:SUCCESS:CI"],
+      unresolvedReviewThreadIds: [threadA, threadB],
+      processedReviewThreadIds: [`${threadA}@${headSha}`, `${threadB}@${headSha}`],
+      verificationProbeOutcomes: [`codex_turn:${command}:passed:none`],
+    }),
+    last_tracked_pr_progress_summary: "no_meaningful_tracked_pr_progress",
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    processed_review_thread_ids: [`${threadA}@${headSha}`, `${threadB}@${headSha}`],
+    processed_review_thread_fingerprints: [
+      `${threadA}@${headSha}#comment-stale-p1`,
+      `${threadB}@${headSha}#comment-stale-p2`,
+    ],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command,
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head probe covered the stale Connector findings.",
+        recorded_at: "2026-07-01T06:52:31Z",
+      },
+    ],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+  const issue = createIssue({
+    number: 147,
+    title: "P5-09 terminal security acceptance",
+    updatedAt: "2026-07-01T07:22:42Z",
+  });
+  const pr = createPullRequest({
+    number: 156,
+    title: "P5-09 terminal security acceptance",
+    url: "https://example.test/pr/156",
+    headRefName: "codex/issue-147",
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    currentHeadCiGreenAt: "2026-07-01T06:52:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-07-01T06:50:19Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "74d44b0a48",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-01T06:50:19Z",
+  });
+  const stateStore = createCountingStateStore("2026-07-01T07:25:00Z");
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [
+        createReviewThread({
+          id: threadA,
+          path: "apps/desktop/api_client.py",
+          line: 494,
+          comments: {
+            nodes: [{
+              id: "comment-stale-p1",
+              body: "P1: Allow result-save audits to recover cleanly.",
+              createdAt: "2026-07-01T03:52:01Z",
+              url: "https://example.test/pr/156#discussion_r3503170216",
+              author: { login: "chatgpt-codex-connector", typeName: "Bot" },
+            }],
+          },
+        }),
+        createReviewThread({
+          id: threadB,
+          path: "services/api/poc_web.py",
+          line: 826,
+          comments: {
+            nodes: [{
+              id: "comment-stale-p2",
+              body: "P2: Make creator publish idempotent.",
+              createdAt: "2026-07-01T04:36:26Z",
+              url: "https://example.test/pr/156#discussion_r3503310471",
+              author: { login: "chatgpt-codex-connector", typeName: "Bot" },
+            }],
+          },
+        }),
+      ],
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["147"];
+  assert.equal(updated.state, "ready_to_merge");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.provider_success_head_sha, headSha);
+  assert.ok(updated.provider_success_observed_at);
+  assert.equal(updated.last_tracked_pr_progress_snapshot, null);
+  assert.equal(updated.last_tracked_pr_progress_summary, null);
+  assert.equal(stateStore.saveCalls, 1);
+  assert.deepEqual(recoveryEvents.map((event) => event.reason), [
+    `tracked_pr_lifecycle_recovered: resumed issue #147 from blocked to ready_to_merge using fresh tracked PR #156 facts at head ${headSha}`,
+  ]);
+});
+
+test("reconcileRecoverableBlockedIssueStates does not promote required reviews with record-scoped proof", async () => {
+  const headSha = "74d44b0a48f7b65fbcc9361a6509727c3ba987dc";
+  const threadId = "thread-required-review-proof";
+  const commentId = "comment-required-review-proof";
+  const command = "npm run build";
+  const config = createConfig({
+    humanReviewBlocksMerge: false,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    localCiCommand: command,
+  });
+  const original = createRecord({
+    issue_number: 148,
+    state: "blocked",
+    blocked_reason: "manual_review",
+    pr_number: 157,
+    last_head_sha: headSha,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    processed_review_thread_ids: [`${threadId}@${headSha}`],
+    processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command,
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head probe covered the Connector finding.",
+        recorded_at: "2026-07-01T06:52:31Z",
+      },
+    ],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+  const issue = createIssue({ number: 148, updatedAt: "2026-07-01T07:22:42Z" });
+  const pr = createPullRequest({
+    number: 157,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: "REVIEW_REQUIRED",
+    configuredBotCurrentHeadObservedAt: "2026-07-01T06:50:19Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "74d44b0a48",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-01T06:50:19Z",
+  });
+  const stateStore = createCountingStateStore("2026-07-01T07:25:00Z");
+
+  await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [
+        createReviewThread({
+          id: threadId,
+          comments: {
+            nodes: [{
+              id: commentId,
+              body: "P2: Keep required-review PRs out of ready promotion.",
+              createdAt: "2026-07-01T03:52:01Z",
+              url: "https://example.test/pr/157#discussion_required",
+              author: { login: "chatgpt-codex-connector", typeName: "Bot" },
+            }],
+          },
+        }),
+      ],
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  assert.equal(state.issues["148"].state, "addressing_review");
+  assert.equal(state.issues["148"].blocked_reason, null);
+});
+
+test("reconcileRecoverableBlockedIssueStates does not promote changes-requested reviews with record-scoped proof", async () => {
+  const headSha = "74d44b0a48f7b65fbcc9361a6509727c3ba987dc";
+  const threadId = "thread-changes-requested-proof";
+  const commentId = "comment-changes-requested-proof";
+  const command = "npm run build";
+  const config = createConfig({
+    humanReviewBlocksMerge: false,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    localCiCommand: command,
+  });
+  const original = createRecord({
+    issue_number: 150,
+    state: "blocked",
+    blocked_reason: "manual_review",
+    pr_number: 159,
+    last_head_sha: headSha,
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    processed_review_thread_ids: [`${threadId}@${headSha}`],
+    processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command,
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head probe covered the Connector finding.",
+        recorded_at: "2026-07-01T06:52:31Z",
+      },
+    ],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+  const issue = createIssue({ number: 150, updatedAt: "2026-07-01T07:22:42Z" });
+  const pr = createPullRequest({
+    number: 159,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: "CHANGES_REQUESTED",
+    configuredBotCurrentHeadObservedAt: "2026-07-01T06:50:19Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "74d44b0a48",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-01T06:50:19Z",
+  });
+  const stateStore = createCountingStateStore("2026-07-01T07:25:00Z");
+
+  await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [
+        createReviewThread({
+          id: threadId,
+          comments: {
+            nodes: [{
+              id: commentId,
+              body: "P2: Keep changes-requested PRs out of ready promotion.",
+              createdAt: "2026-07-01T03:52:01Z",
+              url: "https://example.test/pr/159#discussion_changes_requested",
+              author: { login: "chatgpt-codex-connector", typeName: "Bot" },
+            }],
+          },
+        }),
+      ],
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  assert.equal(state.issues["150"].state, "blocked");
+  assert.equal(state.issues["150"].blocked_reason, "manual_review");
+});
+
+test("reconcileRecoverableBlockedIssueStates requires stop-no-progress for record-scoped proof recovery", async () => {
+  const headSha = "74d44b0a48f7b65fbcc9361a6509727c3ba987dc";
+  const threadId = "thread-non-terminal-proof";
+  const commentId = "comment-non-terminal-proof";
+  const command = "npm run build";
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    localCiCommand: command,
+  });
+  const original = createRecord({
+    issue_number: 151,
+    state: "blocked",
+    blocked_reason: "manual_review",
+    pr_number: 160,
+    last_head_sha: headSha,
+    last_tracked_pr_repeat_failure_decision: null,
+    processed_review_thread_ids: [`${threadId}@${headSha}`],
+    processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command,
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head probe covered the Connector finding.",
+        recorded_at: "2026-07-01T06:52:31Z",
+      },
+    ],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+  const issue = createIssue({ number: 151, updatedAt: "2026-07-01T07:22:42Z" });
+  const pr = createPullRequest({
+    number: 160,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    configuredBotCurrentHeadObservedAt: "2026-07-01T06:50:19Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "74d44b0a48",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-01T06:50:19Z",
+  });
+  const stateStore = createCountingStateStore("2026-07-01T07:25:00Z");
+
+  await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [
+        createReviewThread({
+          id: threadId,
+          comments: {
+            nodes: [{
+              id: commentId,
+              body: "P2: Non-terminal manual review should remain on the normal repair path.",
+              createdAt: "2026-07-01T03:52:01Z",
+              url: "https://example.test/pr/160#discussion_non_terminal",
+              author: { login: "chatgpt-codex-connector", typeName: "Bot" },
+            }],
+          },
+        }),
+      ],
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  assert.equal(state.issues["151"].state, "addressing_review");
+  assert.equal(state.issues["151"].blocked_reason, null);
+  assert.equal(state.issues["151"].provider_success_head_sha, null);
+});
+
+test("reconcileRecoverableBlockedIssueStates preserves local manual review blocks despite record-scoped proof", async () => {
+  const headSha = "74d44b0a48f7b65fbcc9361a6509727c3ba987dc";
+  const threadId = "thread-local-review-proof";
+  const commentId = "comment-local-review-proof";
+  const command = "npm run build";
+  const config = createConfig({
+    humanReviewBlocksMerge: false,
+    localReviewEnabled: true,
+    localReviewPolicy: "block_merge",
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    localCiCommand: command,
+  });
+  const failureContext = {
+    category: "review" as const,
+    summary: "Local pre-merge review still requires manual review.",
+    signature: "local-review:manual",
+    command: null,
+    details: ["pre_merge_evaluation_outcome=manual_review_blocked"],
+    url: null,
+    updated_at: "2026-07-01T07:25:00Z",
+  };
+  const original = createRecord({
+    issue_number: 149,
+    state: "blocked",
+    blocked_reason: "manual_review",
+    pr_number: 158,
+    last_head_sha: headSha,
+    pre_merge_evaluation_outcome: "manual_review_blocked",
+    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    processed_review_thread_ids: [`${threadId}@${headSha}`],
+    processed_review_thread_fingerprints: [`${threadId}@${headSha}#${commentId}`],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command,
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Focused current-head probe covered the Connector finding.",
+        recorded_at: "2026-07-01T06:52:31Z",
+      },
+    ],
+  });
+  const state: SupervisorStateFile = createSupervisorState({
+    issues: [original],
+  });
+  const issue = createIssue({ number: 149, updatedAt: "2026-07-01T07:22:42Z" });
+  const pr = createPullRequest({
+    number: 158,
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    configuredBotCurrentHeadObservedAt: "2026-07-01T06:50:19Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "74d44b0a48",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-01T06:50:19Z",
+  });
+  const stateStore = createCountingStateStore("2026-07-01T07:25:00Z");
+
+  await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      getUnresolvedReviewThreads: async () => [
+        createReviewThread({
+          id: threadId,
+          comments: {
+            nodes: [{
+              id: commentId,
+              body: "P2: Connector proof exists but local review still blocks.",
+              createdAt: "2026-07-01T03:52:01Z",
+              url: "https://example.test/pr/158#discussion_local_review",
+              author: { login: "chatgpt-codex-connector", typeName: "Bot" },
+            }],
+          },
+        }),
+      ],
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "blocked",
+      inferFailureContext: () => failureContext,
+      blockedReasonForLifecycleState: () => "manual_review",
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  assert.equal(state.issues["149"].state, "blocked");
+  assert.equal(state.issues["149"].blocked_reason, "manual_review");
+  assert.equal(state.issues["149"].pre_merge_evaluation_outcome, "manual_review_blocked");
+});
+
 test("reconcileRecoverableBlockedIssueStates ignores human replies when comparing same-head Codex Connector churn guidance", async () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector"],

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -593,7 +593,7 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         syncCopilotReviewRequestObservation: syncCopilotReviewRequestObservationImpl,
         syncCopilotReviewTimeoutState: syncCopilotReviewTimeoutStateImpl,
       });
-      const nextState = projection.nextState;
+      let nextState = projection.nextState;
       if (projection.shouldSuppressRecovery) {
         continue;
       }
@@ -602,18 +602,49 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
         nextState !== "blocked" &&
         hasOnlyOutdatedConfiguredBotResidue(config, reviewThreads);
+      const blockedManualReviewProjectionRecoverableByCurrentHeadProof =
+        projection.nextBlockedReason === "manual_review" &&
+        record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
+        record.pre_merge_evaluation_outcome !== "manual_review_blocked";
       const sameHeadCurrentHeadRepairProofRecovery =
         record.blocked_reason === "manual_review" &&
         record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
         record.last_head_sha === trackedPullRequest.headRefOid &&
-        nextState !== "blocked" &&
+        (nextState !== "blocked" || blockedManualReviewProjectionRecoverableByCurrentHeadProof) &&
         projectCurrentHeadCodexRepairProof({
           config,
           record: projection.recordForState,
           pr: trackedPullRequest,
           checks,
           reviewThreads,
+          allowRecordProcessedThreadEvidence: true,
         }) !== null;
+      const sameHeadCurrentHeadRepairProofPromotesReady =
+        sameHeadCurrentHeadRepairProofRecovery &&
+        (
+          nextState === "addressing_review" ||
+          (nextState === "blocked" && projection.nextBlockedReason === "manual_review")
+        ) &&
+        trackedPullRequest.state === "OPEN" &&
+        !trackedPullRequest.isDraft &&
+        trackedPullRequest.reviewDecision !== "REVIEW_REQUIRED" &&
+        trackedPullRequest.reviewDecision !== "CHANGES_REQUESTED" &&
+        trackedPullRequest.mergeStateStatus === "CLEAN";
+      if (sameHeadCurrentHeadRepairProofPromotesReady) {
+        nextState = "ready_to_merge";
+      }
+      const currentHeadRepairProofMergeLatencyVisibilityPatch: Partial<IssueRunRecord> =
+        sameHeadCurrentHeadRepairProofRecovery
+          ? {
+            ...projection.mergeLatencyVisibilityPatch,
+            provider_success_head_sha: trackedPullRequest.headRefOid,
+            provider_success_observed_at:
+              projection.mergeLatencyVisibilityPatch.provider_success_observed_at ??
+              trackedPullRequest.configuredBotCurrentHeadObservedAt ??
+              trackedPullRequest.currentHeadCiGreenAt ??
+              record.provider_success_observed_at,
+          }
+          : projection.mergeLatencyVisibilityPatch;
       const recoverySuppression = staleLocalManualReviewResidueRecovery || sameHeadCurrentHeadRepairProofRecovery
         ? {
             shouldSuppress: false,
@@ -734,6 +765,10 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
       if (nextState === "blocked" || preserveDraftReadyPromotionBlocker) {
         const headAdvanceResetPatch = resetTrackedPrHeadScopedStateOnAdvance(record, trackedPullRequest.headRefOid);
         const headAdvanced = Object.keys(headAdvanceResetPatch).length > 0;
+        const blockedMergeLatencyVisibilityPatch =
+          projection.mergeLatencyVisibilityPatch.provider_success_head_sha !== null
+            ? projection.mergeLatencyVisibilityPatch
+            : {};
         const blockerSemanticsChanged =
           headAdvanced
           || nextBlockedReason !== record.blocked_reason
@@ -766,6 +801,7 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
           ...projection.reviewWaitPatch,
           ...projection.copilotReviewRequestObservationPatch,
           ...projection.copilotReviewTimeoutPatch,
+          ...blockedMergeLatencyVisibilityPatch,
         };
         const nextPatch = blockerSemanticsChanged
           ? {
@@ -795,7 +831,7 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         codexConnectorReviewRequestObservationPatch: projection.codexConnectorReviewRequestObservationPatch,
         copilotReviewRequestObservationPatch: projection.copilotReviewRequestObservationPatch,
         copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
-        mergeLatencyVisibilityPatch: projection.mergeLatencyVisibilityPatch,
+        mergeLatencyVisibilityPatch: currentHeadRepairProofMergeLatencyVisibilityPatch,
       });
       if (!staleLocalManualReviewResidueRecovery && effectiveRecoverySuppression.progressSummary !== null) {
         patch.last_tracked_pr_progress_summary = effectiveRecoverySuppression.progressSummary;


### PR DESCRIPTION
## Summary
- allow blocked manual-review recovery to opt into record-scoped processed thread evidence when a current-head Codex clean comment and focused codex_turn verification are present
- promote that same-head recovery back to ready_to_merge and persist provider-success visibility instead of returning to addressing_review
- keep the broader PR-state and stale-remediation proof paths on the existing stricter artifact-scoped behavior

Fixes #2399.

## Verification
- npx tsx --test src/current-head-codex-repair-proof.test.ts src/recovery-blocked-issue-reconciliation.test.ts
- npx tsx --test src/pull-request-state-policy.test.ts src/supervisor/stale-review-bot-remediation.test.ts src/supervisor/supervisor-diagnostics-explain-stale-review-bot.test.ts
- npm run build
- git diff --check