### PR TITLE
Handle top-level Codex review findings

### DIFF
--- a/src/codex-connector-review-churn.ts
+++ b/src/codex-connector-review-churn.ts
@@ -10,6 +10,10 @@ import {
   codexConnectorStaleReviewCommitThreads,
   latestCodexConnectorPSeverity,
 } from "./codex-connector-review-policy";
+import {
+  codexConnectorMustFixTopLevelReviewFindings,
+  type CodexConnectorTopLevelReviewFinding,
+} from "./codex-connector-top-level-review";
 
 export interface CodexConnectorReviewChurnDiagnostic {
   mustFixCount: number;
@@ -166,10 +170,10 @@ function extractReviewCommentSummary(body: string): string {
 }
 
 export function buildCodexConnectorMustFixFindingDetails(args: {
-  pr: Pick<GitHubPullRequest, "number" | "headRefOid"> | null;
+  pr: Pick<GitHubPullRequest, "number" | "headRefOid" | "configuredBotTopLevelReviewFindings"> | null;
   reviewThreads: ReviewThread[];
 }): string[] {
-  return clusterConfiguredBotReviewThreads(codexConnectorMustFixReviewThreads(args.reviewThreads)).map((cluster, index) => {
+  const threadDetails = clusterConfiguredBotReviewThreads(codexConnectorMustFixReviewThreads(args.reviewThreads)).map((cluster, index) => {
     const representativeThread = cluster.threads[0];
     const latestComment = latestCodexConnectorReviewCommentNode(representativeThread) ?? latestReviewComment(representativeThread);
     const lineRange = representativeThread.line == null ? "unknown" : String(representativeThread.line);
@@ -197,6 +201,43 @@ export function buildCodexConnectorMustFixFindingDetails(args: {
         .join("; ")}`,
     ].join("\n");
   });
+  const topLevelFindings = codexConnectorMustFixTopLevelReviewFindings(
+    args.pr?.configuredBotTopLevelReviewFindings ?? [],
+  );
+  const topLevelDetails = topLevelFindings.map((finding, index) =>
+    formatTopLevelFindingDetail({
+      finding,
+      index: threadDetails.length + index + 1,
+      pr: args.pr,
+    }),
+  );
+  return [...threadDetails, ...topLevelDetails];
+}
+
+function formatTopLevelFindingDetail(args: {
+  finding: CodexConnectorTopLevelReviewFinding;
+  index: number;
+  pr: Pick<GitHubPullRequest, "number" | "headRefOid"> | null;
+}): string {
+  const lineRange =
+    args.finding.lineEnd > args.finding.line ? `${args.finding.line}-${args.finding.lineEnd}` : String(args.finding.line);
+  return [
+    `- Root-cause repair group ${args.index}`,
+    `  Policy: Codex Connector must_fix_remaining`,
+    `  Source: top_level_codex_review_comment`,
+    `  Severity: ${args.finding.severity}`,
+    `  PR: ${args.pr ? `#${args.pr.number}` : "unknown"}`,
+    `  Head SHA: ${args.pr?.headRefOid ?? args.finding.headSha}`,
+    `  Finding ID: ${args.finding.id}`,
+    `  Affected files: ${args.finding.path}`,
+    `  Representative source URLs: ${args.finding.sourceUrl}`,
+    `  Source URL: ${args.finding.commentUrl ?? args.finding.sourceUrl}`,
+    `  File: ${args.finding.path}`,
+    `  Line range: ${lineRange}`,
+    `  Summary: ${args.finding.title}`,
+    `  Latest relevant comment: ${extractReviewCommentSummary(args.finding.body)}`,
+    `  Evidence: ${args.finding.id} ${args.finding.path}:${lineRange} ${args.finding.sourceUrl}`,
+  ].join("\n");
 }
 
 export interface ConfiguredBotReviewThreadCluster {

--- a/src/codex-connector-review-policy.test.ts
+++ b/src/codex-connector-review-policy.test.ts
@@ -73,6 +73,41 @@ test("Codex Connector policy classifies must-fix, nitpick, and stale review comm
   });
 });
 
+test("Codex Connector convergence treats top-level Codex Review comment findings as must-fix", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const result = evaluateCodexConnectorConvergencePolicy(
+    config,
+    {
+      configuredBotCurrentHeadObservedAt: null,
+      configuredBotTopLevelReviewFindings: [
+        {
+          id: "IC_kw:finding:1",
+          commentId: "IC_kw",
+          commentDatabaseId: 4884683854,
+          commentCreatedAt: "2026-07-05T03:19:37Z",
+          commentUrl: "https://example.test/pr/219#issuecomment-4884683854",
+          sourceUrl: "https://example.test/blob/head-sha/datasets/poc_evaluation_manifest_v1.json#L139-L140",
+          path: "datasets/poc_evaluation_manifest_v1.json",
+          line: 139,
+          lineEnd: 140,
+          headSha: "head-sha",
+          severity: "P2",
+          title: "Link the text-PDF sample to a PDF fixture",
+          body: "The sample resolves to parser-output JSON instead of a real PDF upload.",
+          authorLogin: "chatgpt-codex-connector",
+          fingerprint: "IC_kw|head-sha|datasets/poc_evaluation_manifest_v1.json|139|P2|link",
+        },
+      ],
+    },
+    [],
+  );
+
+  assert.equal(result?.outcome, "must_fix_remaining");
+  assert.equal(result?.mergeEffect, "blocked");
+  assert.equal(result?.findingCount, 1);
+  assert.equal(result?.highestSeverity, "P2");
+});
+
 test("review policy input snapshots provider, PR, thread vocabulary, and processed evidence", () => {
   const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
   const p2Thread = codexThread({

--- a/src/codex-connector-review-policy.test.ts
+++ b/src/codex-connector-review-policy.test.ts
@@ -108,6 +108,51 @@ test("Codex Connector convergence treats top-level Codex Review comment findings
   assert.equal(result?.highestSeverity, "P2");
 });
 
+test("Codex Connector policy block reports top-level finding location when it owns the highest severity", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const p2Thread = codexThread({
+    id: "thread-p2",
+    path: "src/thread-target.ts",
+    line: 88,
+    body: "P2: Preserve failed restore cleanup as a blocking verification failure.",
+  });
+
+  assert.deepEqual(
+    buildCodexConnectorPolicyBlockDiagnostic(config, [p2Thread], {
+      headRefOid: "head-sha",
+      configuredBotCurrentHeadObservedAt: "2026-07-05T03:19:37Z",
+      configuredBotLatestReviewedCommitSha: "head-sha",
+      configuredBotTopLevelReviewFindings: [
+        {
+          id: "IC_kw:finding:1",
+          commentId: "IC_kw",
+          commentDatabaseId: 4884683854,
+          commentCreatedAt: "2026-07-05T03:19:37Z",
+          commentUrl: "https://example.test/pr/219#issuecomment-4884683854",
+          sourceUrl: "https://example.test/blob/head-sha/src/top-level-target.ts#L12-L13",
+          path: "src/top-level-target.ts",
+          line: 12,
+          lineEnd: 13,
+          headSha: "head-sha",
+          severity: "P0",
+          title: "Do not drop persisted review findings",
+          body: "This can drop blocking findings from replayed decisions.",
+          authorLogin: "chatgpt-codex-connector",
+          fingerprint: "IC_kw|head-sha|src/top-level-target.ts|12|P0|drop",
+        },
+      ],
+    }),
+    {
+      count: 2,
+      severity: "P0",
+      file: "src/top-level-target.ts",
+      line: "12-13",
+      threadUrl: "https://example.test/blob/head-sha/src/top-level-target.ts#L12-L13",
+      nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path",
+    },
+  );
+});
+
 test("review policy input snapshots provider, PR, thread vocabulary, and processed evidence", () => {
   const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
   const p2Thread = codexThread({

--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -818,6 +818,21 @@ export function buildCodexConnectorPolicyBlockDiagnostic(
       .filter((candidate): candidate is CodexConnectorPSeverity => candidate !== null),
     ...topLevelMustFixFindings.map((finding) => finding.severity),
   ]);
+  const threadHasSelectedSeverity = mustFixThreads.some((thread) => latestCodexConnectorPSeverity(thread) === severity);
+  const representativeTopLevelFinding = topLevelMustFixFindings.find((finding) => finding.severity === severity) ?? null;
+  if (!threadHasSelectedSeverity && representativeTopLevelFinding) {
+    return {
+      count: mustFixThreads.length + topLevelMustFixFindings.length,
+      severity,
+      file: formatDiagnosticToken(representativeTopLevelFinding.path),
+      line:
+        representativeTopLevelFinding.lineEnd > representativeTopLevelFinding.line
+          ? `${representativeTopLevelFinding.line}-${representativeTopLevelFinding.lineEnd}`
+          : String(representativeTopLevelFinding.line),
+      threadUrl: formatDiagnosticToken(representativeTopLevelFinding.sourceUrl),
+      nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path",
+    };
+  }
   const representativeThread =
     mustFixThreads.find((thread) => latestCodexConnectorPSeverity(thread) === severity) ?? mustFixThreads[0];
   const latestComment = latestReviewComment(representativeThread);

--- a/src/codex-connector-review-policy.ts
+++ b/src/codex-connector-review-policy.ts
@@ -17,6 +17,10 @@ import {
   hasCodexConnectorStrongRiskWording,
   isCodexConnectorReviewer,
 } from "./external-review/external-review-normalization";
+import {
+  codexConnectorMustFixTopLevelReviewFindings,
+  codexConnectorNitpickTopLevelReviewFindings,
+} from "./codex-connector-top-level-review";
 
 export type ReviewPolicyThreadVocabulary =
   | "current_head_thread"
@@ -624,8 +628,15 @@ function codexConnectorPSeverityRank(severity: CodexConnectorPSeverity): number 
 }
 
 function maxCodexConnectorPSeverity(threads: ReviewThread[]): CodexConnectorPSeverity {
-  return threads
-    .map((thread) => latestCodexConnectorPSeverity(thread))
+  return maxCodexConnectorPSeverityFromValues(
+    threads
+      .map((thread) => latestCodexConnectorPSeverity(thread))
+      .filter((severity): severity is CodexConnectorPSeverity => severity !== null),
+  );
+}
+
+function maxCodexConnectorPSeverityFromValues(severities: CodexConnectorPSeverity[]): CodexConnectorPSeverity {
+  return severities
     .filter((severity): severity is CodexConnectorPSeverity => severity !== null)
     .sort((left, right) => codexConnectorPSeverityRank(left) - codexConnectorPSeverityRank(right))[0] ?? "P3";
 }
@@ -688,7 +699,10 @@ function buildDiagnosticReviewPolicyInput(
 
 export function evaluateCodexConnectorConvergencePolicy(
   config: SupervisorConfig,
-  pr: Pick<GitHubPullRequest, "configuredBotCurrentHeadObservedAt">,
+  pr: Pick<
+    GitHubPullRequest,
+    "configuredBotCurrentHeadObservedAt" | "configuredBotTopLevelReviewFindings"
+  >,
   reviewThreads: ReviewThread[],
 ): CodexConnectorConvergencePolicyResult | null {
   if (!configuredReviewProviderKinds(config).includes("codex")) {
@@ -696,8 +710,11 @@ export function evaluateCodexConnectorConvergencePolicy(
   }
 
   const mustFixThreads = codexConnectorMustFixReviewThreads(reviewThreads);
-  const mustFixCount = mustFixThreads.length;
-  const nitpickCount = codexConnectorNitpickOnlyReviewThreads(reviewThreads).length;
+  const topLevelFindings = pr.configuredBotTopLevelReviewFindings ?? [];
+  const mustFixTopLevelFindings = codexConnectorMustFixTopLevelReviewFindings(topLevelFindings);
+  const nitpickTopLevelFindings = codexConnectorNitpickTopLevelReviewFindings(topLevelFindings);
+  const mustFixCount = mustFixThreads.length + mustFixTopLevelFindings.length;
+  const nitpickCount = codexConnectorNitpickOnlyReviewThreads(reviewThreads).length + nitpickTopLevelFindings.length;
   const currentHeadObservedAt = validPolicyTimestamp(pr.configuredBotCurrentHeadObservedAt);
   const findingCount = mustFixCount + nitpickCount;
   if (mustFixCount > 0) {
@@ -706,7 +723,12 @@ export function evaluateCodexConnectorConvergencePolicy(
       currentHeadObservedAt,
       findingCount,
       mergeEffect: "blocked",
-      highestSeverity: maxCodexConnectorPSeverity(mustFixThreads),
+      highestSeverity: maxCodexConnectorPSeverityFromValues([
+        ...mustFixThreads
+          .map((thread) => latestCodexConnectorPSeverity(thread))
+          .filter((severity): severity is CodexConnectorPSeverity => severity !== null),
+        ...mustFixTopLevelFindings.map((finding) => finding.severity),
+      ]),
       nextAction: "repair_must_fix_findings",
       mustFixCount,
     };
@@ -748,28 +770,59 @@ export function evaluateCodexConnectorConvergencePolicy(
 export function buildCodexConnectorPolicyBlockDiagnostic(
   config: SupervisorConfig,
   reviewThreads: ReviewThread[],
-  pr?: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
+  pr?: Pick<
+    GitHubPullRequest,
+    | "headRefOid"
+    | "configuredBotCurrentHeadObservedAt"
+    | "configuredBotLatestReviewedCommitSha"
+    | "configuredBotTopLevelReviewFindings"
+  >,
 ): CodexConnectorPolicyBlockDiagnostic | null {
   if (!configuredReviewProviderKinds(config).includes("codex")) {
     return null;
   }
   const policyInput = buildDiagnosticReviewPolicyInput(config, reviewThreads, pr);
+  const topLevelMustFixFindings = codexConnectorMustFixTopLevelReviewFindings(
+    pr?.configuredBotTopLevelReviewFindings ?? [],
+  );
   const currentHeadMustFixThreadIds = new Set(
     policyInput.threads
       .filter((thread) => thread.boundaryOutcome === "must_fix_current_head" || thread.boundaryOutcome === "escalated_p3")
       .map((thread) => thread.id),
   );
   const mustFixThreads = reviewThreads.filter((thread) => currentHeadMustFixThreadIds.has(thread.id));
-  if (mustFixThreads.length === 0) {
+  if (mustFixThreads.length === 0 && topLevelMustFixFindings.length === 0) {
     return null;
   }
 
-  const severity = maxCodexConnectorPSeverity(mustFixThreads);
+  if (mustFixThreads.length === 0) {
+    const severity = maxCodexConnectorPSeverityFromValues(topLevelMustFixFindings.map((finding) => finding.severity));
+    const representativeFinding =
+      topLevelMustFixFindings.find((finding) => finding.severity === severity) ?? topLevelMustFixFindings[0]!;
+    return {
+      count: topLevelMustFixFindings.length,
+      severity,
+      file: formatDiagnosticToken(representativeFinding.path),
+      line:
+        representativeFinding.lineEnd > representativeFinding.line
+          ? `${representativeFinding.line}-${representativeFinding.lineEnd}`
+          : String(representativeFinding.line),
+      threadUrl: formatDiagnosticToken(representativeFinding.sourceUrl),
+      nextAction: "fix_on_new_head_or_wait_for_github_thread_resolution_or_use_explicit_manual_operator_path",
+    };
+  }
+
+  const severity = maxCodexConnectorPSeverityFromValues([
+    ...mustFixThreads
+      .map((thread) => latestCodexConnectorPSeverity(thread))
+      .filter((candidate): candidate is CodexConnectorPSeverity => candidate !== null),
+    ...topLevelMustFixFindings.map((finding) => finding.severity),
+  ]);
   const representativeThread =
     mustFixThreads.find((thread) => latestCodexConnectorPSeverity(thread) === severity) ?? mustFixThreads[0];
   const latestComment = latestReviewComment(representativeThread);
   return {
-    count: mustFixThreads.length,
+    count: mustFixThreads.length + topLevelMustFixFindings.length,
     severity,
     file: formatDiagnosticToken(representativeThread.path ?? "unknown"),
     line: representativeThread.line == null ? "unknown" : String(representativeThread.line),
@@ -781,7 +834,13 @@ export function buildCodexConnectorPolicyBlockDiagnostic(
 export function buildCodexConnectorP2P3PolicyDiagnostic(
   config: SupervisorConfig,
   reviewThreads: ReviewThread[],
-  pr?: Pick<GitHubPullRequest, "headRefOid" | "configuredBotCurrentHeadObservedAt" | "configuredBotLatestReviewedCommitSha">,
+  pr?: Pick<
+    GitHubPullRequest,
+    | "headRefOid"
+    | "configuredBotCurrentHeadObservedAt"
+    | "configuredBotLatestReviewedCommitSha"
+    | "configuredBotTopLevelReviewFindings"
+  >,
 ): CodexConnectorP2P3PolicyDiagnostic | null {
   if (!configuredReviewProviderKinds(config).includes("codex")) {
     return null;
@@ -803,6 +862,16 @@ export function buildCodexConnectorP2P3PolicyDiagnostic(
     } else if (thread.boundaryOutcome === "escalated_p3") {
       diagnostic.p3Escalated += 1;
     } else if (thread.boundaryOutcome === "softened_p3_advisory") {
+      diagnostic.p3Softened += 1;
+    }
+  }
+
+  for (const finding of pr?.configuredBotTopLevelReviewFindings ?? []) {
+    if (finding.severity === "P2") {
+      diagnostic.p2Actionable += 1;
+    } else if (finding.severity === "P3" && hasCodexConnectorStrongRiskWording(`${finding.title}\n${finding.body}`)) {
+      diagnostic.p3Escalated += 1;
+    } else if (finding.severity === "P3") {
       diagnostic.p3Softened += 1;
     }
   }

--- a/src/codex-connector-top-level-review.test.ts
+++ b/src/codex-connector-top-level-review.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { parseCodexConnectorTopLevelReviewFindings } from "./codex-connector-top-level-review";
+import {
+  codexConnectorCurrentHeadTopLevelReviewFindings,
+  parseCodexConnectorTopLevelReviewFindings,
+} from "./codex-connector-top-level-review";
 
 test("parseCodexConnectorTopLevelReviewFindings preserves malformed encoded paths", () => {
   const findings = parseCodexConnectorTopLevelReviewFindings({
@@ -24,4 +27,32 @@ test("parseCodexConnectorTopLevelReviewFindings preserves malformed encoded path
   assert.equal(findings[0]?.path, "src/file%ZZname.ts");
   assert.equal(findings[0]?.line, 12);
   assert.equal(findings[0]?.lineEnd, 13);
+});
+
+test("codexConnectorCurrentHeadTopLevelReviewFindings keeps findings tied with success timestamps", () => {
+  const findings = codexConnectorCurrentHeadTopLevelReviewFindings({
+    currentHeadSha: "6dc3165c745feb07b5e67a9036366d4e4b3206d3",
+    supersededAt: "2026-07-05T03:19:37Z",
+    comments: [
+      {
+        id: "IC_kw",
+        databaseId: 4884683854,
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-07-05T03:19:37Z",
+        url: "https://github.com/TommyKammy/codex-supervisor/pull/2404#issuecomment-4884683854",
+        body: [
+          "### Codex Review",
+          "",
+          "https://github.com/TommyKammy/codex-supervisor/blob/6dc3165c745feb07b5e67a9036366d4e4b3206d3/src/file.ts#L12",
+          "",
+          "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> Keep tied findings**",
+          "",
+          "Same-second ordering is ambiguous, so the finding remains active.",
+        ].join("\n"),
+      },
+    ],
+  });
+
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0]?.severity, "P2");
 });

--- a/src/codex-connector-top-level-review.test.ts
+++ b/src/codex-connector-top-level-review.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseCodexConnectorTopLevelReviewFindings } from "./codex-connector-top-level-review";
+
+test("parseCodexConnectorTopLevelReviewFindings preserves malformed encoded paths", () => {
+  const findings = parseCodexConnectorTopLevelReviewFindings({
+    id: "IC_kw",
+    databaseId: 4884683854,
+    authorLogin: "chatgpt-codex-connector",
+    createdAt: "2026-07-05T03:19:37Z",
+    url: "https://github.com/TommyKammy/codex-supervisor/pull/2404#issuecomment-4884683854",
+    body: [
+      "### Codex Review",
+      "",
+      "https://github.com/TommyKammy/codex-supervisor/blob/6dc3165c745feb07b5e67a9036366d4e4b3206d3/src/file%ZZname.ts#L12-L13",
+      "",
+      "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> Guard malformed encoded paths**",
+      "",
+      "A malformed percent escape should not abort PR hydration.",
+    ].join("\n"),
+  });
+
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0]?.path, "src/file%ZZname.ts");
+  assert.equal(findings[0]?.line, 12);
+  assert.equal(findings[0]?.lineEnd, 13);
+});

--- a/src/codex-connector-top-level-review.ts
+++ b/src/codex-connector-top-level-review.ts
@@ -213,10 +213,13 @@ export function codexConnectorNitpickTopLevelReviewFindings(
 export function codexConnectorCurrentHeadTopLevelReviewFindings(args: {
   comments: CodexConnectorTopLevelReviewCommentInput[];
   currentHeadSha: string | null | undefined;
+  supersededAt?: string | null | undefined;
 }): CodexConnectorTopLevelReviewFinding[] {
+  const supersededAtMs = args.supersededAt ? Date.parse(args.supersededAt) : 0;
   return args.comments
     .flatMap((comment) => parseCodexConnectorTopLevelReviewFindings(comment))
-    .filter((finding) => codexConnectorReviewFindingMatchesHead(finding, args.currentHeadSha));
+    .filter((finding) => codexConnectorReviewFindingMatchesHead(finding, args.currentHeadSha))
+    .filter((finding) => !supersededAtMs || Date.parse(finding.commentCreatedAt) > supersededAtMs);
 }
 
 export function codexConnectorPSeverityRank(severity: CodexConnectorPSeverity): number {

--- a/src/codex-connector-top-level-review.ts
+++ b/src/codex-connector-top-level-review.ts
@@ -1,0 +1,234 @@
+import {
+  type CodexConnectorPSeverity,
+  extractCodexConnectorPSeverity,
+  hasCodexConnectorStrongRiskWording,
+  isCodexConnectorReviewer,
+} from "./external-review/external-review-normalization";
+
+export interface CodexConnectorTopLevelReviewCommentInput {
+  id?: string | null;
+  databaseId?: number | null;
+  authorLogin: string | null;
+  createdAt: string | null;
+  body: string | null;
+  url?: string | null;
+}
+
+export interface CodexConnectorTopLevelReviewFinding {
+  id: string;
+  commentId: string | null;
+  commentDatabaseId: number | null;
+  commentCreatedAt: string;
+  commentUrl: string | null;
+  sourceUrl: string;
+  path: string;
+  line: number;
+  lineEnd: number;
+  headSha: string;
+  severity: CodexConnectorPSeverity;
+  title: string;
+  body: string;
+  authorLogin: string;
+  fingerprint: string;
+}
+
+const CODEX_REVIEW_HEADING_RE = /###\s*(?:💡\s*)?Codex Review/iu;
+const SOURCE_URL_RE =
+  /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/blob\/([0-9a-f]{7,40})\/([^\s#]+)#L(\d+)(?:-L(\d+))?/giu;
+
+function normalizeWhitespace(value: string): string {
+  return value.replace(/\s+/gu, " ").trim();
+}
+
+function normalizeCommitShaForComparison(sha: string | null | undefined): string | null {
+  const normalized = sha?.trim();
+  return normalized ? normalized.toLowerCase() : null;
+}
+
+export function codexConnectorReviewFindingMatchesHead(
+  finding: Pick<CodexConnectorTopLevelReviewFinding, "headSha">,
+  currentHeadSha: string | null | undefined,
+): boolean {
+  const findingHead = normalizeCommitShaForComparison(finding.headSha);
+  const currentHead = normalizeCommitShaForComparison(currentHeadSha);
+  return Boolean(
+    findingHead &&
+      currentHead &&
+      (findingHead === currentHead || findingHead.startsWith(currentHead) || currentHead.startsWith(findingHead)),
+  );
+}
+
+function splitBodyBeforeDetails(body: string): string {
+  const detailsIndex = body.search(/<details\b/iu);
+  return detailsIndex >= 0 ? body.slice(0, detailsIndex) : body;
+}
+
+function stripTitleMarkup(value: string): string {
+  const title = normalizeWhitespace(
+    value
+      .replace(/^#+\s*/u, "")
+      .replace(/!\[[^\]]*\]\([^)]*\)/gu, " ")
+      .replace(/<[^>]+>/gu, " ")
+      .replace(/\*\*/gu, " ")
+      .replace(/[`*_]+/gu, " "),
+  );
+  return title.length > 0 ? title : "Codex Connector finding";
+}
+
+function bodySummary(body: string): string {
+  const normalized = normalizeWhitespace(body.replace(/```[\s\S]*?```/gu, " "));
+  if (!normalized) {
+    return "review details available at source link";
+  }
+  const sentence = normalized.match(/^(.{1,180}?[.!?])(?:\s|$)/u)?.[1] ?? normalized;
+  return sentence.length > 180 ? `${sentence.slice(0, 177)}...` : sentence;
+}
+
+function parseFindingBlock(args: {
+  block: string;
+  sourceUrl: string;
+  headSha: string;
+  path: string;
+  line: number;
+  lineEnd: number;
+  comment: CodexConnectorTopLevelReviewCommentInput;
+  authorLogin: string;
+  index: number;
+}): CodexConnectorTopLevelReviewFinding | null {
+  const severity = extractCodexConnectorPSeverity(args.block);
+  if (!severity) {
+    return null;
+  }
+
+  const lines = args.block
+    .replace(args.sourceUrl, "")
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && line !== "---");
+  const titleLineIndex = lines.findIndex((line) => extractCodexConnectorPSeverity(line) === severity);
+  const title = titleLineIndex >= 0 ? stripTitleMarkup(lines[titleLineIndex] ?? "") : bodySummary(args.block);
+  const detailsBody = lines
+    .slice(titleLineIndex >= 0 ? titleLineIndex + 1 : 0)
+    .join("\n")
+    .trim();
+  const commentId = args.comment.id ?? null;
+  const commentCreatedAt = args.comment.createdAt;
+  if (!commentCreatedAt) {
+    return null;
+  }
+
+  const fingerprint = [
+    commentId ?? commentCreatedAt,
+    args.headSha.toLowerCase(),
+    args.path,
+    String(args.line),
+    severity,
+    normalizeWhitespace(title).toLowerCase(),
+  ].join("|");
+
+  return {
+    id: `${commentId ?? commentCreatedAt}:finding:${args.index + 1}`,
+    commentId,
+    commentDatabaseId: args.comment.databaseId ?? null,
+    commentCreatedAt,
+    commentUrl: args.comment.url ?? null,
+    sourceUrl: args.sourceUrl,
+    path: args.path,
+    line: args.line,
+    lineEnd: args.lineEnd,
+    headSha: args.headSha,
+    severity,
+    title,
+    body: detailsBody,
+    authorLogin: args.authorLogin,
+    fingerprint,
+  };
+}
+
+export function parseCodexConnectorTopLevelReviewFindings(
+  comment: CodexConnectorTopLevelReviewCommentInput,
+): CodexConnectorTopLevelReviewFinding[] {
+  const authorLogin = comment.authorLogin?.trim() ?? "";
+  if (!authorLogin || !isCodexConnectorReviewer(authorLogin) || !comment.body || !CODEX_REVIEW_HEADING_RE.test(comment.body)) {
+    return [];
+  }
+
+  const body = splitBodyBeforeDetails(comment.body);
+  const matches = Array.from(body.matchAll(SOURCE_URL_RE));
+  const findings: CodexConnectorTopLevelReviewFinding[] = [];
+  for (let index = 0; index < matches.length; index += 1) {
+    const match = matches[index]!;
+    const sourceUrl = match[0];
+    const headSha = match[1]!;
+    const encodedPath = match[2]!;
+    const line = Number(match[3]);
+    const lineEnd = Number(match[4] ?? match[3]);
+    if (!Number.isInteger(line) || !Number.isInteger(lineEnd) || line <= 0 || lineEnd < line) {
+      continue;
+    }
+
+    const blockStart = match.index ?? 0;
+    const nextMatch = matches[index + 1];
+    const blockEnd = nextMatch?.index ?? body.length;
+    const block = body.slice(blockStart, blockEnd);
+    const finding = parseFindingBlock({
+      block,
+      sourceUrl,
+      headSha,
+      path: decodeURIComponent(encodedPath),
+      line,
+      lineEnd,
+      comment,
+      authorLogin,
+      index,
+    });
+    if (finding) {
+      findings.push(finding);
+    }
+  }
+
+  return findings;
+}
+
+export function codexConnectorMustFixTopLevelReviewFindings(
+  findings: CodexConnectorTopLevelReviewFinding[],
+): CodexConnectorTopLevelReviewFinding[] {
+  return findings.filter((finding) => {
+    if (finding.severity === "P0" || finding.severity === "P1" || finding.severity === "P2") {
+      return true;
+    }
+    return hasCodexConnectorStrongRiskWording(`${finding.title}\n${finding.body}`);
+  });
+}
+
+export function codexConnectorNitpickTopLevelReviewFindings(
+  findings: CodexConnectorTopLevelReviewFinding[],
+): CodexConnectorTopLevelReviewFinding[] {
+  return findings.filter(
+    (finding) =>
+      finding.severity === "P3" && !hasCodexConnectorStrongRiskWording(`${finding.title}\n${finding.body}`),
+  );
+}
+
+export function codexConnectorCurrentHeadTopLevelReviewFindings(args: {
+  comments: CodexConnectorTopLevelReviewCommentInput[];
+  currentHeadSha: string | null | undefined;
+}): CodexConnectorTopLevelReviewFinding[] {
+  return args.comments
+    .flatMap((comment) => parseCodexConnectorTopLevelReviewFindings(comment))
+    .filter((finding) => codexConnectorReviewFindingMatchesHead(finding, args.currentHeadSha));
+}
+
+export function codexConnectorPSeverityRank(severity: CodexConnectorPSeverity): number {
+  return { P0: 0, P1: 1, P2: 2, P3: 3 }[severity];
+}
+
+export function highestCodexConnectorPSeverity(
+  findings: Array<Pick<CodexConnectorTopLevelReviewFinding, "severity">>,
+): CodexConnectorPSeverity | null {
+  return (
+    findings
+      .map((finding) => finding.severity)
+      .sort((left, right) => codexConnectorPSeverityRank(left) - codexConnectorPSeverityRank(right))[0] ?? null
+  );
+}

--- a/src/codex-connector-top-level-review.ts
+++ b/src/codex-connector-top-level-review.ts
@@ -250,7 +250,7 @@ export function codexConnectorCurrentHeadTopLevelReviewFindings(args: {
   return args.comments
     .flatMap((comment) => parseCodexConnectorTopLevelReviewFindings(comment))
     .filter((finding) => codexConnectorReviewFindingMatchesHead(finding, args.currentHeadSha))
-    .filter((finding) => !supersededAtMs || Date.parse(finding.commentCreatedAt) > supersededAtMs);
+    .filter((finding) => !supersededAtMs || Date.parse(finding.commentCreatedAt) >= supersededAtMs);
 }
 
 export function codexConnectorPSeverityRank(severity: CodexConnectorPSeverity): number {

--- a/src/codex-connector-top-level-review.ts
+++ b/src/codex-connector-top-level-review.ts
@@ -4,6 +4,7 @@ import {
   hasCodexConnectorStrongRiskWording,
   isCodexConnectorReviewer,
 } from "./external-review/external-review-normalization";
+import type { ReviewThread } from "./core/types";
 
 export interface CodexConnectorTopLevelReviewCommentInput {
   id?: string | null;
@@ -43,6 +44,14 @@ function normalizeWhitespace(value: string): string {
 function normalizeCommitShaForComparison(sha: string | null | undefined): string | null {
   const normalized = sha?.trim();
   return normalized ? normalized.toLowerCase() : null;
+}
+
+function decodeReviewPath(encodedPath: string): string {
+  try {
+    return decodeURIComponent(encodedPath);
+  } catch {
+    return encodedPath;
+  }
 }
 
 export function codexConnectorReviewFindingMatchesHead(
@@ -175,7 +184,7 @@ export function parseCodexConnectorTopLevelReviewFindings(
       block,
       sourceUrl,
       headSha,
-      path: decodeURIComponent(encodedPath),
+      path: decodeReviewPath(encodedPath),
       line,
       lineEnd,
       comment,
@@ -208,6 +217,28 @@ export function codexConnectorNitpickTopLevelReviewFindings(
     (finding) =>
       finding.severity === "P3" && !hasCodexConnectorStrongRiskWording(`${finding.title}\n${finding.body}`),
   );
+}
+
+export function codexConnectorTopLevelReviewFindingRetryTarget(
+  finding: CodexConnectorTopLevelReviewFinding,
+): Pick<ReviewThread, "id" | "comments"> {
+  return {
+    id: `codex-top-level-finding:${finding.id}`,
+    comments: {
+      nodes: [
+        {
+          id: finding.fingerprint,
+          body: `${finding.severity}: ${finding.title}\n${finding.body}`.trim(),
+          createdAt: finding.commentCreatedAt,
+          url: finding.sourceUrl,
+          author: {
+            login: finding.authorLogin,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
 }
 
 export function codexConnectorCurrentHeadTopLevelReviewFindings(args: {

--- a/src/codex/codex-prompt.test.ts
+++ b/src/codex/codex-prompt.test.ts
@@ -1637,6 +1637,65 @@ test("buildCodexConnectorReviewGuidance directly renders clustered churn as spec
   assert.deepEqual(labels, ["Codex Connector clustered root-cause repair"]);
 });
 
+test("buildCodexPrompt renders top-level Codex Review comment findings as must-fix repair targets", () => {
+  const pr = createPullRequest({
+    number: 219,
+    headRefOid: "b0642d776275b58f3d2918fa1a48cb522d6f21ce",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewFindingCount: 1,
+    configuredBotTopLevelReviewHighestSeverity: "P2",
+    configuredBotTopLevelReviewFindings: [
+      {
+        id: "IC_kw:finding:1",
+        commentId: "IC_kw",
+        commentDatabaseId: 4884683854,
+        commentCreatedAt: "2026-07-05T03:19:37Z",
+        commentUrl: "https://example.test/pr/219#issuecomment-4884683854",
+        sourceUrl:
+          "https://github.com/TommyKammy/VeriDoc/blob/b0642d776275b58f3d2918fa1a48cb522d6f21ce/datasets/poc_evaluation_manifest_v1.json#L139-L140",
+        path: "datasets/poc_evaluation_manifest_v1.json",
+        line: 139,
+        lineEnd: 140,
+        headSha: "b0642d776275b58f3d2918fa1a48cb522d6f21ce",
+        severity: "P2",
+        title: "Link the text-PDF sample to a PDF fixture",
+        body: "The sample resolves to parser-output JSON instead of a real PDF upload, so PDF parsing coverage is lost.",
+        authorLogin: "chatgpt-codex-connector",
+        fingerprint: "IC_kw|head|datasets/poc_evaluation_manifest_v1.json|139|P2|link",
+      },
+    ],
+  });
+
+  const prompt = buildCodexPrompt({
+    kind: "start",
+    config: createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
+    repoSlug: "owner/repo",
+    issue,
+    branch: "codex/issue-2403",
+    workspacePath: "/tmp/workspaces/issue-2403",
+    state: "addressing_review" satisfies RunState,
+    record: {
+      repeated_failure_signature_count: 0,
+      blocked_verification_retry_count: 0,
+      timeout_retry_count: 0,
+    },
+    pr,
+    checks: [],
+    reviewThreads: [],
+    alwaysReadFiles: [],
+    onDemandMemoryFiles: [],
+    journalPath: "/tmp/workspaces/issue-2403/.codex-supervisor/issue-journal.md",
+  } satisfies AgentTurnContext);
+
+  assert.match(prompt, /Codex Connector actionable review-thread fast path:/);
+  assert.match(prompt, /Source: top_level_codex_review_comment/);
+  assert.match(prompt, /Severity: P2/);
+  assert.match(prompt, /File: datasets\/poc_evaluation_manifest_v1\.json/);
+  assert.match(prompt, /Line range: 139-140/);
+  assert.match(prompt, /Summary: Link the text-PDF sample to a PDF fixture/);
+  assert.doesNotMatch(prompt, /No unresolved configured-bot review threads\./);
+});
+
 test("buildCodexPrompt adds a stable same-file Codex Connector churn repair dossier", () => {
   const pr = createPullRequest({
     number: 2250,

--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -23,6 +23,7 @@ const EXPECTED_TOP_LEVEL_ENTRIES = {
     "codex-connector-review-request-decision.ts",
     "codex-connector-review-request-identity.ts",
     "codex-connector-review-request-transition.ts",
+    "codex-connector-top-level-review.ts",
     "codex-connector-tracked-pr-test-helpers.ts",
     "codex-connector-valid-review-repair-selection.ts",
     "codex-connector-valid-review-repair.ts",

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -50,6 +50,9 @@ export interface PullRequestCopilotReviewLifecycleResponse {
     } | null>;
   } | null;
   comments?: {
+    pageInfo?: {
+      hasPreviousPage?: boolean | null;
+    } | null;
     nodes?: Array<{
       id?: string | null;
       databaseId?: number | null;

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -372,6 +372,9 @@ export function applyConfiguredBotReviewSummary(
     configuredBotDraftSkipAt: summary?.draftSkipAt ?? null,
     configuredBotTopLevelReviewStrength: summary?.topLevelReview.strength ?? null,
     configuredBotTopLevelReviewSubmittedAt: summary?.topLevelReview.submittedAt ?? null,
+    configuredBotTopLevelReviewFindingCount: summary?.topLevelReview.findingCount ?? null,
+    configuredBotTopLevelReviewHighestSeverity: summary?.topLevelReview.highestSeverity ?? null,
+    configuredBotTopLevelReviewFindings: summary?.topLevelReview.findings ?? null,
     configuredBotOnlyChangesRequestedReview: summary?.topLevelReview.configuredBotOnlyChangesRequestedReview ?? null,
   };
 }

--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -504,6 +504,84 @@ test("GitHubPullRequestHydrator reuses arrived configured-bot lifecycle for the 
   assert.equal(lifecycleCallCount, 1);
 });
 
+test("GitHubPullRequestHydrator refreshes Codex issue-comment findings after arrived status hydration", async () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const headSha = "6dc3165c745feb07b5e67a9036366d4e4b3206d3";
+  let lifecycleCallCount = 0;
+  const pullRequestPayload = (comments: unknown[]) => ({
+    reviewRequests: { nodes: [] },
+    reviews: { nodes: [] },
+    comments: {
+      pageInfo: { hasPreviousPage: false },
+      nodes: comments,
+    },
+    reviewThreads: { nodes: [] },
+    timelineItems: { nodes: [] },
+    commits: { nodes: [] },
+  });
+  const hydrator = new GitHubPullRequestHydrator(config, async (args) => {
+    if (args[0] !== "api" || args[1] !== "graphql") {
+      throw new Error(`Unexpected args: ${args.join(" ")}`);
+    }
+    lifecycleCallCount += 1;
+    const comments =
+      lifecycleCallCount === 1
+        ? [
+            {
+              id: "IC_finding",
+              databaseId: 4884683854,
+              createdAt: "2026-07-05T03:19:37Z",
+              url: "https://example.test/pr/44#issuecomment-4884683854",
+              viewerDidAuthor: false,
+              author: { login: "chatgpt-codex-connector[bot]" },
+              body: [
+                "### Codex Review",
+                "",
+                `https://github.com/owner/repo/blob/${headSha}/src/file.ts#L12`,
+                "",
+                "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> Keep cached findings fresh**",
+                "",
+                "The current-head finding should be refreshed on each Codex status hydration.",
+              ].join("\n"),
+            },
+          ]
+        : [
+            {
+              id: "IC_success",
+              databaseId: 4884683855,
+              createdAt: "2026-07-05T03:25:37Z",
+              url: "https://example.test/pr/44#issuecomment-4884683855",
+              viewerDidAuthor: false,
+              author: { login: "chatgpt-codex-connector[bot]" },
+              body: "Codex Review: no major issues found.",
+            },
+          ];
+    return {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        data: {
+          repository: {
+            pullRequest: pullRequestPayload(comments),
+          },
+        },
+      }),
+      stderr: "",
+    };
+  });
+
+  const first = await hydrator.hydrate(createPullRequest({ headRefOid: headSha }));
+  const second = await hydrator.hydrate(createPullRequest({ headRefOid: headSha }));
+
+  assert.equal(first?.hydrationProvenance, "fresh");
+  assert.equal(first?.configuredBotTopLevelReviewStrength, "blocking");
+  assert.equal(first?.configuredBotTopLevelReviewFindingCount, 1);
+  assert.equal(second?.hydrationProvenance, "fresh");
+  assert.equal(second?.configuredBotTopLevelReviewStrength, null);
+  assert.equal(second?.configuredBotTopLevelReviewFindingCount, null);
+  assert.equal(second?.configuredBotCurrentHeadObservationSource, "codex_pr_success_comment");
+  assert.equal(lifecycleCallCount, 2);
+});
+
 test("GitHubPullRequestHydrator hydrates arrived lifecycle from actionable configured-bot issue comments", async () => {
   const config = createConfig({ reviewBotLogins: ["coderabbitai[bot]"] });
   let lifecycleQuery: string | null = null;

--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -1294,3 +1294,88 @@ test("GitHubPullRequestHydrator hydrates large GraphQL payloads without parsing 
   assert.equal(pr?.configuredBotTopLevelReviewStrength, "blocking");
   assert.equal(pr?.configuredBotTopLevelReviewSubmittedAt, "2026-04-14T01:02:03Z");
 });
+
+test("GitHubPullRequestHydrator pages issue comments before summarizing top-level Codex findings", async () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const headSha = "6dc3165c745feb07b5e67a9036366d4e4b3206d3";
+  const commands: string[] = [];
+  const hydrator = new GitHubPullRequestHydrator(config, async (args) => {
+    commands.push(args.join(" "));
+    const queryArg = args.find((arg) => arg.startsWith("query=")) ?? "";
+    if (queryArg.includes("pullRequest(number: $number)")) {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewRequests: { nodes: [] },
+                reviews: { nodes: [] },
+                comments: {
+                  pageInfo: { hasPreviousPage: true },
+                  nodes: [],
+                },
+                reviewThreads: { nodes: [] },
+                timelineItems: { nodes: [] },
+                commits: { nodes: [] },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    if (queryArg.includes("issue(number: $number)")) {
+      return {
+        exitCode: 0,
+        stdout: JSON.stringify({
+          data: {
+            repository: {
+              issue: {
+                comments: {
+                  nodes: [
+                    {
+                      id: "IC_kw",
+                      databaseId: 4884683854,
+                      createdAt: "2026-07-05T03:19:37Z",
+                      url: "https://example.test/pr/44#issuecomment-4884683854",
+                      viewerDidAuthor: false,
+                      author: {
+                        login: "chatgpt-codex-connector",
+                        __typename: "Bot",
+                      },
+                      body: [
+                        "### Codex Review",
+                        "",
+                        `https://github.com/owner/repo/blob/${headSha}/src/file.ts#L12`,
+                        "",
+                        "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub> Keep paged findings active**",
+                        "",
+                        "The current-head finding is outside the last-100 PR comment window.",
+                      ].join("\n"),
+                    },
+                  ],
+                  pageInfo: {
+                    hasNextPage: false,
+                    endCursor: null,
+                  },
+                },
+              },
+            },
+          },
+        }),
+        stderr: "",
+      };
+    }
+
+    throw new Error(`Unexpected args: ${args.join(" ")}`);
+  });
+
+  const pr = await hydrator.hydrate(createPullRequest({ headRefOid: headSha }));
+
+  assert.equal(commands.length, 2);
+  assert.equal(pr?.configuredBotTopLevelReviewStrength, "blocking");
+  assert.equal(pr?.configuredBotTopLevelReviewFindingCount, 1);
+  assert.equal(pr?.configuredBotTopLevelReviewFindings?.[0]?.title, "Keep paged findings active");
+});

--- a/src/github/github-pull-request-hydrator.test.ts
+++ b/src/github/github-pull-request-hydrator.test.ts
@@ -1380,7 +1380,7 @@ test("GitHubPullRequestHydrator pages issue comments before summarizing top-leve
   const hydrator = new GitHubPullRequestHydrator(config, async (args) => {
     commands.push(args.join(" "));
     const queryArg = args.find((arg) => arg.startsWith("query=")) ?? "";
-    if (queryArg.includes("pullRequest(number: $number)")) {
+    if (queryArg.includes("pullRequest(number: $number)") && queryArg.includes("comments(last: 100)")) {
       return {
         exitCode: 0,
         stdout: JSON.stringify({
@@ -1404,13 +1404,13 @@ test("GitHubPullRequestHydrator pages issue comments before summarizing top-leve
       };
     }
 
-    if (queryArg.includes("issue(number: $number)")) {
+    if (queryArg.includes("pullRequest(number: $number)") && queryArg.includes("comments(first: 100")) {
       return {
         exitCode: 0,
         stdout: JSON.stringify({
           data: {
             repository: {
-              issue: {
+              pullRequest: {
                 comments: {
                   nodes: [
                     {

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -390,7 +390,7 @@ export class GitHubPullRequestHydrator {
       const query = `
         query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
           repository(owner: $owner, name: $repo) {
-            issue(number: $number) {
+            pullRequest(number: $number) {
               comments(first: 100, after: $cursor) {
                 nodes {
                   id
@@ -430,7 +430,7 @@ export class GitHubPullRequestHydrator {
       const payload = parseJson<{
         data?: {
           repository?: {
-            issue?: {
+            pullRequest?: {
               comments?: {
                 nodes?: Array<{
                   id?: string | null;
@@ -454,7 +454,7 @@ export class GitHubPullRequestHydrator {
         };
       }>(result.stdout, `gh api graphql issue comments issue=${issueNumber}`);
 
-      const connection = payload.data?.repository?.issue?.comments;
+      const connection = payload.data?.repository?.pullRequest?.comments;
       comments.push(
         ...(connection?.nodes?.flatMap((comment) =>
           comment?.id

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -5,6 +5,7 @@ import {
   PullRequestCopilotReviewLifecycleResponse,
 } from "./github-hydration";
 import { ConfiguredBotReviewSummary } from "./github-review-signals";
+import { configuredReviewProviderKinds } from "../core/review-providers";
 import { SupervisorConfig } from "../core/types";
 import { parseJson, truncate } from "../core/utils";
 import type { CopilotReviewState, GitHubPullRequest, IssueComment } from "./types";
@@ -131,6 +132,17 @@ export class GitHubPullRequestHydrator {
   async hydrateForStatus(pr: GitHubPullRequest | null): Promise<GitHubPullRequest | null> {
     if (!pr) {
       return null;
+    }
+
+    if (configuredReviewProviderKinds(this.config).includes("codex")) {
+      try {
+        const summary = await this.fetchConfiguredBotReviewSummary(pr.number, pr.headRefOid);
+        return withHydrationProvenance(applyConfiguredBotReviewSummary(pr, summary), "fresh");
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.warn(`Failed to hydrate Copilot review lifecycle for PR #${pr.number}: ${truncate(message, 500) ?? "unknown error"}`);
+        return withHydrationProvenance(applyConfiguredBotReviewSummary(pr, null), "fresh");
+      }
     }
 
     const cacheKey = `${pr.number}:${pr.headRefOid}`;

--- a/src/github/github-pull-request-hydrator.ts
+++ b/src/github/github-pull-request-hydrator.ts
@@ -7,7 +7,7 @@ import {
 import { ConfiguredBotReviewSummary } from "./github-review-signals";
 import { SupervisorConfig } from "../core/types";
 import { parseJson, truncate } from "../core/utils";
-import type { CopilotReviewState, GitHubPullRequest } from "./types";
+import type { CopilotReviewState, GitHubPullRequest, IssueComment } from "./types";
 
 const COPILOT_REVIEW_TRANSITION_CACHE_TTL_MS = 30_000;
 const COPILOT_REVIEW_CACHE_MAX_ENTRIES = 128;
@@ -207,6 +207,9 @@ export class GitHubPullRequestHydrator {
               }
             }
             comments(last: 100) {
+              pageInfo {
+                hasPreviousPage
+              }
               nodes {
                 id
                 databaseId
@@ -331,12 +334,146 @@ export class GitHubPullRequestHydrator {
       };
     }>(result.stdout, `gh api graphql copilot review lifecycle pr=${prNumber}`);
 
+    const lifecycle = payload.data?.repository?.pullRequest;
+    const issueComments = lifecycle?.comments?.pageInfo?.hasPreviousPage
+      ? await this.fetchIssueComments(prNumber)
+      : null;
+    let lifecycleWithPagedIssueComments: PullRequestCopilotReviewLifecycleResponse | null | undefined = lifecycle;
+    if (lifecycle && issueComments) {
+      lifecycleWithPagedIssueComments = {
+        ...lifecycle,
+        comments: {
+          ...lifecycle.comments,
+          nodes: issueComments.map((comment) => ({
+            id: comment.id,
+            databaseId: comment.databaseId,
+            createdAt: comment.createdAt,
+            body: comment.body,
+            url: comment.url,
+            viewerDidAuthor: comment.viewerDidAuthor,
+            author: comment.author
+              ? {
+                  login: comment.author.login,
+                }
+              : null,
+          })),
+        },
+      };
+    }
+
     return buildConfiguredBotReviewSummary(
-      payload.data?.repository?.pullRequest,
+      lifecycleWithPagedIssueComments,
       this.config.reviewBotLogins,
       currentHeadOid,
       { prNumber, headSha: currentHeadOid },
     );
+  }
+
+  private async fetchIssueComments(issueNumber: number): Promise<IssueComment[]> {
+    const { owner, repo } = repoOwnerAndName(this.config.repoSlug);
+    const comments: IssueComment[] = [];
+    let cursor: string | null = null;
+
+    while (true) {
+      const query = `
+        query($owner: String!, $repo: String!, $number: Int!, $cursor: String) {
+          repository(owner: $owner, name: $repo) {
+            issue(number: $number) {
+              comments(first: 100, after: $cursor) {
+                nodes {
+                  id
+                  databaseId
+                  createdAt
+                  body
+                  url
+                  viewerDidAuthor
+                  author {
+                    login
+                    __typename
+                  }
+                }
+                pageInfo {
+                  hasNextPage
+                  endCursor
+                }
+              }
+            }
+          }
+        }
+      `;
+
+      const result = await this.runGhJsonCommand([
+        "api",
+        "graphql",
+        "-f",
+        `query=${query}`,
+        "-F",
+        `owner=${owner}`,
+        "-F",
+        `repo=${repo}`,
+        "-F",
+        `number=${issueNumber}`,
+        ...(cursor ? ["-F", `cursor=${cursor}`] : []),
+      ]);
+      const payload = parseJson<{
+        data?: {
+          repository?: {
+            issue?: {
+              comments?: {
+                nodes?: Array<{
+                  id?: string | null;
+                  databaseId?: number | null;
+                  createdAt?: string | null;
+                  body?: string | null;
+                  url?: string | null;
+                  viewerDidAuthor?: boolean | null;
+                  author?: {
+                    login?: string | null;
+                    __typename?: string | null;
+                  } | null;
+                } | null>;
+                pageInfo?: {
+                  hasNextPage?: boolean | null;
+                  endCursor?: string | null;
+                } | null;
+              } | null;
+            } | null;
+          };
+        };
+      }>(result.stdout, `gh api graphql issue comments issue=${issueNumber}`);
+
+      const connection = payload.data?.repository?.issue?.comments;
+      comments.push(
+        ...(connection?.nodes?.flatMap((comment) =>
+          comment?.id
+            ? [
+                {
+                  id: comment.id,
+                  databaseId: comment.databaseId ?? null,
+                  body: comment.body ?? "",
+                  createdAt: comment.createdAt ?? "",
+                  url: comment.url ?? null,
+                  viewerDidAuthor: comment.viewerDidAuthor ?? null,
+                  author: comment.author
+                    ? {
+                        login: comment.author.login ?? null,
+                        typeName: comment.author.__typename ?? null,
+                      }
+                    : null,
+                },
+              ]
+            : [],
+        ) ?? []),
+      );
+
+      const pageInfo = connection?.pageInfo;
+      if (!pageInfo?.hasNextPage || !pageInfo.endCursor) {
+        break;
+      }
+      cursor = pageInfo.endCursor;
+    }
+
+    return comments;
   }
 }
 

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -1412,6 +1412,93 @@ test("buildConfiguredBotReviewSummary lets later same-head Codex success superse
   assert.equal(summary.currentHeadActionableObservedAt, null);
 });
 
+test("buildConfiguredBotReviewSummary lets unanchored Codex success supersede older top-level findings consistently", () => {
+  const headSha = "b0642d776275b58f3d2918fa1a48cb522d6f21ce";
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [
+      {
+        id: "IC_finding",
+        databaseId: 4884683854,
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-07-05T03:19:37Z",
+        url: "https://example.test/pr/219#issuecomment-4884683854",
+        body: [
+          "### Codex Review",
+          "",
+          `https://github.com/TommyKammy/VeriDoc/blob/${headSha}/datasets/poc_evaluation_manifest_v1.json#L139-L140`,
+          "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Link the text-PDF sample to a PDF fixture**",
+          "",
+          "The sample resolves to parser-output JSON instead of a real PDF upload.",
+        ].join("\n"),
+      },
+      {
+        id: "IC_success",
+        databaseId: 4884683999,
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-07-05T03:25:37Z",
+        url: "https://example.test/pr/219#issuecomment-4884683999",
+        body: "Codex Review: no major issues found.",
+      },
+    ],
+    statusContexts: [],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector"], headSha);
+
+  assert.equal(summary.topLevelReview.strength, null);
+  assert.equal(summary.topLevelReview.submittedAt, null);
+  assert.equal(summary.currentHeadObservedAt, "2026-07-05T03:25:37Z");
+  assert.equal(summary.currentHeadObservationSource, "codex_pr_success_comment");
+  assert.equal(summary.currentHeadCodexSuccessReviewedCommitSha, null);
+  assert.equal(summary.currentHeadCodexSuccessObservedAt, "2026-07-05T03:25:37Z");
+});
+
+test("buildConfiguredBotReviewSummary keeps active top-level must-fix findings blocking despite later nitpick reviews", () => {
+  const headSha = "b0642d776275b58f3d2918fa1a48cb522d6f21ce";
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "chatgpt-codex-connector",
+        submittedAt: "2026-07-05T03:25:37Z",
+        commitOid: headSha,
+        state: "CHANGES_REQUESTED",
+        body: "Nitpick: prefer a shorter helper name.",
+      },
+    ],
+    comments: [],
+    issueComments: [
+      {
+        id: "IC_finding",
+        databaseId: 4884683854,
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-07-05T03:19:37Z",
+        url: "https://example.test/pr/219#issuecomment-4884683854",
+        body: [
+          "### Codex Review",
+          "",
+          `https://github.com/TommyKammy/VeriDoc/blob/${headSha}/datasets/poc_evaluation_manifest_v1.json#L139-L140`,
+          "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Link the text-PDF sample to a PDF fixture**",
+          "",
+          "The sample resolves to parser-output JSON instead of a real PDF upload.",
+        ].join("\n"),
+      },
+    ],
+    statusContexts: [],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector"], headSha);
+
+  assert.equal(summary.topLevelReview.strength, "blocking");
+  assert.equal(summary.topLevelReview.findingCount, 1);
+  assert.equal(summary.topLevelReview.highestSeverity, "P2");
+});
+
 test("buildConfiguredBotReviewSummary anchors Codex Connector no-major issue comments to reviewed commits", () => {
   const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
   const facts: CopilotReviewLifecycleFacts = {

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -1412,7 +1412,7 @@ test("buildConfiguredBotReviewSummary lets later same-head Codex success superse
   assert.equal(summary.currentHeadActionableObservedAt, null);
 });
 
-test("buildConfiguredBotReviewSummary lets unanchored Codex success supersede older top-level findings consistently", () => {
+test("buildConfiguredBotReviewSummary does not let unanchored Codex success supersede current-head top-level findings", () => {
   const headSha = "b0642d776275b58f3d2918fa1a48cb522d6f21ce";
   const facts: CopilotReviewLifecycleFacts = {
     reviewRequests: [],
@@ -1449,10 +1449,13 @@ test("buildConfiguredBotReviewSummary lets unanchored Codex success supersede ol
 
   const summary = buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector"], headSha);
 
-  assert.equal(summary.topLevelReview.strength, null);
-  assert.equal(summary.topLevelReview.submittedAt, null);
+  assert.equal(summary.topLevelReview.strength, "blocking");
+  assert.equal(summary.topLevelReview.submittedAt, "2026-07-05T03:19:37Z");
+  assert.equal(summary.topLevelReview.findingCount, 1);
+  assert.equal(summary.topLevelReview.highestSeverity, "P2");
   assert.equal(summary.currentHeadObservedAt, "2026-07-05T03:25:37Z");
   assert.equal(summary.currentHeadObservationSource, "codex_pr_success_comment");
+  assert.equal(summary.currentHeadActionableObservedAt, "2026-07-05T03:19:37Z");
   assert.equal(summary.currentHeadCodexSuccessReviewedCommitSha, null);
   assert.equal(summary.currentHeadCodexSuccessObservedAt, "2026-07-05T03:25:37Z");
 });

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -1499,6 +1499,49 @@ test("buildConfiguredBotReviewSummary keeps active top-level must-fix findings b
   assert.equal(summary.topLevelReview.highestSeverity, "P2");
 });
 
+test("buildConfiguredBotReviewSummary preserves configured-bot blocking reviews when Codex only reports top-level nitpicks", () => {
+  const headSha = "b0642d776275b58f3d2918fa1a48cb522d6f21ce";
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-07-05T03:19:37Z",
+        commitOid: headSha,
+        state: "CHANGES_REQUESTED",
+        body: "This migration can skip the required verification gate.",
+      },
+    ],
+    comments: [],
+    issueComments: [
+      {
+        id: "IC_nitpick",
+        databaseId: 4884683856,
+        authorLogin: "chatgpt-codex-connector[bot]",
+        createdAt: "2026-07-05T03:25:37Z",
+        url: "https://example.test/pr/219#issuecomment-4884683856",
+        body: [
+          "### Codex Review",
+          "",
+          `https://github.com/TommyKammy/VeriDoc/blob/${headSha}/src/file.ts#L12`,
+          "**<sub><sub>![P3 Badge](https://img.shields.io/badge/P3-blue?style=flat)</sub></sub>  Prefer a shorter helper name**",
+          "",
+          "Nitpick: this helper name is a little verbose.",
+        ].join("\n"),
+      },
+    ],
+    statusContexts: [],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]", "chatgpt-codex-connector"], headSha);
+
+  assert.equal(summary.topLevelReview.strength, "blocking");
+  assert.equal(summary.topLevelReview.submittedAt, "2026-07-05T03:19:37Z");
+  assert.equal(summary.topLevelReview.findingCount, 1);
+  assert.equal(summary.topLevelReview.highestSeverity, "P3");
+});
+
 test("buildConfiguredBotReviewSummary anchors Codex Connector no-major issue comments to reviewed commits", () => {
   const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
   const facts: CopilotReviewLifecycleFacts = {

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -1412,6 +1412,60 @@ test("buildConfiguredBotReviewSummary lets later same-head Codex success superse
   assert.equal(summary.currentHeadActionableObservedAt, null);
 });
 
+test("buildConfiguredBotReviewSummary preserves earlier anchored Codex success when followed by unanchored success", () => {
+  const headSha = "b0642d776275b58f3d2918fa1a48cb522d6f21ce";
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [
+      {
+        id: "IC_finding",
+        databaseId: 4884683854,
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-07-05T03:19:37Z",
+        url: "https://example.test/pr/219#issuecomment-4884683854",
+        body: [
+          "### Codex Review",
+          "",
+          `https://github.com/TommyKammy/VeriDoc/blob/${headSha}/datasets/poc_evaluation_manifest_v1.json#L139-L140`,
+          "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Link the text-PDF sample to a PDF fixture**",
+          "",
+          "The sample resolves to parser-output JSON instead of a real PDF upload.",
+        ].join("\n"),
+      },
+      {
+        id: "IC_anchored_success",
+        databaseId: 4884683999,
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-07-05T03:25:37Z",
+        url: "https://example.test/pr/219#issuecomment-4884683999",
+        body: `Codex Review: no major issues found.\n\n**Reviewed commit:** \`${headSha.slice(0, 10)}\``,
+      },
+      {
+        id: "IC_unanchored_success",
+        databaseId: 4884684000,
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-07-05T03:26:37Z",
+        url: "https://example.test/pr/219#issuecomment-4884684000",
+        body: "Codex Review: no major issues found.",
+      },
+    ],
+    statusContexts: [],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector"], headSha);
+
+  assert.equal(summary.topLevelReview.strength, null);
+  assert.equal(summary.topLevelReview.submittedAt, null);
+  assert.equal(summary.topLevelReview.findingCount, undefined);
+  assert.equal(summary.currentHeadObservedAt, "2026-07-05T03:26:37Z");
+  assert.equal(summary.currentHeadObservationSource, "codex_pr_success_comment");
+  assert.equal(summary.currentHeadCodexSuccessReviewedCommitSha, null);
+  assert.equal(summary.currentHeadCodexSuccessObservedAt, "2026-07-05T03:26:37Z");
+});
+
 test("buildConfiguredBotReviewSummary does not let unanchored Codex success supersede current-head top-level findings", () => {
   const headSha = "b0642d776275b58f3d2918fa1a48cb522d6f21ce";
   const facts: CopilotReviewLifecycleFacts = {

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -1312,6 +1312,59 @@ test("buildConfiguredBotReviewSummary recognizes live Codex Connector no-major-i
   });
 });
 
+test("buildConfiguredBotReviewSummary treats current-head Codex Review issue comments as blocking top-level findings", () => {
+  const headSha = "b0642d776275b58f3d2918fa1a48cb522d6f21ce";
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [
+      {
+        id: "IC_kw",
+        databaseId: 4884683854,
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-07-05T03:19:37Z",
+        url: "https://github.com/TommyKammy/VeriDoc/pull/219#issuecomment-4884683854",
+        body: [
+          "### Codex Review",
+          "",
+          `https://github.com/TommyKammy/VeriDoc/blob/${headSha}/datasets/fixtures/pdf/record-pdf-representative.pdf#L42-L43`,
+          "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Preserve the PDF fixture bytes across checkout**",
+          "",
+          "On Windows clones with core.autocrlf=true, checkout can rewrite LF to CRLF and corrupt the PDF xref offsets.",
+          "",
+          "---",
+          "",
+          `https://github.com/TommyKammy/VeriDoc/blob/${headSha}/datasets/poc_evaluation_manifest_v1.json#L139-L140`,
+          "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Link the text-PDF sample to a PDF fixture**",
+          "",
+          "The sample resolves to parser-output JSON instead of a real PDF upload, so PDF parsing coverage is lost.",
+          "",
+          "<details><summary>About Codex</summary></details>",
+        ].join("\n"),
+      },
+    ],
+    statusContexts: [],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector"], headSha);
+
+  assert.equal(summary.lifecycle.state, "arrived");
+  assert.equal(summary.topLevelReview.strength, "blocking");
+  assert.equal(summary.topLevelReview.submittedAt, "2026-07-05T03:19:37Z");
+  assert.equal(summary.topLevelReview.findingCount, 2);
+  assert.equal(summary.topLevelReview.highestSeverity, "P2");
+  assert.deepEqual(
+    summary.topLevelReview.findings?.map((finding) => `${finding.severity}:${finding.path}:${finding.line}-${finding.lineEnd}`),
+    [
+      "P2:datasets/fixtures/pdf/record-pdf-representative.pdf:42-43",
+      "P2:datasets/poc_evaluation_manifest_v1.json:139-140",
+    ],
+  );
+  assert.equal(summary.currentHeadActionableObservedAt, "2026-07-05T03:19:37Z");
+});
+
 test("buildConfiguredBotReviewSummary anchors Codex Connector no-major issue comments to reviewed commits", () => {
   const headSha = "647c90b90b820cb17b83d2d80b5dddd3e789028b";
   const facts: CopilotReviewLifecycleFacts = {

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -1322,7 +1322,7 @@ test("buildConfiguredBotReviewSummary treats current-head Codex Review issue com
       {
         id: "IC_kw",
         databaseId: 4884683854,
-        authorLogin: "chatgpt-codex-connector",
+        authorLogin: "chatgpt-codex-connector[bot]",
         createdAt: "2026-07-05T03:19:37Z",
         url: "https://github.com/TommyKammy/VeriDoc/pull/219#issuecomment-4884683854",
         body: [

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -1362,7 +1362,54 @@ test("buildConfiguredBotReviewSummary treats current-head Codex Review issue com
       "P2:datasets/poc_evaluation_manifest_v1.json:139-140",
     ],
   );
+  assert.equal(summary.currentHeadObservedAt, "2026-07-05T03:19:37Z");
+  assert.equal(summary.currentHeadObservationSource, "codex_top_level_review_comment");
   assert.equal(summary.currentHeadActionableObservedAt, "2026-07-05T03:19:37Z");
+});
+
+test("buildConfiguredBotReviewSummary lets later same-head Codex success supersede older top-level findings", () => {
+  const headSha = "b0642d776275b58f3d2918fa1a48cb522d6f21ce";
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [],
+    comments: [],
+    issueComments: [
+      {
+        id: "IC_finding",
+        databaseId: 4884683854,
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-07-05T03:19:37Z",
+        url: "https://example.test/pr/219#issuecomment-4884683854",
+        body: [
+          "### Codex Review",
+          "",
+          `https://github.com/TommyKammy/VeriDoc/blob/${headSha}/datasets/poc_evaluation_manifest_v1.json#L139-L140`,
+          "**<sub><sub>![P2 Badge](https://img.shields.io/badge/P2-yellow?style=flat)</sub></sub>  Link the text-PDF sample to a PDF fixture**",
+          "",
+          "The sample resolves to parser-output JSON instead of a real PDF upload.",
+        ].join("\n"),
+      },
+      {
+        id: "IC_success",
+        databaseId: 4884683999,
+        authorLogin: "chatgpt-codex-connector",
+        createdAt: "2026-07-05T03:25:37Z",
+        url: "https://example.test/pr/219#issuecomment-4884683999",
+        body: `Codex Review: Didn't find any major issues. :tada:\n\n**Reviewed commit:** \`${headSha.slice(0, 10)}\``,
+      },
+    ],
+    statusContexts: [],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector"], headSha);
+
+  assert.equal(summary.topLevelReview.strength, null);
+  assert.equal(summary.topLevelReview.submittedAt, null);
+  assert.equal(summary.topLevelReview.findingCount, undefined);
+  assert.equal(summary.currentHeadObservedAt, "2026-07-05T03:25:37Z");
+  assert.equal(summary.currentHeadObservationSource, "codex_pr_success_comment");
+  assert.equal(summary.currentHeadActionableObservedAt, null);
 });
 
 test("buildConfiguredBotReviewSummary anchors Codex Connector no-major issue comments to reviewed commits", () => {

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -529,7 +529,11 @@ function inferConfiguredBotTopLevelReviewSummary(
       highestSeverity: highestCodexConnectorPSeverity(topLevelFindings),
       findings: topLevelFindings,
     };
-    if (!latestConfiguredReview.submittedAt || parseTimestamp(latestFindingSubmittedAt) >= latestConfiguredReviewMs) {
+    if (
+      mustFixFindings.length > 0 ||
+      !latestConfiguredReview.submittedAt ||
+      parseTimestamp(latestFindingSubmittedAt) >= latestConfiguredReviewMs
+    ) {
       return issueCommentSummary;
     }
     return {
@@ -812,7 +816,7 @@ function inferCurrentHeadCodexSuccessObservation(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
   currentHeadOid: string | null | undefined,
-): { observedAt: string; reviewedCommitSha: string } | null {
+): { observedAt: string; reviewedCommitSha: string | null } | null {
   const normalizedCurrentHeadOid = currentHeadOid?.trim();
   if (!normalizedCurrentHeadOid) {
     return null;
@@ -823,7 +827,7 @@ function inferCurrentHeadCodexSuccessObservation(
     return null;
   }
 
-  let latest: { createdAt: string; createdAtMs: number; reviewedCommitSha: string } | null = null;
+  let latest: { createdAt: string; createdAtMs: number; reviewedCommitSha: string | null } | null = null;
   for (const comment of facts.issueComments) {
     const authorLogin = normalizeLogin(comment.authorLogin);
     if (
@@ -835,7 +839,7 @@ function inferCurrentHeadCodexSuccessObservation(
     }
 
     const reviewedCommitSha = reviewedCommitFromBody(comment.body);
-    if (!commitShaMatchesByPrefix(reviewedCommitSha, normalizedCurrentHeadOid)) {
+    if (reviewedCommitSha && !commitShaMatchesByPrefix(reviewedCommitSha, normalizedCurrentHeadOid)) {
       continue;
     }
 
@@ -845,7 +849,7 @@ function inferCurrentHeadCodexSuccessObservation(
     }
 
     if (!latest || createdAtMs >= latest.createdAtMs) {
-      latest = { createdAt: comment.createdAt!, createdAtMs, reviewedCommitSha: reviewedCommitSha! };
+      latest = { createdAt: comment.createdAt!, createdAtMs, reviewedCommitSha };
     }
   }
 

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -861,6 +861,47 @@ function inferCurrentHeadCodexSuccessObservation(
     : null;
 }
 
+function inferCurrentHeadAnchoredCodexSuccessObservedAt(
+  facts: CopilotReviewLifecycleFacts,
+  reviewBotLogins: string[],
+  currentHeadOid: string | null | undefined,
+): string | null {
+  const normalizedCurrentHeadOid = currentHeadOid?.trim();
+  if (!normalizedCurrentHeadOid) {
+    return null;
+  }
+
+  const configuredReviewBots = new Set(normalizeReviewBotLogins(reviewBotLogins));
+  if (!hasConfiguredCodexConnectorLogin(configuredReviewBots)) {
+    return null;
+  }
+
+  let latest: { createdAt: string; createdAtMs: number } | null = null;
+  for (const comment of facts.issueComments) {
+    const authorLogin = normalizeLogin(comment.authorLogin);
+    const reviewedCommitSha = reviewedCommitFromBody(comment.body);
+    if (
+      !authorLogin ||
+      !isCodexConnectorLogin(authorLogin) ||
+      !isCodexConnectorPrSuccessCommentText(comment.body) ||
+      !commitShaMatchesByPrefix(reviewedCommitSha, normalizedCurrentHeadOid)
+    ) {
+      continue;
+    }
+
+    const createdAtMs = parseTimestamp(comment.createdAt);
+    if (createdAtMs === 0) {
+      continue;
+    }
+
+    if (!latest || createdAtMs >= latest.createdAtMs) {
+      latest = { createdAt: comment.createdAt!, createdAtMs };
+    }
+  }
+
+  return latest?.createdAt ?? null;
+}
+
 function inferConfiguredBotCurrentHeadActionableObservedAt(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
@@ -1109,7 +1150,7 @@ export function buildConfiguredBotReviewSummary(
   );
   const currentHeadCodexFindingSupersededAt = currentHeadCodexSuccessObservation?.reviewedCommitSha
     ? currentHeadCodexSuccessObservation.observedAt
-    : null;
+    : inferCurrentHeadAnchoredCodexSuccessObservedAt(facts, reviewBotLogins, currentHeadOid);
   const currentHeadActionableObservedAt = inferConfiguredBotCurrentHeadActionableObservedAt(
     facts,
     reviewBotLogins,

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -1107,17 +1107,20 @@ export function buildConfiguredBotReviewSummary(
     reviewBotLogins,
     currentHeadOid,
   );
+  const currentHeadCodexFindingSupersededAt = currentHeadCodexSuccessObservation?.reviewedCommitSha
+    ? currentHeadCodexSuccessObservation.observedAt
+    : null;
   const currentHeadActionableObservedAt = inferConfiguredBotCurrentHeadActionableObservedAt(
     facts,
     reviewBotLogins,
     currentHeadOid,
-    currentHeadCodexSuccessObservation?.observedAt ?? null,
+    currentHeadCodexFindingSupersededAt,
   );
   const topLevelReview = inferConfiguredBotTopLevelReviewSummary(
     facts,
     reviewBotLogins,
     currentHeadOid,
-    currentHeadCodexSuccessObservation?.observedAt ?? null,
+    currentHeadCodexFindingSupersededAt,
   );
   Object.defineProperty(topLevelReview, "configuredBotOnlyChangesRequestedReview", {
     enumerable: false,

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -532,7 +532,7 @@ function inferConfiguredBotTopLevelReviewSummary(
     if (
       mustFixFindings.length > 0 ||
       !latestConfiguredReview.submittedAt ||
-      parseTimestamp(latestFindingSubmittedAt) >= latestConfiguredReviewMs
+      (latestConfiguredReview.strength !== "blocking" && parseTimestamp(latestFindingSubmittedAt) >= latestConfiguredReviewMs)
     ) {
       return issueCommentSummary;
     }

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -11,6 +11,14 @@ import {
   normalizeReviewProviderLogin,
 } from "../core/review-providers";
 import type { CopilotReviewState } from "./types";
+import {
+  codexConnectorCurrentHeadTopLevelReviewFindings,
+  codexConnectorMustFixTopLevelReviewFindings,
+  codexConnectorNitpickTopLevelReviewFindings,
+  highestCodexConnectorPSeverity,
+  parseCodexConnectorTopLevelReviewFindings,
+  type CodexConnectorTopLevelReviewFinding,
+} from "../codex-connector-top-level-review";
 
 export interface CopilotReviewLifecycleFacts {
   reviewsComplete?: boolean;
@@ -70,6 +78,9 @@ export interface CopilotReviewLifecycle {
 export interface ConfiguredBotTopLevelReviewSummary {
   strength: "nitpick_only" | "blocking" | null;
   submittedAt: string | null;
+  findingCount?: number | null;
+  highestSeverity?: "P0" | "P1" | "P2" | "P3" | null;
+  findings?: CodexConnectorTopLevelReviewFinding[];
   configuredBotOnlyChangesRequestedReview?: boolean | null;
 }
 
@@ -416,7 +427,10 @@ export function inferCopilotReviewLifecycle(
   });
   const matchingIssueCommentTimes = facts.issueComments.flatMap((comment) => {
     const authorLogin = normalizeLogin(comment.authorLogin);
-    return authorLogin && configuredReviewBots.has(authorLogin) && hasActionableReviewText(comment.body) && scopedToActiveRequest(comment.createdAt)
+    return authorLogin &&
+      configuredReviewBots.has(authorLogin) &&
+      (hasActionableReviewText(comment.body) || parseCodexConnectorTopLevelReviewFindings(comment).length > 0) &&
+      scopedToActiveRequest(comment.createdAt)
       ? [comment.createdAt]
       : [];
   });
@@ -461,6 +475,7 @@ export function inferCopilotReviewLifecycle(
 function inferConfiguredBotTopLevelReviewSummary(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
+  currentHeadOid: string | null | undefined,
 ): ConfiguredBotTopLevelReviewSummary {
   const configuredReviewBots = new Set(normalizeReviewBotLogins(reviewBotLogins));
   if (configuredReviewBots.size === 0) {
@@ -490,6 +505,36 @@ function inferConfiguredBotTopLevelReviewSummary(
       submittedAt: review.submittedAt,
     };
     latestConfiguredReviewMs = submittedAtMs;
+  }
+
+  const currentHeadCodexReviewComments = facts.issueComments.filter((comment) => {
+    const authorLogin = normalizeLogin(comment.authorLogin);
+    return Boolean(authorLogin && configuredReviewBots.has(authorLogin) && isCodexConnectorLogin(authorLogin));
+  });
+  const topLevelFindings = codexConnectorCurrentHeadTopLevelReviewFindings({
+    comments: currentHeadCodexReviewComments,
+    currentHeadSha: currentHeadOid,
+  });
+  const mustFixFindings = codexConnectorMustFixTopLevelReviewFindings(topLevelFindings);
+  const nitpickFindings = codexConnectorNitpickTopLevelReviewFindings(topLevelFindings);
+  if (mustFixFindings.length > 0 || nitpickFindings.length > 0) {
+    const latestFindingSubmittedAt = latestTimestamp(topLevelFindings.map((finding) => finding.commentCreatedAt));
+    const issueCommentSummary: ConfiguredBotTopLevelReviewSummary = {
+      strength: mustFixFindings.length > 0 ? "blocking" : "nitpick_only",
+      submittedAt: latestFindingSubmittedAt,
+      findingCount: topLevelFindings.length,
+      highestSeverity: highestCodexConnectorPSeverity(topLevelFindings),
+      findings: topLevelFindings,
+    };
+    if (!latestConfiguredReview.submittedAt || parseTimestamp(latestFindingSubmittedAt) >= latestConfiguredReviewMs) {
+      return issueCommentSummary;
+    }
+    return {
+      ...latestConfiguredReview,
+      findingCount: topLevelFindings.length,
+      highestSeverity: highestCodexConnectorPSeverity(topLevelFindings),
+      findings: topLevelFindings,
+    };
   }
 
   if (!latestConfiguredReview.strength) {
@@ -853,6 +898,17 @@ function inferConfiguredBotCurrentHeadActionableObservedAt(
     }
   }
 
+  const topLevelFindings = codexConnectorCurrentHeadTopLevelReviewFindings({
+    comments: facts.issueComments.filter((comment) => {
+      const authorLogin = normalizeLogin(comment.authorLogin);
+      return Boolean(authorLogin && configuredReviewBots.has(authorLogin) && isCodexConnectorLogin(authorLogin));
+    }),
+    currentHeadSha: normalizedCurrentHeadOid,
+  });
+  for (const finding of codexConnectorMustFixTopLevelReviewFindings(topLevelFindings)) {
+    currentHeadActionableTimes.push(finding.commentCreatedAt);
+  }
+
   return latestTimestamp(currentHeadActionableTimes);
 }
 
@@ -1035,7 +1091,7 @@ export function buildConfiguredBotReviewSummary(
     currentHeadOid,
     currentHeadCodexSuccessObservation?.observedAt ?? null,
   );
-  const topLevelReview = inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins);
+  const topLevelReview = inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins, currentHeadOid);
   Object.defineProperty(topLevelReview, "configuredBotOnlyChangesRequestedReview", {
     enumerable: false,
     value: inferConfiguredBotOnlyChangesRequestedReview(facts, reviewBotLogins),

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -105,6 +105,7 @@ export type ConfiguredBotCurrentHeadObservationSource =
   | "review_thread_comment"
   | "status_context"
   | "codex_pr_success_comment"
+  | "codex_top_level_review_comment"
   | null;
 
 export interface CodexConnectorReviewRequestObservation {
@@ -476,6 +477,7 @@ function inferConfiguredBotTopLevelReviewSummary(
   facts: CopilotReviewLifecycleFacts,
   reviewBotLogins: string[],
   currentHeadOid: string | null | undefined,
+  currentHeadCodexSuccessObservedAt: string | null | undefined,
 ): ConfiguredBotTopLevelReviewSummary {
   const configuredReviewBots = new Set(normalizeReviewBotLogins(reviewBotLogins));
   if (configuredReviewBots.size === 0) {
@@ -514,6 +516,7 @@ function inferConfiguredBotTopLevelReviewSummary(
   const topLevelFindings = codexConnectorCurrentHeadTopLevelReviewFindings({
     comments: currentHeadCodexReviewComments,
     currentHeadSha: currentHeadOid,
+    supersededAt: currentHeadCodexSuccessObservedAt,
   });
   const mustFixFindings = codexConnectorMustFixTopLevelReviewFindings(topLevelFindings);
   const nitpickFindings = codexConnectorNitpickTopLevelReviewFindings(topLevelFindings);
@@ -746,6 +749,20 @@ function inferConfiguredBotCurrentHeadObservation(
         currentHeadObservations.push({ observedAt: comment.createdAt, source: "codex_pr_success_comment" });
       }
     }
+
+    const topLevelFindings = codexConnectorCurrentHeadTopLevelReviewFindings({
+      comments: facts.issueComments.filter((comment) => {
+        const authorLogin = normalizeLogin(comment.authorLogin);
+        return Boolean(authorLogin && configuredReviewBots.has(authorLogin) && isCodexConnectorLogin(authorLogin));
+      }),
+      currentHeadSha: normalizedCurrentHeadOid,
+    });
+    for (const finding of topLevelFindings) {
+      currentHeadObservations.push({
+        observedAt: finding.commentCreatedAt,
+        source: "codex_top_level_review_comment",
+      });
+    }
   }
 
   const latestStrongCurrentHeadObservedAt = latestTimestamp(currentHeadObservations.map((observation) => observation.observedAt));
@@ -904,6 +921,7 @@ function inferConfiguredBotCurrentHeadActionableObservedAt(
       return Boolean(authorLogin && configuredReviewBots.has(authorLogin) && isCodexConnectorLogin(authorLogin));
     }),
     currentHeadSha: normalizedCurrentHeadOid,
+    supersededAt: currentHeadCodexSuccessObservedAt,
   });
   for (const finding of codexConnectorMustFixTopLevelReviewFindings(topLevelFindings)) {
     currentHeadActionableTimes.push(finding.commentCreatedAt);
@@ -1091,7 +1109,12 @@ export function buildConfiguredBotReviewSummary(
     currentHeadOid,
     currentHeadCodexSuccessObservation?.observedAt ?? null,
   );
-  const topLevelReview = inferConfiguredBotTopLevelReviewSummary(facts, reviewBotLogins, currentHeadOid);
+  const topLevelReview = inferConfiguredBotTopLevelReviewSummary(
+    facts,
+    reviewBotLogins,
+    currentHeadOid,
+    currentHeadCodexSuccessObservation?.observedAt ?? null,
+  );
   Object.defineProperty(topLevelReview, "configuredBotOnlyChangesRequestedReview", {
     enumerable: false,
     value: inferConfiguredBotOnlyChangesRequestedReview(facts, reviewBotLogins),

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -50,6 +50,9 @@ export interface GitHubPullRequest {
   configuredBotDraftSkipAt?: string | null;
   configuredBotTopLevelReviewStrength?: "nitpick_only" | "blocking" | null;
   configuredBotTopLevelReviewSubmittedAt?: string | null;
+  configuredBotTopLevelReviewFindingCount?: number | null;
+  configuredBotTopLevelReviewHighestSeverity?: "P0" | "P1" | "P2" | "P3" | null;
+  configuredBotTopLevelReviewFindings?: import("../codex-connector-top-level-review").CodexConnectorTopLevelReviewFinding[] | null;
   configuredBotOnlyChangesRequestedReview?: boolean | null;
   requiredConversationResolution?: {
     state: "enabled" | "disabled" | "unavailable" | "unknown";

--- a/src/post-turn-pull-request-ready-promotion.test.ts
+++ b/src/post-turn-pull-request-ready-promotion.test.ts
@@ -187,6 +187,84 @@ test("handlePostTurnPullRequestTransitionsPhase refreshes PR state after marking
   assert.equal(syncJournalCalls, 3);
 });
 
+test("handlePostTurnPullRequestTransitionsPhase keeps draft PRs blocked by top-level Codex findings out of ready promotion", async () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const issue = createIssue({ title: "Gate ready promotion on top-level Codex findings" });
+  const draftPr = createPullRequest({
+    title: "Top-level Codex finding gate",
+    isDraft: true,
+    headRefOid: "head-116",
+    configuredBotTopLevelReviewFindings: [
+      {
+        id: "IC_kw:finding:1",
+        commentId: "IC_kw",
+        commentDatabaseId: 4884683854,
+        commentCreatedAt: "2026-07-05T03:19:37Z",
+        commentUrl: "https://example.test/pr/116#issuecomment-4884683854",
+        sourceUrl: "https://example.test/blob/head-116/src/file.ts#L12",
+        path: "src/file.ts",
+        line: 12,
+        lineEnd: 12,
+        headSha: "head-116",
+        severity: "P2",
+        title: "Block ready promotion",
+        body: "Top-level Codex findings should block the same post-turn gates as review threads.",
+        authorLogin: "chatgpt-codex-connector",
+        fingerprint: "IC_kw|head-116|src/file.ts|12|P2|block",
+      },
+    ],
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: {
+      "102": createRecord({
+        state: "draft_pr",
+        pr_number: 116,
+        last_head_sha: "head-116",
+      }),
+    },
+  };
+  let readyCalls = 0;
+
+  const result = await handlePostTurnPullRequestTransitionsPhase({
+    config,
+    stateStore: createNoopStateStore(),
+    github: createDefaultGithub({
+      markPullRequestReady: async () => {
+        readyCalls += 1;
+      },
+    }),
+    context: {
+      state,
+      record: state.issues["102"]!,
+      issue,
+      workspacePath: "/tmp/workspace",
+      syncJournal: async () => undefined,
+      memoryArtifacts: TEST_MEMORY_ARTIFACTS,
+      pr: draftPr,
+      options: { dryRun: false },
+    },
+    derivePullRequestLifecycleSnapshot: (record) => createLifecycleSnapshot(record, "draft_pr"),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    blockedReasonFromReviewState: () => null,
+    summarizeChecks,
+    configuredBotReviewThreads,
+    manualReviewThreads,
+    mergeConflictDetected: () => false,
+    loadOpenPullRequestSnapshot: async () => ({
+      pr: draftPr,
+      checks: [{ name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [],
+    }),
+  });
+
+  assert.equal(readyCalls, 0);
+  assert.equal(result.pr.isDraft, true);
+});
+
 test("handlePostTurnPullRequestTransitionsPhase clears stale ready-promotion blockers when refreshed state is waiting_ci", async (t) => {
   const { workspacePath, headSha } = await createTrackedIssueBranchRepo();
   t.after(async () => {

--- a/src/post-turn-pull-request.ts
+++ b/src/post-turn-pull-request.ts
@@ -49,6 +49,7 @@ import { maybePromoteDraftPullRequestToReady } from "./post-turn-ready-promotion
 import { effectiveConfiguredBotReviewThreadsForState } from "./pull-request-state-codex-residue-policy";
 import { getWorkspaceStatus } from "./core/workspace";
 import { projectCurrentHeadCodexRepairProof } from "./current-head-codex-repair-proof";
+import { codexConnectorMustFixTopLevelReviewFindings } from "./codex-connector-top-level-review";
 
 export { syncTrackedPrPersistentStatusComment } from "./tracked-pr-status-comment";
 
@@ -312,13 +313,16 @@ function hasEffectiveConfiguredBotReviewBlockers(args: {
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
 }): boolean {
-  return effectiveConfiguredBotReviewThreadsForState(
-    args.config,
-    args.record,
-    args.pr,
-    args.checks,
-    args.reviewThreads,
-  ).length > 0;
+  return (
+    effectiveConfiguredBotReviewThreadsForState(
+      args.config,
+      args.record,
+      args.pr,
+      args.checks,
+      args.reviewThreads,
+    ).length > 0 ||
+    codexConnectorMustFixTopLevelReviewFindings(args.pr.configuredBotTopLevelReviewFindings ?? []).length > 0
+  );
 }
 
 function staleReviewRepairProbeMayReadWorkspace(args: {

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -285,6 +285,47 @@ test("inferStateFromPullRequest still blocks stronger configured-bot top-level c
   assert.equal(inferStateFromPullRequest(config, createRecord({ state: "pr_open" }), pr, passingChecks(), []), "blocked");
 });
 
+test("inferStateFromPullRequest repairs top-level Codex must-fix findings even without aggregate reviewDecision", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    humanReviewBlocksMerge: false,
+  });
+  const pr = createPullRequest({
+    reviewDecision: null,
+    copilotReviewState: "arrived",
+    copilotReviewRequestedAt: "2026-07-05T03:18:00Z",
+    copilotReviewArrivedAt: "2026-07-05T03:19:37Z",
+    configuredBotCurrentHeadObservedAt: "2026-07-05T03:19:37Z",
+    configuredBotCurrentHeadObservationSource: "codex_top_level_review_comment",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-07-05T03:19:37Z",
+    configuredBotTopLevelReviewFindings: [
+      {
+        id: "IC_kw:finding:1",
+        commentId: "IC_kw",
+        commentDatabaseId: 4884683854,
+        commentCreatedAt: "2026-07-05T03:19:37Z",
+        commentUrl: "https://example.test/pr/219#issuecomment-4884683854",
+        sourceUrl: "https://example.test/blob/head123/datasets/poc_evaluation_manifest_v1.json#L139-L140",
+        path: "datasets/poc_evaluation_manifest_v1.json",
+        line: 139,
+        lineEnd: 140,
+        headSha: "head123",
+        severity: "P2",
+        title: "Link the text-PDF sample to a PDF fixture",
+        body: "The sample resolves to parser-output JSON instead of a real PDF upload.",
+        authorLogin: "chatgpt-codex-connector",
+        fingerprint: "IC_kw|head123|datasets/poc_evaluation_manifest_v1.json|139|P2|link",
+      },
+    ],
+  });
+
+  assert.equal(
+    inferStateFromPullRequest(config, createRecord({ state: "pr_open", last_head_sha: "head123" }), pr, passingChecks(), []),
+    "addressing_review",
+  );
+});
+
 test("inferStateFromPullRequest allows a journal-only configured-bot thread when the PR is otherwise green and CodeRabbit status is SUCCESS", () => {
   const config = createConfig({
     reviewBotLogins: ["coderabbitai", "coderabbitai[bot]"],

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -392,6 +392,31 @@ test("inferStateFromPullRequest blocks top-level Codex findings after their retr
     ),
     "blocked",
   );
+  assert.equal(
+    blockedReasonFromReviewState(
+      config,
+      createRecord({
+        state: "pr_open",
+        last_head_sha: "head123",
+        review_loop_retry_state: [
+          {
+            fingerprint,
+            pr_number: 219,
+            head_sha: "head123",
+            thread_id: target.id,
+            latest_comment_fingerprint: finding.fingerprint,
+            attempts: 1,
+            first_attempted_at: "2026-07-05T03:21:00Z",
+            last_attempted_at: "2026-07-05T03:21:00Z",
+          },
+        ],
+      }),
+      pr,
+      passingChecks(),
+      [],
+    ),
+    "manual_review",
+  );
 });
 
 test("inferStateFromPullRequest allows a journal-only configured-bot thread when the PR is otherwise green and CodeRabbit status is SUCCESS", () => {

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -21,6 +21,7 @@ import {
   CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
   createCodexConnectorTrackedReviewResidueScenario,
 } from "./codex-connector-tracked-pr-test-helpers";
+import { codexConnectorTopLevelReviewFindingRetryTarget } from "./codex-connector-top-level-review";
 import {
   currentHeadRepairProofSatisfiesConfiguredProviderSignal,
   hasConfiguredProviderSuccess,
@@ -31,6 +32,7 @@ import {
   VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
 } from "./supervisor/stale-review-bot-remediation";
 import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "./codex-connector-valid-review-repair";
+import { reviewLoopRetryFingerprintForThread } from "./review-handling";
 
 test("inferStateFromPullRequest routes actionable high local-review retry into local_review_fix", () => {
   const config = createConfig({
@@ -323,6 +325,72 @@ test("inferStateFromPullRequest repairs top-level Codex must-fix findings even w
   assert.equal(
     inferStateFromPullRequest(config, createRecord({ state: "pr_open", last_head_sha: "head123" }), pr, passingChecks(), []),
     "addressing_review",
+  );
+});
+
+test("inferStateFromPullRequest blocks top-level Codex findings after their retry budget is exhausted", () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    humanReviewBlocksMerge: false,
+  });
+  const finding = {
+    id: "IC_kw:finding:1",
+    commentId: "IC_kw",
+    commentDatabaseId: 4884683854,
+    commentCreatedAt: "2026-07-05T03:19:37Z",
+    commentUrl: "https://example.test/pr/219#issuecomment-4884683854",
+    sourceUrl: "https://example.test/blob/head123/datasets/poc_evaluation_manifest_v1.json#L139-L140",
+    path: "datasets/poc_evaluation_manifest_v1.json",
+    line: 139,
+    lineEnd: 140,
+    headSha: "head123",
+    severity: "P2" as const,
+    title: "Link the text-PDF sample to a PDF fixture",
+    body: "The sample resolves to parser-output JSON instead of a real PDF upload.",
+    authorLogin: "chatgpt-codex-connector",
+    fingerprint: "IC_kw|head123|datasets/poc_evaluation_manifest_v1.json|139|P2|link",
+  };
+  const pr = createPullRequest({
+    number: 219,
+    headRefOid: "head123",
+    reviewDecision: null,
+    copilotReviewState: "arrived",
+    copilotReviewRequestedAt: "2026-07-05T03:18:00Z",
+    copilotReviewArrivedAt: "2026-07-05T03:19:37Z",
+    configuredBotCurrentHeadObservedAt: "2026-07-05T03:19:37Z",
+    configuredBotCurrentHeadObservationSource: "codex_top_level_review_comment",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewSubmittedAt: "2026-07-05T03:19:37Z",
+    configuredBotTopLevelReviewFindings: [finding],
+  });
+  const target = codexConnectorTopLevelReviewFindingRetryTarget(finding);
+  const fingerprint = reviewLoopRetryFingerprintForThread(pr, target);
+  assert.ok(fingerprint);
+
+  assert.equal(
+    inferStateFromPullRequest(
+      config,
+      createRecord({
+        state: "pr_open",
+        last_head_sha: "head123",
+        review_loop_retry_state: [
+          {
+            fingerprint,
+            pr_number: 219,
+            head_sha: "head123",
+            thread_id: target.id,
+            latest_comment_fingerprint: finding.fingerprint,
+            attempts: 1,
+            first_attempted_at: "2026-07-05T03:21:00Z",
+            last_attempted_at: "2026-07-05T03:21:00Z",
+          },
+        ],
+      }),
+      pr,
+      passingChecks(),
+      [],
+    ),
+    "blocked",
   );
 });
 

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -19,6 +19,7 @@ import {
   codexConnectorMustFixReviewThreads,
   latestCodexConnectorReviewCommentFingerprint,
 } from "./codex-connector-review-policy";
+import { codexConnectorMustFixTopLevelReviewFindings } from "./codex-connector-top-level-review";
 import { shouldReenterCodexConnectorValidReviewRepair } from "./codex-connector-valid-review-repair-selection";
 import {
   actionableConfiguredBotReviewThreads,
@@ -339,6 +340,11 @@ export function inferStateFromPullRequest(
   });
   const reviewDecisionSatisfiedForState = reviewSatisfied(pr) || botReviewDecisionResidueSatisfied;
   const codexConnectorMustFixThreads = codexConnectorMustFixReviewThreads(unresolvedBotThreads);
+  const codexConnectorMustFixTopLevelFindings = codexConnectorMustFixTopLevelReviewFindings(
+    pr.configuredBotTopLevelReviewFindings ?? [],
+  );
+  const hasCodexConnectorMustFixRepairTargets =
+    codexConnectorMustFixThreads.length > 0 || codexConnectorMustFixTopLevelFindings.length > 0;
   const codexConnectorMustFixThreadIds = new Set(codexConnectorMustFixThreads.map((thread) => thread.id));
   const retryFingerprintForThread = (thread: ReviewThread) =>
     codexConnectorMustFixThreadIds.has(thread.id) ? latestCodexConnectorReviewCommentFingerprint(thread) : undefined;
@@ -504,7 +510,7 @@ export function inferStateFromPullRequest(
 
   if (
     stillValidCodexRepairAvailable ||
-    codexConnectorMustFixThreads.length > 0 &&
+    hasCodexConnectorMustFixRepairTargets &&
     !codexConnectorMustFixThreadsExhausted &&
     !checkSummary.hasFailing &&
     !checkSummary.hasPending &&

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -232,6 +232,14 @@ export function blockedReasonFromReviewState(
       reviewThreads,
     });
   const unresolvedBotThreads = effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads);
+  const codexConnectorMustFixTopLevelFindings = codexConnectorMustFixTopLevelReviewFindings(
+    pr.configuredBotTopLevelReviewFindings ?? [],
+  );
+  const codexConnectorMustFixTopLevelFindingsExhausted =
+    codexConnectorMustFixTopLevelFindings.length > 0 &&
+    codexConnectorMustFixTopLevelFindings
+      .map(codexConnectorTopLevelReviewFindingRetryTarget)
+      .every((target) => reviewLoopRetryBudgetExhaustedForThread(record, pr, target, 1));
   const botReviewDecisionResidueSatisfied = verifiedConfiguredBotReviewDecisionResidueSatisfied({
     verifiedCurrentHeadRepairResidue,
     effectiveConfiguredBotBlockerCount: unresolvedBotThreads.length,
@@ -274,6 +282,15 @@ export function blockedReasonFromReviewState(
   }
 
   if (unresolvedBotThreads.length > 0) {
+    return "manual_review";
+  }
+
+  if (
+    codexConnectorMustFixTopLevelFindingsExhausted &&
+    !checkSummary.hasPending &&
+    !checkSummary.hasFailing &&
+    !mergeConflictDetected(pr)
+  ) {
     return "manual_review";
   }
 

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -19,7 +19,10 @@ import {
   codexConnectorMustFixReviewThreads,
   latestCodexConnectorReviewCommentFingerprint,
 } from "./codex-connector-review-policy";
-import { codexConnectorMustFixTopLevelReviewFindings } from "./codex-connector-top-level-review";
+import {
+  codexConnectorMustFixTopLevelReviewFindings,
+  codexConnectorTopLevelReviewFindingRetryTarget,
+} from "./codex-connector-top-level-review";
 import { shouldReenterCodexConnectorValidReviewRepair } from "./codex-connector-valid-review-repair-selection";
 import {
   actionableConfiguredBotReviewThreads,
@@ -343,21 +346,26 @@ export function inferStateFromPullRequest(
   const codexConnectorMustFixTopLevelFindings = codexConnectorMustFixTopLevelReviewFindings(
     pr.configuredBotTopLevelReviewFindings ?? [],
   );
+  const codexConnectorMustFixTopLevelFindingTargets = codexConnectorMustFixTopLevelFindings.map(
+    codexConnectorTopLevelReviewFindingRetryTarget,
+  );
   const hasCodexConnectorMustFixRepairTargets =
     codexConnectorMustFixThreads.length > 0 || codexConnectorMustFixTopLevelFindings.length > 0;
   const codexConnectorMustFixThreadIds = new Set(codexConnectorMustFixThreads.map((thread) => thread.id));
   const retryFingerprintForThread = (thread: ReviewThread) =>
     codexConnectorMustFixThreadIds.has(thread.id) ? latestCodexConnectorReviewCommentFingerprint(thread) : undefined;
-  const reviewLoopRetryBudgetAvailable = (thread: ReviewThread) =>
+  const reviewLoopRetryBudgetAvailable = (thread: Pick<ReviewThread, "id" | "comments">) =>
+    !reviewLoopRetryBudgetExhaustedForThread(record, pr, thread, 1);
+  const reviewLoopRetryBudgetAvailableForThread = (thread: ReviewThread) =>
     !reviewLoopRetryBudgetExhaustedForThread(record, pr, thread, 1, retryFingerprintForThread(thread));
   const pendingBotThreads = pendingBotReviewThreads(config, record, pr, unresolvedBotThreads).filter(
-    reviewLoopRetryBudgetAvailable,
+    reviewLoopRetryBudgetAvailableForThread,
   );
   const botFollowUpState = configuredBotReviewFollowUpState(config, record, pr, unresolvedBotThreads);
   const actionableFollowUpThreads = actionableConfiguredBotReviewThreads(config, unresolvedBotThreads).filter(
     (thread) => !thread.isResolved && !thread.isOutdated,
   );
-  const availableActionableFollowUpThreads = actionableFollowUpThreads.filter(reviewLoopRetryBudgetAvailable);
+  const availableActionableFollowUpThreads = actionableFollowUpThreads.filter(reviewLoopRetryBudgetAvailableForThread);
   const botFollowUpStateEligibleWithRetryBudget =
     botFollowUpState === "eligible" && availableActionableFollowUpThreads.length > 0;
   const botFollowUpStateExhaustedByRetryBudget =
@@ -366,7 +374,14 @@ export function inferStateFromPullRequest(
     availableActionableFollowUpThreads.length === 0;
   const codexConnectorMustFixThreadsExhausted =
     codexConnectorMustFixThreads.length > 0 &&
-    codexConnectorMustFixThreads.every((thread) => !reviewLoopRetryBudgetAvailable(thread));
+    codexConnectorMustFixThreads.every((thread) => !reviewLoopRetryBudgetAvailableForThread(thread));
+  const codexConnectorMustFixTopLevelFindingsExhausted =
+    codexConnectorMustFixTopLevelFindingTargets.length > 0 &&
+    codexConnectorMustFixTopLevelFindingTargets.every((target) => !reviewLoopRetryBudgetAvailable(target));
+  const codexConnectorMustFixRepairTargetsExhausted =
+    hasCodexConnectorMustFixRepairTargets &&
+    (codexConnectorMustFixThreads.length === 0 || codexConnectorMustFixThreadsExhausted) &&
+    (codexConnectorMustFixTopLevelFindingTargets.length === 0 || codexConnectorMustFixTopLevelFindingsExhausted);
   const checkSummary = summarizeChecks(checks);
   const staleCodexWaitHasOnlyOutdatedResidue = staleSameHeadCodexWaitHasOnlyOutdatedResidue(
     config,
@@ -432,8 +447,8 @@ export function inferStateFromPullRequest(
 
     if (unresolvedBotThreads.length > 0 || pr.configuredBotTopLevelReviewStrength === "blocking") {
       if (
-        codexConnectorMustFixThreads.length > 0 &&
-        !codexConnectorMustFixThreadsExhausted &&
+        hasCodexConnectorMustFixRepairTargets &&
+        !codexConnectorMustFixRepairTargetsExhausted &&
         !checkSummary.hasFailing &&
         !checkSummary.hasPending &&
         (!config.humanReviewBlocksMerge || manualThreads.length === 0) &&
@@ -511,7 +526,7 @@ export function inferStateFromPullRequest(
   if (
     stillValidCodexRepairAvailable ||
     hasCodexConnectorMustFixRepairTargets &&
-    !codexConnectorMustFixThreadsExhausted &&
+    !codexConnectorMustFixRepairTargetsExhausted &&
     !checkSummary.hasFailing &&
     !checkSummary.hasPending &&
     (!config.humanReviewBlocksMerge || manualThreads.length === 0) &&
@@ -521,7 +536,7 @@ export function inferStateFromPullRequest(
   }
 
   if (
-    codexConnectorMustFixThreadsExhausted &&
+    codexConnectorMustFixRepairTargetsExhausted &&
     pendingBotThreads.length === 0 &&
     !botFollowUpStateEligibleWithRetryBudget &&
     !checkSummary.hasFailing &&

--- a/src/recovery-current-head-evidence.test.ts
+++ b/src/recovery-current-head-evidence.test.ts
@@ -33,6 +33,7 @@ test("currentHeadConfiguredBotEvidence requires an observed current-head signal 
       configuredBotCurrentHeadObservedAt: "2026-06-12T00:00:00Z",
       configuredBotCurrentHeadStatusState: "SUCCESS",
       configuredBotTopLevelReviewStrength: "blocking",
+      configuredBotTopLevelReviewFindings: [],
     }),
     "configured_bot_current_head_passed",
   );
@@ -41,6 +42,7 @@ test("currentHeadConfiguredBotEvidence requires an observed current-head signal 
       configuredBotCurrentHeadObservedAt: "2026-06-12T00:00:00Z",
       configuredBotCurrentHeadStatusState: null,
       configuredBotTopLevelReviewStrength: "nitpick_only",
+      configuredBotTopLevelReviewFindings: [],
     }),
     "configured_bot_current_head_passed",
   );
@@ -49,6 +51,7 @@ test("currentHeadConfiguredBotEvidence requires an observed current-head signal 
       configuredBotCurrentHeadObservedAt: null,
       configuredBotCurrentHeadStatusState: "SUCCESS",
       configuredBotTopLevelReviewStrength: "nitpick_only",
+      configuredBotTopLevelReviewFindings: [],
     }),
     null,
   );
@@ -57,6 +60,34 @@ test("currentHeadConfiguredBotEvidence requires an observed current-head signal 
       configuredBotCurrentHeadObservedAt: "2026-06-12T00:00:00Z",
       configuredBotCurrentHeadStatusState: "FAILURE",
       configuredBotTopLevelReviewStrength: "blocking",
+      configuredBotTopLevelReviewFindings: [],
+    }),
+    null,
+  );
+  assert.equal(
+    currentHeadConfiguredBotEvidence({
+      configuredBotCurrentHeadObservedAt: "2026-06-12T00:00:00Z",
+      configuredBotCurrentHeadStatusState: null,
+      configuredBotTopLevelReviewStrength: "nitpick_only",
+      configuredBotTopLevelReviewFindings: [
+        {
+          id: "finding-1",
+          commentId: "comment-1",
+          commentDatabaseId: 1,
+          commentCreatedAt: "2026-06-12T00:00:00Z",
+          commentUrl: "https://example.test/pr#issuecomment-1",
+          sourceUrl: "https://example.test/blob/head/src/file.ts#L1",
+          path: "src/file.ts",
+          line: 1,
+          lineEnd: 1,
+          headSha: "head",
+          severity: "P2",
+          title: "Keep blocking evidence active",
+          body: "This finding should prevent current-head evidence from being treated as passed.",
+          authorLogin: "chatgpt-codex-connector",
+          fingerprint: "finding-1",
+        },
+      ],
     }),
     null,
   );
@@ -71,6 +102,7 @@ test("trackedHandoffExternalProgressEvidence prefers green checks before configu
         configuredBotCurrentHeadObservedAt: "2026-06-12T00:00:00Z",
         configuredBotCurrentHeadStatusState: "SUCCESS",
         configuredBotTopLevelReviewStrength: "nitpick_only",
+        configuredBotTopLevelReviewFindings: [],
       },
       checks: [check({ name: "build", bucket: "pass", state: "SUCCESS" })],
     }),
@@ -84,6 +116,7 @@ test("trackedHandoffExternalProgressEvidence prefers green checks before configu
         configuredBotCurrentHeadObservedAt: "2026-06-12T00:00:00Z",
         configuredBotCurrentHeadStatusState: "SUCCESS",
         configuredBotTopLevelReviewStrength: "nitpick_only",
+        configuredBotTopLevelReviewFindings: [],
       },
       checks: [check({ name: "build", bucket: "pass", state: "SUCCESS" })],
     }),

--- a/src/recovery-current-head-evidence.ts
+++ b/src/recovery-current-head-evidence.ts
@@ -1,4 +1,5 @@
 import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck } from "./core/types";
+import { codexConnectorMustFixTopLevelReviewFindings } from "./codex-connector-top-level-review";
 import { summarizeChecks } from "./supervisor/supervisor-status-rendering";
 
 export function firstPassingCheckEvidence(checks: PullRequestCheck[]): string | null {
@@ -25,6 +26,7 @@ export function currentHeadConfiguredBotEvidence(
     | "configuredBotCurrentHeadObservedAt"
     | "configuredBotCurrentHeadStatusState"
     | "configuredBotTopLevelReviewStrength"
+    | "configuredBotTopLevelReviewFindings"
   >,
 ): string | null {
   if (!pr.configuredBotCurrentHeadObservedAt) {
@@ -37,9 +39,10 @@ export function currentHeadConfiguredBotEvidence(
     statusState === "pass" ||
     statusState === "passed";
   const topLevelPassed =
-    pr.configuredBotTopLevelReviewStrength === null ||
-    pr.configuredBotTopLevelReviewStrength === undefined ||
-    pr.configuredBotTopLevelReviewStrength === "nitpick_only";
+    codexConnectorMustFixTopLevelReviewFindings(pr.configuredBotTopLevelReviewFindings ?? []).length === 0 &&
+    (pr.configuredBotTopLevelReviewStrength === null ||
+      pr.configuredBotTopLevelReviewStrength === undefined ||
+      pr.configuredBotTopLevelReviewStrength === "nitpick_only");
 
   if (!statusPassed && !topLevelPassed) {
     return null;
@@ -55,6 +58,7 @@ export function trackedHandoffExternalProgressEvidence(args: {
     | "configuredBotCurrentHeadObservedAt"
     | "configuredBotCurrentHeadStatusState"
     | "configuredBotTopLevelReviewStrength"
+    | "configuredBotTopLevelReviewFindings"
     | "headRefOid"
   >;
   checks: PullRequestCheck[];

--- a/src/supervisor/replay-corpus-loading.test.ts
+++ b/src/supervisor/replay-corpus-loading.test.ts
@@ -300,6 +300,42 @@ test("replay corpus validation backfills missing operator summaries from older s
   assert.equal(validated.operatorSummary, null);
 });
 
+test("replay corpus validation preserves top-level Codex Review finding metadata", () => {
+  const pr = createPr({
+    configuredBotTopLevelReviewFindingCount: 1,
+    configuredBotTopLevelReviewHighestSeverity: "P2",
+    configuredBotTopLevelReviewFindings: [
+      {
+        id: "IC_kw:finding:1",
+        commentId: "IC_kw",
+        commentDatabaseId: 4884683854,
+        commentCreatedAt: "2026-07-05T03:19:37Z",
+        commentUrl: "https://example.test/pr/219#issuecomment-4884683854",
+        sourceUrl: "https://example.test/blob/head-532/datasets/poc_evaluation_manifest_v1.json#L139-L140",
+        path: "datasets/poc_evaluation_manifest_v1.json",
+        line: 139,
+        lineEnd: 140,
+        headSha: "head-532",
+        severity: "P2",
+        title: "Link the text-PDF sample to a PDF fixture",
+        body: "The sample resolves to parser-output JSON instead of a real PDF upload.",
+        authorLogin: "chatgpt-codex-connector",
+        fingerprint: "IC_kw|head-532|datasets/poc_evaluation_manifest_v1.json|139|P2|link",
+      },
+    ],
+  });
+  const snapshot = createSnapshot({ pr });
+
+  const validated = validateReplayCorpusInputSnapshot(snapshot, "top-level-codex-review-finding");
+
+  assert.equal(validated.github.pullRequest?.configuredBotTopLevelReviewFindingCount, 1);
+  assert.equal(validated.github.pullRequest?.configuredBotTopLevelReviewHighestSeverity, "P2");
+  assert.deepEqual(
+    validated.github.pullRequest?.configuredBotTopLevelReviewFindings,
+    pr.configuredBotTopLevelReviewFindings,
+  );
+});
+
 test("replay corpus validation preserves host-local CI posture fields", () => {
   const snapshot = createSnapshot({
     record: createRecord({

--- a/src/supervisor/replay-corpus-validation.ts
+++ b/src/supervisor/replay-corpus-validation.ts
@@ -71,6 +71,7 @@ const TIMELINE_ARTIFACT_GATES = [
 const TIMELINE_ARTIFACT_OUTCOMES = ["passed", "failed", "not_configured", "repair_queued"] as const;
 const COPILOT_REVIEW_STATES = ["not_requested", "requested", "arrived"] as const;
 const CONFIGURED_BOT_TOP_LEVEL_REVIEW_STRENGTHS = ["nitpick_only", "blocking"] as const;
+const CODEX_CONNECTOR_P_SEVERITIES = ["P0", "P1", "P2", "P3"] as const;
 const TRACKED_PR_REPEAT_FAILURE_DECISIONS = ["retry_on_progress", "stop_no_progress"] as const;
 
 export function validationError(message: string): Error {
@@ -653,6 +654,27 @@ function validateReviewThread(
   };
 }
 
+function validateTopLevelReviewFinding(raw: unknown, context: string) {
+  const finding = expectObject(raw, context);
+  return {
+    id: expectString(finding.id, `${context} id`),
+    commentId: expectNullableString(finding.commentId, `${context} commentId`),
+    commentDatabaseId: expectNullableInteger(finding.commentDatabaseId, `${context} commentDatabaseId`),
+    commentCreatedAt: expectString(finding.commentCreatedAt, `${context} commentCreatedAt`),
+    commentUrl: expectNullableString(finding.commentUrl, `${context} commentUrl`),
+    sourceUrl: expectString(finding.sourceUrl, `${context} sourceUrl`),
+    path: expectString(finding.path, `${context} path`),
+    line: expectInteger(finding.line, `${context} line`),
+    lineEnd: expectInteger(finding.lineEnd, `${context} lineEnd`),
+    headSha: expectString(finding.headSha, `${context} headSha`),
+    severity: expectEnum(finding.severity, `${context} severity`, CODEX_CONNECTOR_P_SEVERITIES),
+    title: expectString(finding.title, `${context} title`),
+    body: expectStringValue(finding.body, `${context} body`),
+    authorLogin: expectString(finding.authorLogin, `${context} authorLogin`),
+    fingerprint: expectString(finding.fingerprint, `${context} fingerprint`),
+  };
+}
+
 function validatePullRequest(raw: unknown, context: string): ReplayCorpusInputSnapshot["github"]["pullRequest"] {
   if (raw === null) {
     return null;
@@ -718,6 +740,29 @@ function validatePullRequest(raw: unknown, context: string): ReplayCorpusInputSn
       pullRequest.configuredBotTopLevelReviewSubmittedAt,
       `${context} configuredBotTopLevelReviewSubmittedAt`,
     ),
+    configuredBotTopLevelReviewFindingCount:
+      pullRequest.configuredBotTopLevelReviewFindingCount === undefined
+        ? undefined
+        : expectNullableInteger(
+            pullRequest.configuredBotTopLevelReviewFindingCount,
+            `${context} configuredBotTopLevelReviewFindingCount`,
+          ),
+    configuredBotTopLevelReviewHighestSeverity: expectOptionalNullableEnum(
+      pullRequest.configuredBotTopLevelReviewHighestSeverity,
+      `${context} configuredBotTopLevelReviewHighestSeverity`,
+      CODEX_CONNECTOR_P_SEVERITIES,
+    ),
+    configuredBotTopLevelReviewFindings:
+      pullRequest.configuredBotTopLevelReviewFindings === undefined
+        ? undefined
+        : pullRequest.configuredBotTopLevelReviewFindings === null
+          ? null
+          : expectArray(
+              pullRequest.configuredBotTopLevelReviewFindings,
+              `${context} configuredBotTopLevelReviewFindings`,
+            ).map((finding, index) =>
+              validateTopLevelReviewFinding(finding, `${context} configuredBotTopLevelReviewFindings[${index}]`),
+            ),
     mergedAt: expectOptionalNullableString(pullRequest.mergedAt, `${context} mergedAt`),
   };
 }

--- a/src/supervisor/supervisor-active-detailed-status-presenters.ts
+++ b/src/supervisor/supervisor-active-detailed-status-presenters.ts
@@ -19,6 +19,7 @@ import {
   configuredBotRateLimitWaitWindow,
   configuredBotSettledWaitWindow,
   configuredBotTopLevelReviewEffect,
+  configuredBotTopLevelReviewSummary,
   configuredReviewBots,
   configuredReviewStatusLabel,
   externalSignalReadinessDiagnostics,
@@ -295,7 +296,7 @@ export function buildActiveReviewBotProviderLines(
   }
   lines.push(`pr_hydration provenance=${pr.hydrationProvenance ?? "unknown"} head_sha=${pr.headRefOid}`);
   lines.push(
-    `configured_bot_top_level_review strength=${pr.configuredBotTopLevelReviewStrength ?? "none"} submitted_at=${pr.configuredBotTopLevelReviewSubmittedAt ?? "none"} effect=${configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads)}`,
+    `configured_bot_top_level_review ${configuredBotTopLevelReviewSummary(pr)} effect=${configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads)}`,
   );
   const configuredBotRateLimit = configuredBotRateLimitWaitWindow(config, pr);
   if (configuredBotRateLimit.observedAt) {

--- a/src/supervisor/supervisor-status-model-supervisor.test.ts
+++ b/src/supervisor/supervisor-status-model-supervisor.test.ts
@@ -783,7 +783,7 @@ test("buildDetailedStatusModel counts only unresolved configured bot threads in 
 
   assert.ok(
     lines.includes(
-      "configured_bot_top_level_review strength=nitpick_only submitted_at=2026-03-11T14:06:00Z effect=softened",
+      "configured_bot_top_level_review strength=nitpick_only submitted_at=2026-03-11T14:06:00Z finding_count=0 must_fix_count=0 nitpick_count=0 highest_severity=none effect=softened",
     ),
   );
   assert.ok(lines.includes("review_threads bot_pending=0 bot_unresolved=0 bot_effective_unresolved=0 bot_outdated_unresolved=0 manual=0"));

--- a/src/supervisor/supervisor-status-rendering-supervisor-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-rendering-supervisor-review-bot.test.ts
@@ -466,7 +466,7 @@ test("formatDetailedStatus explains softened nitpick-only configured-bot top-lev
 
   assert.match(
     status,
-    /configured_bot_top_level_review strength=nitpick_only submitted_at=2026-03-11T14:06:00Z effect=softened/,
+    /configured_bot_top_level_review strength=nitpick_only submitted_at=2026-03-11T14:06:00Z finding_count=0 must_fix_count=0 nitpick_count=0 highest_severity=none effect=softened/,
   );
 });
 

--- a/src/supervisor/supervisor-status-rendering.test.ts
+++ b/src/supervisor/supervisor-status-rendering.test.ts
@@ -236,7 +236,7 @@ test("formatDetailedStatus renders core lines before appended summaries", () => 
       "external_signal_readiness status=repo_not_ready_for_expected_signals ci=repo_not_configured review=disabled workflows=absent",
       "copilot_review state=not_requested requested_at=none arrived_at=none timed_out_at=none timeout_action=none",
       "pr_hydration provenance=unknown head_sha=deadbeef",
-      "configured_bot_top_level_review strength=none submitted_at=none effect=none",
+      "configured_bot_top_level_review strength=none submitted_at=none finding_count=0 must_fix_count=0 nitpick_count=0 highest_severity=none effect=none",
       "pr_state=OPEN draft=no merge_state=CLEAN review_decision=none head_sha=deadbeef",
       "checks=none",
       "review_threads bot_pending=0 bot_unresolved=0 bot_effective_unresolved=0 bot_outdated_unresolved=0 manual=0",

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -1069,6 +1069,51 @@ test("formatCodexConnectorConvergenceDiagnostic surfaces must-fix convergence st
   );
 });
 
+test("formatCodexConnectorConvergenceDiagnostic reports top-level Codex Review findings as must-fix", () => {
+  const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
+  const pr = createPr({
+    number: 219,
+    headRefOid: "b0642d776275b58f3d2918fa1a48cb522d6f21ce",
+    configuredBotCurrentHeadObservedAt: "2026-07-05T03:19:37Z",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewFindings: [
+      {
+        id: "IC_kw:finding:1",
+        commentId: "IC_kw",
+        commentDatabaseId: 4884683854,
+        commentCreatedAt: "2026-07-05T03:19:37Z",
+        commentUrl: "https://example.test/pr/219#issuecomment-4884683854",
+        sourceUrl:
+          "https://example.test/blob/b0642d776275b58f3d2918fa1a48cb522d6f21ce/datasets/poc_evaluation_manifest_v1.json#L139-L140",
+        path: "datasets/poc_evaluation_manifest_v1.json",
+        line: 139,
+        lineEnd: 140,
+        headSha: "b0642d776275b58f3d2918fa1a48cb522d6f21ce",
+        severity: "P2",
+        title: "Link the text-PDF sample to a PDF fixture",
+        body: "The sample resolves to parser-output JSON instead of a real PDF upload.",
+        authorLogin: "chatgpt-codex-connector",
+        fingerprint: "IC_kw|head|datasets/poc_evaluation_manifest_v1.json|139|P2|link",
+      },
+    ],
+  });
+
+  assert.equal(
+    formatCodexConnectorConvergenceDiagnostic({
+      config,
+      record: createRecord({
+        state: "addressing_review",
+        pr_number: pr.number,
+        provider_success_head_sha: null,
+        provider_success_observed_at: null,
+      }),
+      pr,
+      reviewThreads: [],
+    }),
+    "codex_connector_convergence status=repairing_must_fix provider=codex current_head_sha=b0642d776275b58f3d2918fa1a48cb522d6f21ce current_head_observed_at=2026-07-05T03:19:37Z latest_signal_head_sha=b0642d776275b58f3d2918fa1a48cb522d6f21ce highest_severity=P2 finding_count=1 merge_effect=blocked next_action=repair_must_fix_findings",
+  );
+});
+
 test("formatCodexConnectorConvergenceDiagnostic distinguishes Codex Connector request lifecycle states", () => {
   const config = createConfig({
     reviewBotLogins: ["chatgpt-codex-connector"],

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import {
   configuredBotTopLevelReviewEffect,
+  configuredBotTopLevelReviewSummary,
   externalSignalReadinessDiagnostics,
   configuredReviewStatusLabel,
   reviewBotDiagnostics,
@@ -710,6 +711,42 @@ test("configured review helpers preserve top-level status semantics", () => {
       configuredBotReviewThreads,
     ),
     "awaiting_thread_resolution",
+  );
+  const topLevelFindingPr = createPr({
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-07-05T03:19:37Z",
+    configuredBotTopLevelReviewFindings: [
+      {
+        id: "finding-1",
+        commentId: "comment-1",
+        commentDatabaseId: 1,
+        commentCreatedAt: "2026-07-05T03:19:37Z",
+        commentUrl: "https://example.test/pr#issuecomment-1",
+        sourceUrl: "https://example.test/blob/head-sha/src/file.ts#L1-L2",
+        path: "src/file.ts",
+        line: 1,
+        lineEnd: 2,
+        headSha: "head-sha",
+        severity: "P2",
+        title: "Keep top-level blockers visible",
+        body: "The status effect should not soften while must-fix findings remain.",
+        authorLogin: "chatgpt-codex-connector",
+        fingerprint: "finding-1",
+      },
+    ],
+  });
+  assert.equal(
+    configuredBotTopLevelReviewEffect(
+      createConfig({ reviewBotLogins: ["coderabbitai[bot]"] }),
+      topLevelFindingPr,
+      [],
+      configuredBotReviewThreads,
+    ),
+    "blocking",
+  );
+  assert.equal(
+    configuredBotTopLevelReviewSummary(topLevelFindingPr),
+    "strength=nitpick_only submitted_at=2026-07-05T03:19:37Z finding_count=1 must_fix_count=1 nitpick_count=0 highest_severity=P2",
   );
 });
 

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -7,6 +7,11 @@ import {
 } from "../core/review-providers";
 import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "../core/types";
 import { localReviewDegradedNeedsBlock } from "../review-handling";
+import {
+  codexConnectorMustFixTopLevelReviewFindings,
+  codexConnectorNitpickTopLevelReviewFindings,
+  highestCodexConnectorPSeverity,
+} from "../codex-connector-top-level-review";
 import { classifyStaleReviewBotRecoverability, recoverabilityStatusToken } from "./stale-diagnostic-recoverability";
 import {
   configuredBotCurrentHeadSignalWaitWindow,
@@ -297,7 +302,15 @@ export function configuredBotTopLevelReviewEffect(
   reviewThreads: ReviewThread[],
   configuredBotReviewThreads: ReviewThreadClassifier,
 ): string {
-  if (!repoExpectsConfiguredBotReview(config) || !pr.configuredBotTopLevelReviewStrength) {
+  if (!repoExpectsConfiguredBotReview(config)) {
+    return "none";
+  }
+  const mustFixFindings = codexConnectorMustFixTopLevelReviewFindings(pr.configuredBotTopLevelReviewFindings ?? []);
+  if (mustFixFindings.length > 0) {
+    return "blocking";
+  }
+
+  if (!pr.configuredBotTopLevelReviewStrength) {
     return "none";
   }
 
@@ -308,4 +321,18 @@ export function configuredBotTopLevelReviewEffect(
   }
 
   return "blocking";
+}
+
+export function configuredBotTopLevelReviewSummary(pr: GitHubPullRequest): string {
+  const findings = pr.configuredBotTopLevelReviewFindings ?? [];
+  const mustFixFindings = codexConnectorMustFixTopLevelReviewFindings(findings);
+  const nitpickFindings = codexConnectorNitpickTopLevelReviewFindings(findings);
+  return [
+    `strength=${pr.configuredBotTopLevelReviewStrength ?? "none"}`,
+    `submitted_at=${pr.configuredBotTopLevelReviewSubmittedAt ?? "none"}`,
+    `finding_count=${findings.length}`,
+    `must_fix_count=${mustFixFindings.length}`,
+    `nitpick_count=${nitpickFindings.length}`,
+    `highest_severity=${highestCodexConnectorPSeverity(findings) ?? "none"}`,
+  ].join(" ");
 }

--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -179,6 +179,58 @@ test("nextProcessedReviewThreadPatch records Codex must-fix retries when a later
   ]);
 });
 
+test("nextProcessedReviewThreadPatch records top-level Codex finding retry attempts", () => {
+  const patch = nextProcessedReviewThreadPatch({
+    config: createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] }),
+    preRunState: "addressing_review",
+    record: {
+      processed_review_thread_ids: [],
+      processed_review_thread_fingerprints: [],
+      review_loop_retry_state: [],
+    },
+    currentPr: createPullRequest({
+      number: 2270,
+      headRefOid: "head-a",
+      configuredBotTopLevelReviewFindings: [
+        {
+          id: "IC_kw:finding:1",
+          commentId: "IC_kw",
+          commentDatabaseId: 4884683854,
+          commentCreatedAt: "2026-07-05T03:19:37Z",
+          commentUrl: "https://example.test/pr/2270#issuecomment-4884683854",
+          sourceUrl: "https://example.test/blob/head-a/src/top-level.ts#L14-L15",
+          path: "src/top-level.ts",
+          line: 14,
+          lineEnd: 15,
+          headSha: "head-a",
+          severity: "P2",
+          title: "Keep the top-level finding under retry budget",
+          body: "A top-level Codex finding without a review thread should not retry forever.",
+          authorLogin: "chatgpt-codex-connector",
+          fingerprint: "IC_kw|head-a|src/top-level.ts|14|P2|retry",
+        },
+      ],
+    }),
+    evaluatedReviewHeadSha: "head-a",
+    attemptedAt: "2026-07-05T03:21:00Z",
+    reviewThreadsToProcess: [],
+  });
+
+  assert.deepEqual(patch.review_loop_retry_state, [
+    {
+      fingerprint:
+        "pr=2270|head=head-a|thread=codex-top-level-finding:IC_kw:finding:1|comment=IC_kw|head-a|src/top-level.ts|14|P2|retry",
+      pr_number: 2270,
+      head_sha: "head-a",
+      thread_id: "codex-top-level-finding:IC_kw:finding:1",
+      latest_comment_fingerprint: "IC_kw|head-a|src/top-level.ts|14|P2|retry",
+      attempts: 1,
+      first_attempted_at: "2026-07-05T03:21:00Z",
+      last_attempted_at: "2026-07-05T03:21:00Z",
+    },
+  ]);
+});
+
 test("nextProcessedReviewThreadPatch persists local-review no-change current-head verification evidence", () => {
   const headSha = "7a77d998712882166f79c3710dd4c567da6da779";
   const reviewThreads = [

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -26,6 +26,10 @@ import {
   codexConnectorMustFixReviewThreads,
   latestCodexConnectorReviewCommentFingerprint,
 } from "./codex-connector-review-policy";
+import {
+  codexConnectorMustFixTopLevelReviewFindings,
+  codexConnectorTopLevelReviewFindingRetryTarget,
+} from "./codex-connector-top-level-review";
 import { codexConnectorStillValidReviewRepairThreads } from "./codex-connector-valid-review-repair";
 import {
   actionableConfiguredBotReviewThreads,
@@ -426,7 +430,7 @@ export function nextProcessedReviewThreadPatch(args: {
     IssueRunRecord,
     "processed_review_thread_ids" | "processed_review_thread_fingerprints" | "review_loop_retry_state"
   >;
-  currentPr: Pick<GitHubPullRequest, "number" | "headRefOid"> | null;
+  currentPr: Pick<GitHubPullRequest, "number" | "headRefOid" | "configuredBotTopLevelReviewFindings"> | null;
   evaluatedReviewHeadSha: string;
   reviewThreadsToProcess: ReviewThread[];
   persistVerifiedNoSourceChangeCurrentHead?: boolean;
@@ -474,6 +478,12 @@ export function nextProcessedReviewThreadPatch(args: {
     args.reviewThreadsToProcess,
   ).filter((thread) => !thread.isResolved && !thread.isOutdated);
   const codexMustFixThreadsToTrack = codexConnectorMustFixReviewThreads(unresolvedConfiguredThreadsToProcess);
+  const codexMustFixTopLevelFindingTargetsToTrack =
+    args.currentPr && args.currentPr.headRefOid === args.evaluatedReviewHeadSha
+      ? codexConnectorMustFixTopLevelReviewFindings(args.currentPr.configuredBotTopLevelReviewFindings ?? []).map(
+          codexConnectorTopLevelReviewFindingRetryTarget,
+        )
+      : [];
   const retryThreadsToTrack = uniqueReviewThreadsInOrder(
     unresolvedConfiguredThreadsToProcess,
     new Set([...actionableThreadsToTrack, ...codexMustFixThreadsToTrack].map((thread) => thread.id)),
@@ -483,18 +493,28 @@ export function nextProcessedReviewThreadPatch(args: {
     args.preRunState === "addressing_review" &&
     args.currentPr &&
     args.currentPr.headRefOid === args.evaluatedReviewHeadSha
-      ? retryThreadsToTrack.reduce(
-            (state, thread) =>
+      ? codexMustFixTopLevelFindingTargetsToTrack
+          .reduce(
+            (state, target) =>
               nextReviewLoopRetryStateForThread({
                 record: { review_loop_retry_state: state },
                 pr: args.currentPr!,
-                thread,
+                thread: target,
                 attemptedAt: args.attemptedAt ?? new Date().toISOString(),
-                latestCommentFingerprintOverride: codexMustFixThreadIdsToTrack.has(thread.id)
-                  ? latestCodexConnectorReviewCommentFingerprint(thread)
-                  : undefined,
               }),
-            args.record.review_loop_retry_state ?? [],
+            retryThreadsToTrack.reduce(
+              (state, thread) =>
+                nextReviewLoopRetryStateForThread({
+                  record: { review_loop_retry_state: state },
+                  pr: args.currentPr!,
+                  thread,
+                  attemptedAt: args.attemptedAt ?? new Date().toISOString(),
+                  latestCommentFingerprintOverride: codexMustFixThreadIdsToTrack.has(thread.id)
+                    ? latestCodexConnectorReviewCommentFingerprint(thread)
+                    : undefined,
+                }),
+              args.record.review_loop_retry_state ?? [],
+            ),
           )
           .slice(-200)
       : args.record.review_loop_retry_state ?? [];


### PR DESCRIPTION
## Summary
- Parse top-level `### Codex Review` issue comments from `chatgpt-codex-connector` into current-head findings anchored by blob SHA.
- Hydrate those findings onto PR review signals so blocking/nitpick strength, actionable current-head observation, convergence diagnostics, and Codex repair prompts treat them like first-class review findings.
- Keep them distinct from GitHub review threads; they are not treated as resolvable conversation threads.

Closes #2403.

## Verification
- `npm run build`
- `npx tsx --test src/github/github-review-signals.test.ts src/codex-connector-review-policy.test.ts src/codex/codex-prompt.test.ts src/supervisor/supervisor-status-review-bot.test.ts`
- `npm run verify:supervisor-pre-pr` with local `supervisor.config.*.json` stashed temporarily to avoid host-local path drift checks