### PR TITLE
[codex] Recover current-head Codex residue proof

### DIFF
--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -323,6 +323,83 @@ test("projectCurrentHeadCodexRepairProof keeps processed Codex evidence after tr
   assert.equal(proof?.source, "record_processed_thread_evidence");
 });
 
+test("projectCurrentHeadCodexRepairProof rejects trusted supervisor stale reply from another thread", () => {
+  const headSha = "7cbf3d07397c51cb7a4de4ff47875154cce6f6c6";
+  const thread = codexThread({
+    id: "PRRT_current_clean_supervisor_reply_mismatch",
+    commentId: "comment-codex-before-mismatched-supervisor",
+    severity: "P2",
+    line: 810,
+  });
+  thread.comments.nodes[0]!.createdAt = "2026-07-06T01:36:26Z";
+  thread.comments.nodes.push({
+    id: "comment-supervisor-stale-reply-wrong-thread",
+    body: [
+      `The supervisor reprocessed this configured-bot finding on the current head \`${headSha}\` and classified it as stale.`,
+      `Audit: issue=#216 pr=#220 head=${headSha} thread=PRRT_other_thread reason=stale_review_bot.`,
+      "Evidence: location=scripts/evaluate_dataset.py:810 processed_on_current_head=yes.",
+      "Under the configured `reply_and_resolve` policy, the supervisor is auto-resolving this stale thread now.",
+    ].join("\n\n"),
+    createdAt: "2026-07-06T02:17:27Z",
+    url: "https://example.test/pr/220#discussion_r3526118510",
+    author: {
+      login: "TommyKammy",
+      typeName: "User",
+    },
+  });
+  const config = createConfig({
+    repoSlug: "TommyKammy/VeriDoc",
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "python3 -m unittest tests.test_evaluate_dataset",
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    codex_connector_review_requested_observed_at: "2026-07-06T02:09:23Z",
+    codex_connector_review_requested_head_sha: headSha,
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-codex-before-mismatched-supervisor`],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python3 -m unittest tests.test_evaluate_dataset",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Reverified unresolved Connector review cluster as covered by existing P9 harness guards/tests.",
+        recorded_at: "2026-07-06T02:16:30Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    currentHeadCiGreenAt: "2026-07-06T01:59:38Z",
+    configuredBotCurrentHeadObservedAt: "2026-07-06T02:15:17Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "7cbf3d0739",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-06T02:15:17Z",
+    codexConnectorReviewRequestedAt: "2026-07-06T02:09:23Z",
+    codexConnectorReviewRequestedHeadSha: headSha,
+  });
+
+  const proof = projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+    allowRecordProcessedThreadEvidence: true,
+  });
+
+  assert.equal(proof, null);
+});
+
 test("projectCurrentHeadCodexRepairProof rejects record-scoped proof before latest thread comments", () => {
   const headSha = "74d44b0a48f7b65fbcc9361a6509727c3ba987dc";
   const threads = [

--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -323,6 +323,80 @@ test("projectCurrentHeadCodexRepairProof keeps processed Codex evidence after tr
   assert.equal(proof?.source, "record_processed_thread_evidence");
 });
 
+test("projectCurrentHeadCodexRepairProof accepts structured proof keyed by trusted supervisor stale reply", () => {
+  const headSha = "7cbf3d07397c51cb7a4de4ff47875154cce6f6c6";
+  const thread = codexThread({
+    id: "PRRT_current_clean_supervisor_fingerprint",
+    commentId: "comment-codex-before-supervisor-fingerprint",
+    severity: "P2",
+    line: 810,
+  });
+  thread.comments.nodes[0]!.createdAt = "2026-07-06T01:36:26Z";
+  thread.comments.nodes.push({
+    id: "comment-supervisor-fingerprint",
+    body: [
+      `The supervisor reprocessed this configured-bot finding on the current head \`${headSha}\` and classified it as stale.`,
+      `Audit: issue=#216 pr=#220 head=${headSha} thread=${thread.id} reason=stale_review_bot.`,
+      "Evidence: location=scripts/evaluate_dataset.py:810 processed_on_current_head=yes.",
+    ].join("\n\n"),
+    createdAt: "2026-07-06T02:17:27Z",
+    url: "https://example.test/pr/220#discussion_r3526118512",
+    author: {
+      login: "TommyKammy",
+      typeName: "User",
+    },
+  });
+  const config = createConfig({
+    repoSlug: "TommyKammy/VeriDoc",
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-supervisor-fingerprint`],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run build",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Current-head proof was recorded after the supervisor stale reply.",
+        recorded_at: "2026-07-06T02:18:30Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${thread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-supervisor-fingerprint`],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    currentHeadCiGreenAt: "2026-07-06T02:18:00Z",
+    configuredBotCurrentHeadObservedAt: "2026-07-06T02:15:17Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "7cbf3d0739",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-06T02:15:17Z",
+  });
+
+  const proof = projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+    allowRecordProcessedThreadEvidence: true,
+  });
+
+  assert.equal(proof?.source, "structured_artifact");
+});
+
 test("projectCurrentHeadCodexRepairProof rejects trusted supervisor stale reply from another thread", () => {
   const headSha = "7cbf3d07397c51cb7a4de4ff47875154cce6f6c6";
   const thread = codexThread({

--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -246,6 +246,83 @@ test("projectCurrentHeadCodexRepairProof accepts record-scoped processed evidenc
   assert.match(proof?.summary ?? "", /codex_no_major_support=codex_pr_success_comment_reviewed_current_head/);
 });
 
+test("projectCurrentHeadCodexRepairProof keeps processed Codex evidence after trusted supervisor stale reply", () => {
+  const headSha = "7cbf3d07397c51cb7a4de4ff47875154cce6f6c6";
+  const thread = codexThread({
+    id: "PRRT_current_clean_supervisor_reply",
+    commentId: "comment-codex-before-clean",
+    severity: "P2",
+    line: 810,
+  });
+  thread.comments.nodes[0]!.createdAt = "2026-07-06T01:36:26Z";
+  thread.comments.nodes.push({
+    id: "comment-supervisor-stale-reply",
+    body: [
+      `The supervisor reprocessed this configured-bot finding on the current head \`${headSha}\` and classified it as stale.`,
+      `Audit: issue=#216 pr=#220 head=${headSha} thread=${thread.id} reason=stale_review_bot.`,
+      "Evidence: location=scripts/evaluate_dataset.py:810 processed_on_current_head=yes.",
+      "Under the configured `reply_and_resolve` policy, the supervisor is auto-resolving this stale thread now.",
+    ].join("\n\n"),
+    createdAt: "2026-07-06T02:17:27Z",
+    url: "https://example.test/pr/220#discussion_r3526118509",
+    author: {
+      login: "TommyKammy",
+      typeName: "User",
+    },
+  });
+  const config = createConfig({
+    repoSlug: "TommyKammy/VeriDoc",
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    localCiCommand: "python3 -m unittest tests.test_evaluate_dataset",
+  });
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    codex_connector_review_requested_observed_at: "2026-07-06T02:09:23Z",
+    codex_connector_review_requested_head_sha: headSha,
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-codex-before-clean`],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "python3 -m unittest tests.test_evaluate_dataset",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Reverified unresolved Connector review cluster as covered by existing P9 harness guards/tests.",
+        recorded_at: "2026-07-06T02:16:30Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    reviewDecision: null,
+    currentHeadCiGreenAt: "2026-07-06T01:59:38Z",
+    configuredBotCurrentHeadObservedAt: "2026-07-06T02:15:17Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "7cbf3d0739",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-06T02:15:17Z",
+    codexConnectorReviewRequestedAt: "2026-07-06T02:09:23Z",
+    codexConnectorReviewRequestedHeadSha: headSha,
+  });
+
+  const proof = projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+    allowRecordProcessedThreadEvidence: true,
+  });
+
+  assert.equal(proof?.source, "record_processed_thread_evidence");
+});
+
 test("projectCurrentHeadCodexRepairProof rejects record-scoped proof before latest thread comments", () => {
   const headSha = "74d44b0a48f7b65fbcc9361a6509727c3ba987dc";
   const threads = [

--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -400,6 +400,70 @@ test("projectCurrentHeadCodexRepairProof rejects trusted supervisor stale reply 
   assert.equal(proof, null);
 });
 
+test("projectCurrentHeadCodexRepairProof treats supervisor replies as untrusted when repo owner is unavailable", () => {
+  const headSha = "7cbf3d07397c51cb7a4de4ff47875154cce6f6c6";
+  const thread = codexThread({
+    id: "PRRT_current_clean_missing_repo_slug",
+    commentId: "comment-codex-before-missing-repo-slug",
+    severity: "P2",
+    line: 810,
+  });
+  thread.comments.nodes.push({
+    id: "comment-supervisor-stale-reply-missing-repo-slug",
+    body: [
+      `The supervisor reprocessed this configured-bot finding on the current head \`${headSha}\` and classified it as stale.`,
+      `Audit: issue=#216 pr=#220 head=${headSha} thread=${thread.id} reason=stale_review_bot.`,
+    ].join("\n\n"),
+    createdAt: "2026-07-06T02:17:27Z",
+    url: "https://example.test/pr/220#discussion_r3526118511",
+    author: {
+      login: "TommyKammy",
+      typeName: "User",
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+  });
+  delete (config as { repoSlug?: string }).repoSlug;
+  const record = createRecord({
+    last_head_sha: headSha,
+    blocked_reason: "manual_review",
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-codex-before-missing-repo-slug`],
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run build",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Current head repair proof covers the unresolved Connector residue.",
+        recorded_at: "2026-07-06T02:16:30Z",
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: headSha,
+    currentHeadCiGreenAt: "2026-07-06T01:59:38Z",
+    configuredBotCurrentHeadObservedAt: "2026-07-06T02:15:17Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "7cbf3d0739",
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-06T02:15:17Z",
+  });
+
+  assert.equal(projectCurrentHeadCodexRepairProof({
+    config,
+    record,
+    pr,
+    checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+    reviewThreads: [thread],
+    allowRecordProcessedThreadEvidence: true,
+  }), null);
+});
+
 test("projectCurrentHeadCodexRepairProof rejects record-scoped proof before latest thread comments", () => {
   const headSha = "74d44b0a48f7b65fbcc9361a6509727c3ba987dc";
   const threads = [

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -62,6 +62,7 @@ function configuredReviewProvidersAreCodexOnly(config: SupervisorConfig): boolea
 
 function unresolvedConfiguredBotThreadsAreCodexConnectorOnly(
   config: SupervisorConfig,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
   reviewThreads: ReviewThread[],
 ): boolean {
   return configuredBotReviewThreads(config, reviewThreads)
@@ -71,7 +72,7 @@ function unresolvedConfiguredBotThreadsAreCodexConnectorOnly(
         const latestComment = latestReviewComment(thread);
         return (
           (latestReviewCommentAuthorIsAllowedBot(config, thread) ||
-            Boolean(latestComment && isSupervisorStaleResidueComment(config, latestComment))) &&
+            Boolean(latestComment && isSupervisorStaleResidueComment(config, pr, thread, latestComment))) &&
           hasCodexConnectorFindingReviewComment(thread)
         );
       },
@@ -174,14 +175,14 @@ function repairArtifactCoversCurrentThreads(
   const processedThreadFingerprints = artifact.processed_review_thread_fingerprints ?? [];
   return currentThreads.every((thread) => {
     const headScopedKey = processedReviewThreadKey(thread.id, pr.headRefOid);
-    const latestFingerprint = currentHeadRepairProofThreadFingerprint(config, thread);
+    const latestFingerprint = currentHeadRepairProofThreadFingerprint(config, pr, thread);
     if (
       latestFingerprint &&
       processedThreadFingerprints.includes(
         processedReviewThreadFingerprintKey(thread.id, pr.headRefOid, latestFingerprint),
       )
     ) {
-      return latestReviewThreadCommentPredatesArtifact(config, thread, artifact);
+      return latestReviewThreadCommentPredatesArtifact(config, pr, thread, artifact);
     }
     if (!processedThreadIds.includes(headScopedKey)) {
       return false;
@@ -193,7 +194,7 @@ function repairArtifactCoversCurrentThreads(
     const threadFingerprintPrefix = `${headScopedKey}#`;
     return (
       !processedThreadFingerprints.some((key) => key.startsWith(threadFingerprintPrefix)) &&
-      latestReviewThreadCommentPredatesArtifact(config, thread, artifact)
+      latestReviewThreadCommentPredatesArtifact(config, pr, thread, artifact)
     );
   });
 }
@@ -209,10 +210,11 @@ function coveredCurrentThreadCount(
 
 function latestReviewThreadCommentPredatesArtifact(
   config: SupervisorConfig,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
   thread: ReviewThread,
   artifact: Pick<TimelineArtifact, "recorded_at">,
 ): boolean {
-  const latestComment = currentHeadRepairProofReferenceComment(config, thread);
+  const latestComment = currentHeadRepairProofReferenceComment(config, pr, thread);
   if (!latestComment) {
     return true;
   }
@@ -226,33 +228,102 @@ function latestReviewThreadCommentPredatesArtifact(
   return latestCommentMs <= artifactRecordedMs;
 }
 
-function isSupervisorStaleResidueComment(config: SupervisorConfig, comment: ReviewThreadComment): boolean {
-  return (
-    isTrustedSupervisorMarkerAuthor(config, comment) &&
-    (
-      isSupervisorVerifiedStaleResidueAutoResolveComment(comment.body) ||
-      (
-        /\bThe supervisor reprocessed this configured-bot finding on the current head\b/u.test(comment.body) &&
-        /\bAudit: issue=#\d+ pr=#\d+ head=[^\s]+ thread=[^\s]+ reason=stale_review_bot\b/u.test(comment.body)
-      )
+function supervisorStaleResidueAudit(body: string): {
+  headSha: string;
+  threadId: string;
+  reason: string;
+} | null {
+  const match = body.match(
+    /\bAudit: issue=#\d+ pr=#\d+ head=([^\s]+) thread=([^\s]+) reason=([a-z0-9_]+)\b/u,
+  );
+  if (!match) {
+    return null;
+  }
+  return {
+    headSha: match[1]!,
+    threadId: match[2]!,
+    reason: match[3]!,
+  };
+}
+
+function supervisorStaleResidueAuditMatches(args: {
+  body: string;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  thread: Pick<ReviewThread, "id">;
+  allowedReasons: string[];
+}): boolean {
+  const audit = supervisorStaleResidueAudit(args.body);
+  return Boolean(
+    audit &&
+      args.allowedReasons.includes(audit.reason) &&
+      commitShasEqualForComparison(audit.headSha, args.pr.headRefOid) &&
+      audit.threadId === args.thread.id,
+  );
+}
+
+function isSupervisorStaleResidueComment(
+  config: SupervisorConfig,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  thread: Pick<ReviewThread, "id">,
+  comment: ReviewThreadComment,
+): boolean {
+  if (!isTrustedSupervisorMarkerAuthor(config, comment)) {
+    return false;
+  }
+  const verifiedResidueMarker = isSupervisorVerifiedStaleResidueAutoResolveComment(comment.body);
+  if (
+    verifiedResidueMarker &&
+    supervisorStaleResidueAuditMatches({
+      body: comment.body,
+      pr,
+      thread,
+      allowedReasons: [
+        "verified_no_source_change_auto_resolve",
+        "verified_current_head_repair_auto_resolve",
+      ],
+    })
+  ) {
+    return true;
+  }
+  if (
+    verifiedResidueMarker &&
+    /\bSupervisor confirmed this stale Codex Connector finding is covered by the current-head success signal\b/u.test(
+      comment.body,
     )
+  ) {
+    return true;
+  }
+
+  return (
+    /\bThe supervisor reprocessed this configured-bot finding on the current head\b/u.test(comment.body) &&
+    supervisorStaleResidueAuditMatches({
+      body: comment.body,
+      pr,
+      thread,
+      allowedReasons: ["stale_review_bot"],
+    })
   );
 }
 
 function currentHeadRepairProofReferenceComment(
   config: SupervisorConfig,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
   thread: ReviewThread,
 ): ReviewThreadComment | null {
   const latestComment = latestReviewComment(thread);
-  if (!latestComment || !isSupervisorStaleResidueComment(config, latestComment)) {
+  if (!latestComment || !isSupervisorStaleResidueComment(config, pr, thread, latestComment)) {
     return latestComment;
   }
 
   return latestCodexConnectorReviewCommentNode(thread) ?? latestComment;
 }
 
-function currentHeadRepairProofThreadFingerprint(config: SupervisorConfig, thread: ReviewThread): string | null {
-  const referenceComment = currentHeadRepairProofReferenceComment(config, thread);
+function currentHeadRepairProofThreadFingerprint(
+  config: SupervisorConfig,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  thread: ReviewThread,
+): string | null {
+  const referenceComment = currentHeadRepairProofReferenceComment(config, pr, thread);
   return referenceComment?.id || referenceComment?.createdAt || null;
 }
 
@@ -499,7 +570,7 @@ function projectionSafetyGatesPass(args: {
     checksPresentAndGreen(args.checks) &&
     args.record.last_head_sha === args.pr.headRefOid &&
     !humanReviewBlocksProjection(args.config, args.pr, args.reviewThreads) &&
-    unresolvedConfiguredBotThreadsAreCodexConnectorOnly(args.config, args.reviewThreads)
+    unresolvedConfiguredBotThreadsAreCodexConnectorOnly(args.config, args.pr, args.reviewThreads)
   );
 }
 
@@ -542,7 +613,7 @@ export function projectCurrentHeadCodexRepairProof(args: {
         args.record,
         args.pr,
         thread,
-        currentHeadRepairProofThreadFingerprint(args.config, thread),
+        currentHeadRepairProofThreadFingerprint(args.config, args.pr, thread),
       )
     )
   ) {
@@ -635,14 +706,14 @@ export function projectCurrentHeadCodexRepairProof(args: {
         args.record,
         args.pr,
         thread,
-        currentHeadRepairProofThreadFingerprint(args.config, thread),
+        currentHeadRepairProofThreadFingerprint(args.config, args.pr, thread),
       )
     )
   ) {
     const recordScopedProof = currentHeadPassedCodexTurnArtifacts(args.record, args.pr)
       .filter((artifact) =>
         proofCoverageThreads.every((thread) =>
-          latestReviewThreadCommentPredatesArtifact(args.config, thread, artifact)
+          latestReviewThreadCommentPredatesArtifact(args.config, args.pr, thread, artifact)
         )
       )
       .map((artifact) => {
@@ -758,7 +829,7 @@ export function currentHeadCodexRepairProofRejectionReasons(args: {
         args.record,
         args.pr,
         thread,
-        currentHeadRepairProofThreadFingerprint(args.config, thread),
+        currentHeadRepairProofThreadFingerprint(args.config, args.pr, thread),
       )
     )
   ) {

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -175,19 +175,19 @@ function repairArtifactCoversCurrentThreads(
   const processedThreadFingerprints = artifact.processed_review_thread_fingerprints ?? [];
   return currentThreads.every((thread) => {
     const headScopedKey = processedReviewThreadKey(thread.id, pr.headRefOid);
-    const latestFingerprint = currentHeadRepairProofThreadFingerprint(config, pr, thread);
-    if (
-      latestFingerprint &&
+    const acceptedFingerprints = currentHeadRepairProofThreadFingerprints(config, pr, thread);
+    const matchedFingerprint = acceptedFingerprints.find((candidate) =>
       processedThreadFingerprints.includes(
-        processedReviewThreadFingerprintKey(thread.id, pr.headRefOid, latestFingerprint),
+        processedReviewThreadFingerprintKey(thread.id, pr.headRefOid, candidate.fingerprint),
       )
-    ) {
-      return latestReviewThreadCommentPredatesArtifact(config, pr, thread, artifact);
+    );
+    if (matchedFingerprint) {
+      return reviewThreadCommentPredatesArtifact(matchedFingerprint.comment, artifact);
     }
     if (!processedThreadIds.includes(headScopedKey)) {
       return false;
     }
-    if (!latestFingerprint) {
+    if (acceptedFingerprints.length === 0) {
       return true;
     }
 
@@ -208,6 +208,19 @@ function coveredCurrentThreadCount(
   return currentThreads.filter((thread) => repairArtifactCoversCurrentThreads(config, artifact, pr, [thread])).length;
 }
 
+function reviewThreadCommentPredatesArtifact(
+  comment: ReviewThreadComment,
+  artifact: Pick<TimelineArtifact, "recorded_at">,
+): boolean {
+  const latestCommentMs = Date.parse(comment.createdAt);
+  const artifactRecordedMs = Date.parse(artifact.recorded_at);
+  if (Number.isNaN(latestCommentMs) || Number.isNaN(artifactRecordedMs)) {
+    return false;
+  }
+
+  return latestCommentMs <= artifactRecordedMs;
+}
+
 function latestReviewThreadCommentPredatesArtifact(
   config: SupervisorConfig,
   pr: Pick<GitHubPullRequest, "headRefOid">,
@@ -215,17 +228,7 @@ function latestReviewThreadCommentPredatesArtifact(
   artifact: Pick<TimelineArtifact, "recorded_at">,
 ): boolean {
   const latestComment = currentHeadRepairProofReferenceComment(config, pr, thread);
-  if (!latestComment) {
-    return true;
-  }
-
-  const latestCommentMs = Date.parse(latestComment.createdAt);
-  const artifactRecordedMs = Date.parse(artifact.recorded_at);
-  if (Number.isNaN(latestCommentMs) || Number.isNaN(artifactRecordedMs)) {
-    return false;
-  }
-
-  return latestCommentMs <= artifactRecordedMs;
+  return latestComment ? reviewThreadCommentPredatesArtifact(latestComment, artifact) : true;
 }
 
 function supervisorStaleResidueAudit(body: string): {
@@ -318,13 +321,47 @@ function currentHeadRepairProofReferenceComment(
   return latestCodexConnectorReviewCommentNode(thread) ?? latestComment;
 }
 
+function reviewThreadCommentFingerprint(comment: ReviewThreadComment): string | null {
+  return comment.id || comment.createdAt || null;
+}
+
+function currentHeadRepairProofThreadFingerprints(
+  config: SupervisorConfig,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  thread: ReviewThread,
+): Array<{ fingerprint: string; comment: ReviewThreadComment }> {
+  const referenceComment = currentHeadRepairProofReferenceComment(config, pr, thread);
+  const fingerprints: Array<{ fingerprint: string; comment: ReviewThreadComment }> = [];
+  const appendComment = (comment: ReviewThreadComment | null) => {
+    if (!comment) {
+      return;
+    }
+    const fingerprint = reviewThreadCommentFingerprint(comment);
+    if (!fingerprint || fingerprints.some((candidate) => candidate.fingerprint === fingerprint)) {
+      return;
+    }
+    fingerprints.push({ fingerprint, comment });
+  };
+
+  appendComment(referenceComment);
+  const latestComment = latestReviewComment(thread);
+  if (
+    latestComment &&
+    latestComment !== referenceComment &&
+    isSupervisorStaleResidueComment(config, pr, thread, latestComment)
+  ) {
+    appendComment(latestComment);
+  }
+
+  return fingerprints;
+}
+
 export function currentHeadRepairProofThreadFingerprint(
   config: SupervisorConfig,
   pr: Pick<GitHubPullRequest, "headRefOid">,
   thread: ReviewThread,
 ): string | null {
-  const referenceComment = currentHeadRepairProofReferenceComment(config, pr, thread);
-  return referenceComment?.id || referenceComment?.createdAt || null;
+  return currentHeadRepairProofThreadFingerprints(config, pr, thread)[0]?.fingerprint ?? null;
 }
 
 function headScopedProcessedThreadEvidenceCount(
@@ -609,12 +646,8 @@ export function projectCurrentHeadCodexRepairProof(args: {
   if (
     repairResidueThreads.length > 0 &&
     !repairResidueThreads.every((thread) =>
-      hasProcessedReviewThread(
-        args.record,
-        args.pr,
-        thread,
-        currentHeadRepairProofThreadFingerprint(args.config, args.pr, thread),
-      )
+      currentHeadRepairProofThreadFingerprints(args.config, args.pr, thread)
+        .some((candidate) => hasProcessedReviewThread(args.record, args.pr, thread, candidate.fingerprint))
     )
   ) {
     return null;
@@ -702,12 +735,8 @@ export function projectCurrentHeadCodexRepairProof(args: {
     noMajorSupport &&
     recordProcessedThreadEvidenceCount > 0 &&
     proofCoverageThreads.every((thread) =>
-      hasProcessedReviewThread(
-        args.record,
-        args.pr,
-        thread,
-        currentHeadRepairProofThreadFingerprint(args.config, args.pr, thread),
-      )
+      currentHeadRepairProofThreadFingerprints(args.config, args.pr, thread)
+        .some((candidate) => hasProcessedReviewThread(args.record, args.pr, thread, candidate.fingerprint))
     )
   ) {
     const recordScopedProof = currentHeadPassedCodexTurnArtifacts(args.record, args.pr)
@@ -825,12 +854,8 @@ export function currentHeadCodexRepairProofRejectionReasons(args: {
   if (
     repairResidueThreads.length > 0 &&
     !repairResidueThreads.every((thread) =>
-      hasProcessedReviewThread(
-        args.record,
-        args.pr,
-        thread,
-        currentHeadRepairProofThreadFingerprint(args.config, args.pr, thread),
-      )
+      currentHeadRepairProofThreadFingerprints(args.config, args.pr, thread)
+        .some((candidate) => hasProcessedReviewThread(args.record, args.pr, thread, candidate.fingerprint))
     )
   ) {
     reasons.push("current_head_repair_proof_processed_thread_evidence_missing");

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -318,7 +318,7 @@ function currentHeadRepairProofReferenceComment(
   return latestCodexConnectorReviewCommentNode(thread) ?? latestComment;
 }
 
-function currentHeadRepairProofThreadFingerprint(
+export function currentHeadRepairProofThreadFingerprint(
   config: SupervisorConfig,
   pr: Pick<GitHubPullRequest, "headRefOid">,
   thread: ReviewThread,

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -9,7 +9,7 @@ import {
 } from "./codex-connector-review-policy";
 import { displayLocalCiCommand } from "./core/config";
 import { configuredReviewProviderKinds } from "./core/review-providers";
-import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig, TimelineArtifact } from "./core/types";
+import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, ReviewThreadComment, SupervisorConfig, TimelineArtifact } from "./core/types";
 import { hasCodexConnectorStrongRiskWording } from "./external-review/external-review-normalization";
 import {
   currentHeadLocalVerificationEvidence,
@@ -18,7 +18,6 @@ import {
 } from "./local-ci-policy";
 import {
   hasProcessedReviewThread,
-  latestReviewThreadCommentFingerprint,
   processedReviewThreadFingerprintKey,
   processedReviewThreadKey,
 } from "./review-handling";
@@ -29,6 +28,10 @@ import {
   latestReviewCommentAuthorIsAllowedBot,
   manualReviewThreads,
 } from "./review-thread-reporting";
+import {
+  isSupervisorVerifiedStaleResidueAutoResolveComment,
+  isTrustedSupervisorMarkerAuthor,
+} from "./supervisor/verified-stale-residue-review-thread";
 
 export const VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET =
   "verified_current_head_repair_review_thread_residue";
@@ -64,9 +67,14 @@ function unresolvedConfiguredBotThreadsAreCodexConnectorOnly(
   return configuredBotReviewThreads(config, reviewThreads)
     .filter((thread) => !thread.isResolved)
     .every(
-      (thread) =>
-        latestReviewCommentAuthorIsAllowedBot(config, thread) &&
-        hasCodexConnectorFindingReviewComment(thread),
+      (thread) => {
+        const latestComment = latestReviewComment(thread);
+        return (
+          (latestReviewCommentAuthorIsAllowedBot(config, thread) ||
+            Boolean(latestComment && isSupervisorStaleResidueComment(config, latestComment))) &&
+          hasCodexConnectorFindingReviewComment(thread)
+        );
+      },
     );
 }
 
@@ -76,6 +84,7 @@ function currentConfiguredBotThreads(config: SupervisorConfig, reviewThreads: Re
 }
 
 function currentHeadCodexTurnVerificationArtifact(
+  config: SupervisorConfig,
   record: Pick<IssueRunRecord, "timeline_artifacts">,
   pr: Pick<GitHubPullRequest, "headRefOid">,
   currentThreads: ReviewThread[],
@@ -87,7 +96,7 @@ function currentHeadCodexTurnVerificationArtifact(
       artifact.outcome === "passed" &&
       artifact.head_sha === pr.headRefOid &&
       artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") !== true &&
-      repairArtifactCoversCurrentThreads(artifact, pr, currentThreads),
+      repairArtifactCoversCurrentThreads(config, artifact, pr, currentThreads),
   ) ?? null;
 }
 
@@ -106,6 +115,7 @@ function currentHeadPassedCodexTurnArtifacts(
 }
 
 function currentHeadThreadScopedVerificationArtifacts(
+  config: SupervisorConfig,
   record: Pick<IssueRunRecord, "timeline_artifacts">,
   pr: Pick<GitHubPullRequest, "headRefOid">,
   currentThreads: ReviewThread[],
@@ -119,19 +129,12 @@ function currentHeadThreadScopedVerificationArtifacts(
       artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") !== true &&
       artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) !== true &&
       artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0 &&
-      repairArtifactCoversCurrentThreads(artifact, pr, currentThreads),
+      repairArtifactCoversCurrentThreads(config, artifact, pr, currentThreads),
   );
 }
 
-function currentHeadVerifiedRepairResidueArtifact(
-  record: Pick<IssueRunRecord, "timeline_artifacts">,
-  pr: Pick<GitHubPullRequest, "headRefOid">,
-  currentThreads?: ReviewThread[],
-): TimelineArtifact | null {
-  return currentHeadVerifiedRepairResidueArtifacts(record, pr, currentThreads)[0] ?? null;
-}
-
 function currentHeadVerifiedRepairResidueArtifacts(
+  config: SupervisorConfig,
   record: Pick<IssueRunRecord, "timeline_artifacts">,
   pr: Pick<GitHubPullRequest, "headRefOid">,
   currentThreads?: ReviewThread[],
@@ -143,7 +146,7 @@ function currentHeadVerifiedRepairResidueArtifacts(
       artifact.head_sha === pr.headRefOid &&
       artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
       artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0 &&
-      (!currentThreads || repairArtifactCoversCurrentThreads(artifact, pr, currentThreads)),
+      (!currentThreads || repairArtifactCoversCurrentThreads(config, artifact, pr, currentThreads)),
   );
 }
 
@@ -159,6 +162,7 @@ function artifactHeadScopedProcessedThreadEvidenceCount(
 }
 
 function repairArtifactCoversCurrentThreads(
+  config: SupervisorConfig,
   artifact: TimelineArtifact,
   pr: Pick<GitHubPullRequest, "headRefOid">,
   currentThreads: ReviewThread[],
@@ -170,14 +174,14 @@ function repairArtifactCoversCurrentThreads(
   const processedThreadFingerprints = artifact.processed_review_thread_fingerprints ?? [];
   return currentThreads.every((thread) => {
     const headScopedKey = processedReviewThreadKey(thread.id, pr.headRefOid);
-    const latestFingerprint = latestReviewThreadCommentFingerprint(thread);
+    const latestFingerprint = currentHeadRepairProofThreadFingerprint(config, thread);
     if (
       latestFingerprint &&
       processedThreadFingerprints.includes(
         processedReviewThreadFingerprintKey(thread.id, pr.headRefOid, latestFingerprint),
       )
     ) {
-      return latestReviewThreadCommentPredatesArtifact(thread, artifact);
+      return latestReviewThreadCommentPredatesArtifact(config, thread, artifact);
     }
     if (!processedThreadIds.includes(headScopedKey)) {
       return false;
@@ -189,24 +193,26 @@ function repairArtifactCoversCurrentThreads(
     const threadFingerprintPrefix = `${headScopedKey}#`;
     return (
       !processedThreadFingerprints.some((key) => key.startsWith(threadFingerprintPrefix)) &&
-      latestReviewThreadCommentPredatesArtifact(thread, artifact)
+      latestReviewThreadCommentPredatesArtifact(config, thread, artifact)
     );
   });
 }
 
 function coveredCurrentThreadCount(
+  config: SupervisorConfig,
   artifact: TimelineArtifact,
   pr: Pick<GitHubPullRequest, "headRefOid">,
   currentThreads: ReviewThread[],
 ): number {
-  return currentThreads.filter((thread) => repairArtifactCoversCurrentThreads(artifact, pr, [thread])).length;
+  return currentThreads.filter((thread) => repairArtifactCoversCurrentThreads(config, artifact, pr, [thread])).length;
 }
 
 function latestReviewThreadCommentPredatesArtifact(
+  config: SupervisorConfig,
   thread: ReviewThread,
   artifact: Pick<TimelineArtifact, "recorded_at">,
 ): boolean {
-  const latestComment = latestReviewComment(thread);
+  const latestComment = currentHeadRepairProofReferenceComment(config, thread);
   if (!latestComment) {
     return true;
   }
@@ -218,6 +224,36 @@ function latestReviewThreadCommentPredatesArtifact(
   }
 
   return latestCommentMs <= artifactRecordedMs;
+}
+
+function isSupervisorStaleResidueComment(config: SupervisorConfig, comment: ReviewThreadComment): boolean {
+  return (
+    isTrustedSupervisorMarkerAuthor(config, comment) &&
+    (
+      isSupervisorVerifiedStaleResidueAutoResolveComment(comment.body) ||
+      (
+        /\bThe supervisor reprocessed this configured-bot finding on the current head\b/u.test(comment.body) &&
+        /\bAudit: issue=#\d+ pr=#\d+ head=[^\s]+ thread=[^\s]+ reason=stale_review_bot\b/u.test(comment.body)
+      )
+    )
+  );
+}
+
+function currentHeadRepairProofReferenceComment(
+  config: SupervisorConfig,
+  thread: ReviewThread,
+): ReviewThreadComment | null {
+  const latestComment = latestReviewComment(thread);
+  if (!latestComment || !isSupervisorStaleResidueComment(config, latestComment)) {
+    return latestComment;
+  }
+
+  return latestCodexConnectorReviewCommentNode(thread) ?? latestComment;
+}
+
+function currentHeadRepairProofThreadFingerprint(config: SupervisorConfig, thread: ReviewThread): string | null {
+  const referenceComment = currentHeadRepairProofReferenceComment(config, thread);
+  return referenceComment?.id || referenceComment?.createdAt || null;
 }
 
 function headScopedProcessedThreadEvidenceCount(
@@ -501,13 +537,20 @@ export function projectCurrentHeadCodexRepairProof(args: {
     : repairResidueThreads;
   if (
     repairResidueThreads.length > 0 &&
-    !repairResidueThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
+    !repairResidueThreads.every((thread) =>
+      hasProcessedReviewThread(
+        args.record,
+        args.pr,
+        thread,
+        currentHeadRepairProofThreadFingerprint(args.config, thread),
+      )
+    )
   ) {
     return null;
   }
 
   const configuredLocalCiRequired = hasConfiguredLocalCiCommand(args.config);
-  const structuredProof = currentHeadVerifiedRepairResidueArtifacts(args.record, args.pr, proofCoverageThreads)
+  const structuredProof = currentHeadVerifiedRepairResidueArtifacts(args.config, args.record, args.pr, proofCoverageThreads)
     .map((structuredArtifact) => {
       const localVerificationEvidence = configuredLocalCiRequired
         ? currentHeadLocalVerificationEvidence({
@@ -542,7 +585,7 @@ export function projectCurrentHeadCodexRepairProof(args: {
   }
 
   const threadScopedProof = noMajorSupport
-    ? currentHeadThreadScopedVerificationArtifacts(args.record, args.pr, proofCoverageThreads)
+    ? currentHeadThreadScopedVerificationArtifacts(args.config, args.record, args.pr, proofCoverageThreads)
         .map((artifact) => {
           const localVerificationEvidence = configuredLocalCiRequired
             ? currentHeadLocalVerificationEvidence({
@@ -587,11 +630,20 @@ export function projectCurrentHeadCodexRepairProof(args: {
     args.allowRecordProcessedThreadEvidence === true &&
     noMajorSupport &&
     recordProcessedThreadEvidenceCount > 0 &&
-    proofCoverageThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
+    proofCoverageThreads.every((thread) =>
+      hasProcessedReviewThread(
+        args.record,
+        args.pr,
+        thread,
+        currentHeadRepairProofThreadFingerprint(args.config, thread),
+      )
+    )
   ) {
     const recordScopedProof = currentHeadPassedCodexTurnArtifacts(args.record, args.pr)
       .filter((artifact) =>
-        proofCoverageThreads.every((thread) => latestReviewThreadCommentPredatesArtifact(thread, artifact))
+        proofCoverageThreads.every((thread) =>
+          latestReviewThreadCommentPredatesArtifact(args.config, thread, artifact)
+        )
       )
       .map((artifact) => {
         const localVerificationEvidence = configuredLocalCiRequired
@@ -652,7 +704,12 @@ export function projectCurrentHeadCodexRepairProof(args: {
     return null;
   }
 
-  const currentHeadVerification = currentHeadCodexTurnVerificationArtifact(args.record, args.pr, proofCoverageThreads);
+  const currentHeadVerification = currentHeadCodexTurnVerificationArtifact(
+    args.config,
+    args.record,
+    args.pr,
+    proofCoverageThreads,
+  );
   if (!currentHeadVerification) {
     return null;
   }
@@ -696,7 +753,14 @@ export function currentHeadCodexRepairProofRejectionReasons(args: {
   const reasons: string[] = [];
   if (
     repairResidueThreads.length > 0 &&
-    !repairResidueThreads.every((thread) => hasProcessedReviewThread(args.record, args.pr, thread))
+    !repairResidueThreads.every((thread) =>
+      hasProcessedReviewThread(
+        args.record,
+        args.pr,
+        thread,
+        currentHeadRepairProofThreadFingerprint(args.config, thread),
+      )
+    )
   ) {
     reasons.push("current_head_repair_proof_processed_thread_evidence_missing");
   }
@@ -714,17 +778,21 @@ export function currentHeadCodexRepairProofRejectionReasons(args: {
   );
   if (structuredArtifacts.length === 0) {
     const coveringUnmarkedArtifact = currentHeadPassedArtifacts.find((artifact) =>
-      repairArtifactCoversCurrentThreads(artifact, args.pr, proofCoverageThreads)
+      repairArtifactCoversCurrentThreads(args.config, artifact, args.pr, proofCoverageThreads)
     );
     reasons.push(
       coveringUnmarkedArtifact
         ? "current_head_repair_proof_repair_target_missing"
         : "current_head_repair_proof_structured_artifact_missing",
     );
-  } else if (!structuredArtifacts.some((artifact) => repairArtifactCoversCurrentThreads(artifact, args.pr, proofCoverageThreads))) {
+  } else if (!structuredArtifacts.some((artifact) =>
+    repairArtifactCoversCurrentThreads(args.config, artifact, args.pr, proofCoverageThreads)
+  )) {
     const bestCoverage = Math.max(
       0,
-      ...structuredArtifacts.map((artifact) => coveredCurrentThreadCount(artifact, args.pr, proofCoverageThreads)),
+      ...structuredArtifacts.map((artifact) =>
+        coveredCurrentThreadCount(args.config, artifact, args.pr, proofCoverageThreads)
+      ),
     );
     reasons.push(`current_head_repair_proof_thread_coverage_${bestCoverage}_of_${proofCoverageThreads.length}`);
   }
@@ -737,10 +805,10 @@ export function currentHeadCodexRepairProofRejectionReasons(args: {
     const configuredLocalCiCommand = displayLocalCiCommand(args.config.localCiCommand ?? undefined);
     const scopedProofArtifacts = [
       ...structuredArtifacts,
-      ...currentHeadThreadScopedVerificationArtifacts(args.record, args.pr, proofCoverageThreads),
+      ...currentHeadThreadScopedVerificationArtifacts(args.config, args.record, args.pr, proofCoverageThreads),
     ].filter((artifact, index, artifacts) => artifacts.findIndex((candidate) => candidate === artifact) === index);
     const coveringScopedProofArtifacts = scopedProofArtifacts.filter((artifact) =>
-      repairArtifactCoversCurrentThreads(artifact, args.pr, proofCoverageThreads)
+      repairArtifactCoversCurrentThreads(args.config, artifact, args.pr, proofCoverageThreads)
     );
     if (latestLocalCi?.head_sha === args.pr.headRefOid) {
       reasons.push("current_head_repair_proof_latest_local_ci_result_not_passed");
@@ -762,5 +830,19 @@ export function hasCurrentHeadVerifiedRepairResidueArtifact(
   record: Pick<IssueRunRecord, "timeline_artifacts">,
   pr: Pick<GitHubPullRequest, "headRefOid">,
 ): boolean {
-  return currentHeadVerifiedRepairResidueArtifact(record, pr) !== null;
+  return currentHeadVerifiedRepairResidueArtifactsPresent(record, pr);
+}
+
+function currentHeadVerifiedRepairResidueArtifactsPresent(
+  record: Pick<IssueRunRecord, "timeline_artifacts">,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): boolean {
+  return (record.timeline_artifacts ?? []).some(
+    (artifact) =>
+      artifact.type === "verification_result" &&
+      artifact.outcome === "passed" &&
+      artifact.head_sha === pr.headRefOid &&
+      artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
+      artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0,
+  );
 }

--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -2123,6 +2123,7 @@ test("handlePostTurnPullRequestTransitionsPhase keeps verified P1 no-source-chan
 
 test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head repair Codex threads only with the repair opt-in", async () => {
   const config = createConfig({
+    repoSlug: "TommyKammy/codex-supervisor",
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
     configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
     verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
@@ -2151,6 +2152,22 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head r
     },
   });
   const pr = createPullRequest(scenario.pullRequestPatch);
+  scenario.reviewThread.comments.nodes.push({
+    id: "comment-supervisor-stale-reply",
+    body: [
+      "The supervisor reprocessed this configured-bot finding on the current head `head-1988` and classified it as stale.",
+      "",
+      "Audit: issue=#102 pr=#1988 head=head-1988 thread=thread-codex-repair reason=stale_review_bot.",
+      "",
+      "Under the configured `reply_and_resolve` policy, the supervisor is auto-resolving this stale thread now.",
+    ].join("\n"),
+    createdAt: "2026-05-15T00:19:00Z",
+    url: "https://example.test/pr/1988#discussion_supervisor_stale_reply",
+    author: {
+      login: "TommyKammy",
+      typeName: "User",
+    },
+  });
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,
     issues: {
@@ -2228,6 +2245,23 @@ test("handlePostTurnPullRequestTransitionsPhase resolves verified current-head r
   assert.deepEqual(resolveCalls, ["thread-codex-repair"]);
   assert.match(replyCalls[0]?.body ?? "", /reason=verified_current_head_repair_auto_resolve/);
   assert.doesNotMatch(replyCalls[0]?.body ?? "", /verified_no_source_change_auto_resolve/);
+  const autoResolveArtifact = result.record.timeline_artifacts?.find(
+    (artifact) =>
+      artifact.gate === "workspace_preparation" &&
+      artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true,
+  );
+  assert.equal(
+    autoResolveArtifact?.processed_review_thread_fingerprints?.includes(
+      "thread-codex-repair@head-1988#comment-codex-repair",
+    ),
+    true,
+  );
+  assert.equal(
+    autoResolveArtifact?.processed_review_thread_fingerprints?.includes(
+      "thread-codex-repair@head-1988#comment-supervisor-stale-reply",
+    ),
+    false,
+  );
   assert.equal(requestComments.length, 0);
 });
 

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -3469,9 +3469,11 @@ test("reconcileRecoverableBlockedIssueStates persists current-head clean proof a
   const threadB = "PRRT_kwDOTAxt0M6NeErE";
   const command = "python3 -m pytest tests/test_desktop_api_auth.py tests/test_poc_web_api.py -q";
   const config = createConfig({
+    repoSlug: "TommyKammy/VeriDoc",
     reviewBotLogins: ["chatgpt-codex-connector"],
     localCiCommand: command,
-    staleConfiguredBotReviewPolicy: "reply_only",
+    staleConfiguredBotReviewPolicy: "reply_and_resolve",
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
   });
   const original = createRecord({
     issue_number: 147,
@@ -3495,7 +3497,7 @@ test("reconcileRecoverableBlockedIssueStates persists current-head clean proof a
       verificationProbeOutcomes: [`codex_turn:${command}:passed:none`],
     }),
     last_tracked_pr_progress_summary: "no_meaningful_tracked_pr_progress",
-    last_tracked_pr_repeat_failure_decision: "stop_no_progress",
+    last_tracked_pr_repeat_failure_decision: null,
     processed_review_thread_ids: [`${threadA}@${headSha}`, `${threadB}@${headSha}`],
     processed_review_thread_fingerprints: [
       `${threadA}@${headSha}#comment-stale-p1`,
@@ -3552,13 +3554,27 @@ test("reconcileRecoverableBlockedIssueStates persists current-head clean proof a
           path: "apps/desktop/api_client.py",
           line: 494,
           comments: {
-            nodes: [{
-              id: "comment-stale-p1",
-              body: "P1: Allow result-save audits to recover cleanly.",
-              createdAt: "2026-07-01T03:52:01Z",
-              url: "https://example.test/pr/156#discussion_r3503170216",
-              author: { login: "chatgpt-codex-connector", typeName: "Bot" },
-            }],
+            nodes: [
+              {
+                id: "comment-stale-p1",
+                body: "P1: Allow result-save audits to recover cleanly.",
+                createdAt: "2026-07-01T03:52:01Z",
+                url: "https://example.test/pr/156#discussion_r3503170216",
+                author: { login: "chatgpt-codex-connector", typeName: "Bot" },
+              },
+              {
+                id: "comment-supervisor-stale-p1",
+                body: [
+                  `The supervisor reprocessed this configured-bot finding on the current head \`${headSha}\` and classified it as stale.`,
+                  `Audit: issue=#147 pr=#156 head=${headSha} thread=${threadA} reason=stale_review_bot.`,
+                  "Evidence: location=apps/desktop/api_client.py:494 processed_on_current_head=yes.",
+                  "Under the configured `reply_and_resolve` policy, the supervisor is auto-resolving this stale thread now.",
+                ].join("\n\n"),
+                createdAt: "2026-07-01T06:53:00Z",
+                url: "https://example.test/pr/156#discussion_r3503170216_followup",
+                author: { login: "TommyKammy", typeName: "User" },
+              },
+            ],
           },
         }),
         createReviewThread({
@@ -3788,7 +3804,7 @@ test("reconcileRecoverableBlockedIssueStates does not promote changes-requested 
   assert.equal(state.issues["150"].blocked_reason, "manual_review");
 });
 
-test("reconcileRecoverableBlockedIssueStates requires stop-no-progress for record-scoped proof recovery", async () => {
+test("reconcileRecoverableBlockedIssueStates accepts record-scoped proof recovery without stop-no-progress", async () => {
   const headSha = "74d44b0a48f7b65fbcc9361a6509727c3ba987dc";
   const threadId = "thread-non-terminal-proof";
   const commentId = "comment-non-terminal-proof";
@@ -3874,9 +3890,9 @@ test("reconcileRecoverableBlockedIssueStates requires stop-no-progress for recor
     },
   );
 
-  assert.equal(state.issues["151"].state, "addressing_review");
+  assert.equal(state.issues["151"].state, "ready_to_merge");
   assert.equal(state.issues["151"].blocked_reason, null);
-  assert.equal(state.issues["151"].provider_success_head_sha, null);
+  assert.equal(state.issues["151"].provider_success_head_sha, headSha);
 });
 
 test("reconcileRecoverableBlockedIssueStates preserves local manual review blocks despite record-scoped proof", async () => {

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -604,11 +604,9 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         hasOnlyOutdatedConfiguredBotResidue(config, reviewThreads);
       const blockedManualReviewProjectionRecoverableByCurrentHeadProof =
         projection.nextBlockedReason === "manual_review" &&
-        record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
         record.pre_merge_evaluation_outcome !== "manual_review_blocked";
       const sameHeadCurrentHeadRepairProofRecovery =
         record.blocked_reason === "manual_review" &&
-        record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
         record.last_head_sha === trackedPullRequest.headRefOid &&
         (nextState !== "blocked" || blockedManualReviewProjectionRecoverableByCurrentHeadProof) &&
         projectCurrentHeadCodexRepairProof({

--- a/src/stale-configured-bot-auto-handle.ts
+++ b/src/stale-configured-bot-auto-handle.ts
@@ -13,6 +13,7 @@ import type {
   TimelineArtifact,
 } from "./core/types";
 import { codexConnectorMustFixReviewThreads } from "./codex-connector-review-policy";
+import { currentHeadRepairProofThreadFingerprint } from "./current-head-codex-repair-proof";
 import {
   buildStaleReviewBotRemediation,
   VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
@@ -22,7 +23,6 @@ import {
   STALE_CONFIGURED_BOT_REVIEW_REASON_CODE,
 } from "./supervisor/stale-review-bot-recovery";
 import {
-  latestReviewThreadCommentFingerprint,
   processedReviewThreadFingerprintKey,
   processedReviewThreadKey,
 } from "./review-handling";
@@ -41,6 +41,7 @@ export interface StaleConfiguredBotReviewRemediationResult {
 const MAX_VERIFIED_REPAIR_RESIDUE_ARTIFACT_KEYS = 200;
 
 function verifiedCurrentHeadRepairResidueArtifact(args: {
+  config: SupervisorConfig;
   pr: GitHubPullRequest;
   reviewThreads: ReviewThread[];
   verificationEvidenceSummary: string | null;
@@ -52,7 +53,7 @@ function verifiedCurrentHeadRepairResidueArtifact(args: {
 
   const processedThreadIds = repairThreads.map((thread) => processedReviewThreadKey(thread.id, args.pr.headRefOid));
   const processedThreadFingerprints = repairThreads.flatMap((thread) => {
-    const latestFingerprint = latestReviewThreadCommentFingerprint(thread);
+    const latestFingerprint = currentHeadRepairProofThreadFingerprint(args.config, args.pr, thread);
     return latestFingerprint
       ? [processedReviewThreadFingerprintKey(thread.id, args.pr.headRefOid, latestFingerprint)]
       : [];
@@ -252,6 +253,7 @@ export async function handleStaleConfiguredBotReviewRemediation(args: {
     (recoveryResult.status === "resolved" || recoveryResult.shouldRefreshPullRequest)
   ) {
     const artifact = verifiedCurrentHeadRepairResidueArtifact({
+      config: args.config,
       pr: args.pr,
       reviewThreads: args.reviewThreads,
       verificationEvidenceSummary: staleReviewBotRemediation.verificationEvidenceSummary,

--- a/src/supervisor/codex-connector-verified-stale-residue-selection.test.ts
+++ b/src/supervisor/codex-connector-verified-stale-residue-selection.test.ts
@@ -1,11 +1,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "../current-head-codex-repair-proof";
 import {
   createConfig,
   createPullRequest,
   createRecord,
+  createReviewThread,
 } from "../turn-execution-test-helpers";
-import { shouldSelectCodexConnectorVerifiedStaleResidueAutoResolve } from "./codex-connector-verified-stale-residue-selection";
+import {
+  shouldReenterCodexConnectorVerifiedStaleResidueAutoResolve,
+  shouldSelectCodexConnectorVerifiedStaleResidueAutoResolve,
+} from "./codex-connector-verified-stale-residue-selection";
 
 test("shouldSelectCodexConnectorVerifiedStaleResidueAutoResolve skips hydration when Codex is not configured", async () => {
   const config = createConfig({
@@ -76,4 +81,87 @@ test("shouldSelectCodexConnectorVerifiedStaleResidueAutoResolve rejects PR branc
 
   assert.equal(result, false);
   assert.deepEqual(calls, ["pull-request"]);
+});
+
+test("shouldReenterCodexConnectorVerifiedStaleResidueAutoResolve keeps proof-based selection behind static auto-resolve gates", () => {
+  const headSha = "42888eec82785a56c2c5419f9426984122d9e96b";
+  const thread = createReviewThread({
+    id: "thread-current-head-proof-on-draft",
+    comments: {
+      nodes: [
+        {
+          id: "comment-current-head-proof-on-draft",
+          body: "P2: This current-head residue has structured proof but must not reserve draft PR work.",
+          createdAt: "2026-07-06T05:35:48Z",
+          url: "https://example.test/pr/2406#discussion_current_head_proof_on_draft",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    issue_number: 2405,
+    state: "blocked",
+    blocked_reason: "manual_review",
+    pr_number: 2406,
+    last_head_sha: headSha,
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`],
+    last_failure_context: {
+      category: "manual",
+      summary: "stale configured-bot residue",
+      signature: `stalled-bot:${thread.id}`,
+      command: null,
+      details: [],
+      url: thread.comments.nodes[0]!.url,
+      updated_at: "2026-07-06T05:40:00Z",
+    },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run build",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Current head repair proof covers the unresolved Connector residue.",
+        recorded_at: "2026-07-06T05:42:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${thread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [`${thread.id}@${headSha}#${thread.comments.nodes[0]!.id}`],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    number: 2406,
+    headRefOid: headSha,
+    isDraft: true,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-07-06T05:42:30Z",
+    configuredBotCurrentHeadObservedAt: "2026-07-06T05:43:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: headSha.slice(0, 10),
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-06T05:43:00Z",
+  });
+
+  assert.equal(
+    shouldReenterCodexConnectorVerifiedStaleResidueAutoResolve({
+      config,
+      record,
+      pr,
+      checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [thread],
+    }),
+    false,
+  );
 });

--- a/src/supervisor/codex-connector-verified-stale-residue-selection.test.ts
+++ b/src/supervisor/codex-connector-verified-stale-residue-selection.test.ts
@@ -165,3 +165,102 @@ test("shouldReenterCodexConnectorVerifiedStaleResidueAutoResolve keeps proof-bas
     false,
   );
 });
+
+test("shouldReenterCodexConnectorVerifiedStaleResidueAutoResolve accepts blocked conversation-resolution stale supervisor replies", () => {
+  const headSha = "6522b240bae26d207fc802509aadb56fb547cd83";
+  const thread = createReviewThread({
+    id: "thread-current-head-proof-after-stale-supervisor-reply",
+    comments: {
+      nodes: [
+        {
+          id: "comment-codex-before-stale-supervisor",
+          body: "P2: This current-head residue is covered by the repair proof.",
+          createdAt: "2026-07-06T05:35:48Z",
+          url: "https://example.test/pr/2406#discussion_current_head_proof_after_stale_supervisor_reply",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+        {
+          id: "comment-stale-supervisor-latest",
+          body: [
+            `The supervisor reprocessed this configured-bot finding on the current head \`${headSha}\` and classified it as stale.`,
+            "",
+            `Audit: issue=#2405 pr=#2406 head=${headSha} thread=thread-current-head-proof-after-stale-supervisor-reply reason=stale_review_bot.`,
+            "",
+            "Under the configured `reply_and_resolve` policy, the supervisor is auto-resolving this stale thread now.",
+          ].join("\n"),
+          createdAt: "2026-07-06T05:45:00Z",
+          url: "https://example.test/pr/2406#discussion_stale_supervisor_latest",
+          author: {
+            login: "TommyKammy",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
+  const config = createConfig({
+    repoSlug: "TommyKammy/codex-supervisor",
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    verifiedCurrentHeadRepairReviewThreadAutoResolve: true,
+  });
+  const record = createRecord({
+    issue_number: 2405,
+    state: "blocked",
+    blocked_reason: "manual_review",
+    pr_number: 2406,
+    last_head_sha: headSha,
+    processed_review_thread_ids: [`${thread.id}@${headSha}`],
+    processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-codex-before-stale-supervisor`],
+    last_failure_context: {
+      category: "manual",
+      summary: "stale configured-bot residue",
+      signature: `stalled-bot:${thread.id}`,
+      command: null,
+      details: ["required_conversation_resolution=enabled"],
+      url: thread.comments.nodes[0]!.url,
+      updated_at: "2026-07-06T05:46:00Z",
+    },
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npm run build",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Current head repair proof covers the unresolved Connector residue.",
+        recorded_at: "2026-07-06T05:47:00Z",
+        repair_targets: [VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET],
+        processed_review_thread_ids: [`${thread.id}@${headSha}`],
+        processed_review_thread_fingerprints: [`${thread.id}@${headSha}#comment-codex-before-stale-supervisor`],
+      },
+    ],
+  });
+  const pr = createPullRequest({
+    number: 2406,
+    headRefOid: headSha,
+    mergeStateStatus: "BLOCKED",
+    mergeable: "MERGEABLE",
+    currentHeadCiGreenAt: "2026-07-06T05:47:30Z",
+    configuredBotCurrentHeadObservedAt: "2026-07-06T05:48:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: headSha.slice(0, 10),
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-06T05:48:00Z",
+  });
+
+  assert.equal(
+    shouldReenterCodexConnectorVerifiedStaleResidueAutoResolve({
+      config,
+      record,
+      pr,
+      checks: [{ name: "Minimal checks", state: "SUCCESS", bucket: "pass", workflow: "CI" }],
+      reviewThreads: [thread],
+    }),
+    true,
+  );
+});

--- a/src/supervisor/codex-connector-verified-stale-residue-selection.ts
+++ b/src/supervisor/codex-connector-verified-stale-residue-selection.ts
@@ -3,6 +3,7 @@ import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread,
 import {
   buildStaleReviewBotRemediation,
   shouldAutoResolveVerifiedStaleReviewResidue,
+  verifiedStaleReviewResidueAutoResolveStaticGatesPass,
 } from "./stale-review-bot-remediation";
 import { projectCurrentHeadCodexRepairProof } from "../current-head-codex-repair-proof";
 import {
@@ -29,6 +30,7 @@ export function shouldReenterCodexConnectorVerifiedStaleResidueAutoResolve(args:
   });
   if (
     args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true &&
+    verifiedStaleReviewResidueAutoResolveStaticGatesPass(args) &&
     projectCurrentHeadCodexRepairProof({
       config: args.config,
       record: args.record,

--- a/src/supervisor/codex-connector-verified-stale-residue-selection.ts
+++ b/src/supervisor/codex-connector-verified-stale-residue-selection.ts
@@ -4,6 +4,7 @@ import {
   buildStaleReviewBotRemediation,
   shouldAutoResolveVerifiedStaleReviewResidue,
 } from "./stale-review-bot-remediation";
+import { projectCurrentHeadCodexRepairProof } from "../current-head-codex-repair-proof";
 import {
   loadReviewThreadFileContents,
   type RepositoryFileContents,
@@ -26,6 +27,19 @@ export function shouldReenterCodexConnectorVerifiedStaleResidueAutoResolve(args:
     reviewThreads: args.reviewThreads,
     repositoryFileContents: args.repositoryFileContents,
   });
+  if (
+    args.config.verifiedCurrentHeadRepairReviewThreadAutoResolve === true &&
+    projectCurrentHeadCodexRepairProof({
+      config: args.config,
+      record: args.record,
+      pr: args.pr,
+      checks: args.checks,
+      reviewThreads: args.reviewThreads,
+      allowRecordProcessedThreadEvidence: true,
+    }) !== null
+  ) {
+    return true;
+  }
 
   return shouldAutoResolveVerifiedStaleReviewResidue({
     ...args,

--- a/src/supervisor/stale-review-bot-recovery.ts
+++ b/src/supervisor/stale-review-bot-recovery.ts
@@ -253,7 +253,7 @@ export async function recoverStaleConfiguredBotReviewThreads(args: {
     args.resolveAfterReply && hasReplyProgressForThread(thread.id) && latestCommentIsTrustedSupervisorReply(thread)
       ? true
       : verifiedCodexAutoResolveReason
-      ? isRecoverableVerifiedCodexStaleResidueThread(args.config, thread)
+      ? isRecoverableVerifiedCodexStaleResidueThread(args.config, thread, args.pr)
       : latestReviewCommentAuthorIsAllowedBot(args.config, thread) ||
         latestCommentIsTrustedSupervisorMarker(thread),
   );

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -1314,13 +1314,12 @@ export function buildStaleReviewBotRemediation(args: {
   };
 }
 
-export function shouldAutoResolveVerifiedStaleReviewResidue(args: {
+export function verifiedStaleReviewResidueAutoResolveStaticGatesPass(args: {
   config: SupervisorConfig;
   record: IssueRunRecord;
   pr: GitHubPullRequest;
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
-  remediation: StaleReviewBotRemediationDto | null;
 }): boolean {
   const configuredThreads = configuredBotReviewThreads(args.config, args.reviewThreads);
   const recoverableCodexThreads = configuredThreads.filter(
@@ -1333,7 +1332,7 @@ export function shouldAutoResolveVerifiedStaleReviewResidue(args: {
         args.record.blocked_reason === "stale_review_bot") &&
       args.record.pr_number === args.pr.number &&
       configuredReviewProviderKinds(args.config).includes("codex") &&
-      !hasMergeConflictState(args.pr) &&
+      hasCleanMergeState(args.pr) &&
       !hasPendingChecks(args.checks) &&
       !hasFailingChecks(args.checks) &&
       manualReviewThreads(args.config, args.reviewThreads).length === 0 &&
@@ -1344,7 +1343,20 @@ export function shouldAutoResolveVerifiedStaleReviewResidue(args: {
         pr: args.pr,
         configuredThreads,
         recoverableThreads: recoverableCodexThreads,
-      }) &&
+      }),
+  );
+}
+
+export function shouldAutoResolveVerifiedStaleReviewResidue(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  remediation: StaleReviewBotRemediationDto | null;
+}): boolean {
+  return Boolean(
+    verifiedStaleReviewResidueAutoResolveStaticGatesPass(args) &&
       args.remediation &&
       ((isVerifiedStaleResidueClassification(args.remediation.classification) &&
         verifiedStaleReviewResidueAutoResolveEnabled(args.config, args.remediation.classification)) ||

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -164,6 +164,15 @@ function hasCleanMergeState(pr: GitHubPullRequest): boolean {
   return pr.state === "OPEN" && !pr.isDraft && pr.mergeStateStatus === "CLEAN" && pr.mergeable === "MERGEABLE";
 }
 
+function hasAutoResolvableMergeState(pr: GitHubPullRequest): boolean {
+  return (
+    pr.state === "OPEN" &&
+    !pr.isDraft &&
+    pr.mergeable === "MERGEABLE" &&
+    (pr.mergeStateStatus === "CLEAN" || pr.mergeStateStatus === "BLOCKED")
+  );
+}
+
 function hasMergeConflictState(pr: GitHubPullRequest): boolean {
   return pr.state !== "OPEN" || pr.isDraft || pr.mergeStateStatus === "DIRTY" || pr.mergeable === "CONFLICTING";
 }
@@ -1324,7 +1333,7 @@ export function verifiedStaleReviewResidueAutoResolveStaticGatesPass(args: {
   const configuredThreads = configuredBotReviewThreads(args.config, args.reviewThreads);
   const recoverableCodexThreads = configuredThreads.filter(
     (thread) => hasCodexConnectorFindingReviewComment(thread) &&
-      isRecoverableVerifiedCodexStaleResidueThread(args.config, thread),
+      isRecoverableVerifiedCodexStaleResidueThread(args.config, thread, args.pr),
   );
   return Boolean(
     args.record.state === "blocked" &&
@@ -1332,7 +1341,7 @@ export function verifiedStaleReviewResidueAutoResolveStaticGatesPass(args: {
         args.record.blocked_reason === "stale_review_bot") &&
       args.record.pr_number === args.pr.number &&
       configuredReviewProviderKinds(args.config).includes("codex") &&
-      hasCleanMergeState(args.pr) &&
+      hasAutoResolvableMergeState(args.pr) &&
       !hasPendingChecks(args.checks) &&
       !hasFailingChecks(args.checks) &&
       manualReviewThreads(args.config, args.reviewThreads).length === 0 &&

--- a/src/supervisor/verified-stale-residue-review-thread.ts
+++ b/src/supervisor/verified-stale-residue-review-thread.ts
@@ -14,7 +14,8 @@ export function isSupervisorVerifiedStaleResidueAutoResolveComment(body: string)
 }
 
 function normalizedRepoOwnerLogin(config: SupervisorConfig): string | null {
-  const owner = config.repoSlug.split("/")[0]?.trim().toLowerCase();
+  const repoSlug = typeof config.repoSlug === "string" ? config.repoSlug : "";
+  const owner = repoSlug.split("/")[0]?.trim().toLowerCase();
   return owner || null;
 }
 

--- a/src/supervisor/verified-stale-residue-review-thread.ts
+++ b/src/supervisor/verified-stale-residue-review-thread.ts
@@ -1,4 +1,5 @@
-import type { ReviewThread, ReviewThreadComment, SupervisorConfig } from "../core/types";
+import { commitShasEqualForComparison } from "../codex-connector-review-policy";
+import type { GitHubPullRequest, ReviewThread, ReviewThreadComment, SupervisorConfig } from "../core/types";
 import { isCodexConnectorReviewer } from "../external-review/external-review-normalization";
 import {
   latestReviewComment,
@@ -25,9 +26,25 @@ export function isTrustedSupervisorMarkerAuthor(config: SupervisorConfig, commen
   return Boolean(login && owner && login === owner);
 }
 
+function supervisorStaleReviewBotAuditMatches(
+  body: string,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  thread: Pick<ReviewThread, "id">,
+): boolean {
+  const match = body.match(
+    /\bAudit: issue=#\d+ pr=#\d+ head=([^\s]+) thread=([^\s]+) reason=stale_review_bot\b/u,
+  );
+  return Boolean(
+    match &&
+      commitShasEqualForComparison(match[1], pr.headRefOid) &&
+      match[2] === thread.id,
+  );
+}
+
 export function isRecoverableVerifiedCodexStaleResidueThread(
   config: SupervisorConfig,
   thread: ReviewThread,
+  pr?: Pick<GitHubPullRequest, "headRefOid">,
 ): boolean {
   const hasCodexConnectorComment = thread.comments.nodes.some((comment) => {
     const login = comment.author?.login;
@@ -48,5 +65,8 @@ export function isRecoverableVerifiedCodexStaleResidueThread(
   }
 
   return isTrustedSupervisorMarkerAuthor(config, latestComment) &&
-    isSupervisorVerifiedStaleResidueAutoResolveComment(latestComment.body);
+    (
+      isSupervisorVerifiedStaleResidueAutoResolveComment(latestComment.body) ||
+      Boolean(pr && supervisorStaleReviewBotAuditMatches(latestComment.body, pr, thread))
+    );
 }


### PR DESCRIPTION
## Summary
- allow current-head repair proof to keep using the original Codex finding fingerprint when a trusted supervisor stale-residue reply is the latest thread comment
- let terminal manual-review records recover from current-head clean proof without requiring the legacy stop-no-progress marker
- select verified current-head repair residue for recovery when record-scoped proof is sufficient

## Root cause
A trusted supervisor stale reply could become the latest review-thread comment and invalidate processed Codex finding evidence. Separately, same-head manual-review recovery required `last_tracked_pr_repeat_failure_decision=stop_no_progress`, so records shaped like VeriDoc #216 could stay terminal with no runnable issue despite current-head clean proof and local verification.

Fixes #2405

## Verification
- `rtk npx tsx --test src/current-head-codex-repair-proof.test.ts`
- `rtk npx tsx --test src/recovery-blocked-issue-reconciliation.test.ts`
- `rtk npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts`
- `rtk npx tsx --test src/pull-request-state-policy.test.ts`
- `rtk npm run build`
- `rtk npm run verify:supervisor-pre-pr`