### PR TITLE
Refactor finding-set proof text evaluator

### DIFF
--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -11,6 +11,7 @@ import { displayLocalCiCommand } from "./core/config";
 import { configuredReviewProviderKinds } from "./core/review-providers";
 import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, ReviewThreadComment, SupervisorConfig, TimelineArtifact } from "./core/types";
 import { hasCodexConnectorStrongRiskWording } from "./external-review/external-review-normalization";
+import { evaluateFindingSetProofText } from "./finding-set-proof-text-evaluator";
 import {
   currentHeadLocalVerificationEvidence,
   hasConfiguredLocalCiCommand,
@@ -132,67 +133,6 @@ function allCodexConnectorRepairResidueThreadsAreP2(reviewThreads: ReviewThread[
   return reviewThreads.length > 0 && reviewThreads.every((thread) => latestCodexConnectorPSeverity(thread) === "P2");
 }
 
-function textDeclaresAffirmativeFindingSetCompletion(
-  normalizedEvidenceText: string,
-  repairResidueThreadCount: number,
-  recordProcessedEvidenceCoversThreadSet: boolean,
-): boolean {
-  const findingSetPhrase = repairResidueThreadCount > 1
-    ? String.raw`\b(?:finding[- ]set|review findings|connector findings)\b`
-    : String.raw`\b(?:finding[- ]set|review finding|review findings|connector finding|connector findings)\b`;
-  const wholeSetQualifiedFindingSetPhrase = String.raw`\b(?:all|every|each|entire|full|complete)\s+(?:current\s+|unresolved\s+|remaining\s+|outstanding\s+|open\s+)?(?:finding[- ]set|review finding|review findings|connector finding|connector findings)\b`;
-  const scopedFindingSetPhrase = String.raw`(?:${findingSetPhrase}|${wholeSetQualifiedFindingSetPhrase})`;
-  const completionPhrase = String.raw`\b(?:verified|covered|repaired)\b`;
-  const nearbyClauseText = String.raw`[^.;:\n]{0,120}?`;
-  const nearbyText = String.raw`[\s\S]{0,120}?`;
-  const nearbyShortText = String.raw`[\s\S]{0,40}?`;
-  const negationPhrase = String.raw`\b(?:not|never|no|none|neither|without|isn't|isnt|aren't|arent|wasn't|wasnt|weren't|werent|cannot|can't|cant|failed to|fails to)\b`;
-  const incompletePhrase = String.raw`\b(?:not all|partial|partially|incomplete|except|excluding|exclude|missing|remain|remains|unaddressed|subset)\b`;
-  const partialFindingSetPhrase = String.raw`\b(?:only\s+some|some)(?:\s+of\s+(?:the\s+)?)?\s+(?:finding[- ]set|review findings|connector findings)\b`;
-  const futureCompletionPhrase = String.raw`\b(?:will be|needs to be|need to be|should be|must be|to be)\b`;
-  const affirmativeCompletion = new RegExp(
-    `(?:${completionPhrase}${nearbyClauseText}${scopedFindingSetPhrase}|${scopedFindingSetPhrase}${nearbyClauseText}${completionPhrase})`,
-    "u",
-  );
-  if (!affirmativeCompletion.test(normalizedEvidenceText)) {
-    return false;
-  }
-  if (new RegExp(
-    `(?:${scopedFindingSetPhrase}${nearbyText}${negationPhrase}${nearbyShortText}${completionPhrase}|${negationPhrase}${nearbyShortText}${completionPhrase}${nearbyText}${scopedFindingSetPhrase}|${negationPhrase}${nearbyShortText}${scopedFindingSetPhrase}${nearbyText}${completionPhrase})`,
-    "u",
-  ).test(normalizedEvidenceText)) {
-    return false;
-  }
-  if (new RegExp(
-    `(?:${partialFindingSetPhrase}|${incompletePhrase}${nearbyText}${findingSetPhrase}|${findingSetPhrase}${nearbyText}${incompletePhrase})`,
-    "u",
-  ).test(normalizedEvidenceText)) {
-    return false;
-  }
-  if (new RegExp(
-    `(?:${scopedFindingSetPhrase}${nearbyText}${futureCompletionPhrase}${nearbyShortText}${completionPhrase}|${futureCompletionPhrase}${nearbyShortText}${completionPhrase}${nearbyText}${scopedFindingSetPhrase})`,
-    "u",
-  ).test(normalizedEvidenceText)) {
-    return false;
-  }
-  const partialCountMatch = normalizedEvidenceText.match(
-    new RegExp(String.raw`\b(\d+)\s*(?:(?:out\s+)?of\s+(?:the\s+)?|/\s*)${repairResidueThreadCount}\b`, "u"),
-  );
-  if (partialCountMatch && Number(partialCountMatch[1]) !== repairResidueThreadCount) {
-    return false;
-  }
-  if (repairResidueThreadCount <= 1 || recordProcessedEvidenceCoversThreadSet) {
-    return true;
-  }
-
-  const countPhrase = String.raw`\b${repairResidueThreadCount}\b`;
-  const wholeSetPhrase = String.raw`\b(?:all|every|entire|full|complete)\b`;
-  return new RegExp(
-    `(?:\\bfinding[- ]set\\b|${wholeSetQualifiedFindingSetPhrase}|${wholeSetPhrase}${nearbyText}${findingSetPhrase}|${findingSetPhrase}${nearbyText}${wholeSetPhrase}|${countPhrase}${nearbyText}${findingSetPhrase}|${findingSetPhrase}${nearbyText}${countPhrase})`,
-    "u",
-  ).test(normalizedEvidenceText);
-}
-
 function artifactDeclaresFindingSetScope(
   config: SupervisorConfig,
   artifact: TimelineArtifact,
@@ -205,13 +145,12 @@ function artifactDeclaresFindingSetScope(
   }
 
   return [artifact.summary, artifact.command].some((value) => {
-    const normalizedEvidenceText = value?.trim().toLowerCase();
-    return normalizedEvidenceText
-      ? textDeclaresAffirmativeFindingSetCompletion(
-          normalizedEvidenceText,
-          repairResidueThreads.length,
+    return value?.trim()
+      ? evaluateFindingSetProofText({
+          evidenceText: value,
+          repairResidueThreadCount: repairResidueThreads.length,
           recordProcessedEvidenceCoversThreadSet,
-        )
+        }).accepted
       : false;
   });
 }

--- a/src/finding-set-proof-text-evaluator.test.ts
+++ b/src/finding-set-proof-text-evaluator.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  evaluateFindingSetProofText,
+  type FindingSetProofTextEvaluationReason,
+} from "./finding-set-proof-text-evaluator";
+
+function reasonFor(summary: string, args: {
+  repairResidueThreadCount?: number;
+  recordProcessedEvidenceCoversThreadSet?: boolean;
+} = {}): FindingSetProofTextEvaluationReason {
+  return evaluateFindingSetProofText({
+    evidenceText: summary,
+    repairResidueThreadCount: args.repairResidueThreadCount ?? 2,
+    recordProcessedEvidenceCoversThreadSet: args.recordProcessedEvidenceCoversThreadSet ?? false,
+  }).reason;
+}
+
+test("evaluateFindingSetProofText accepts explicit current-head finding-set completion", () => {
+  assert.deepEqual(evaluateFindingSetProofText({
+    evidenceText: "Current-head verification covered all review findings.",
+    repairResidueThreadCount: 2,
+    recordProcessedEvidenceCoversThreadSet: false,
+  }), {
+    accepted: true,
+    reason: "accepted",
+  });
+});
+
+test("evaluateFindingSetProofText separates summary-only rejection reasons", () => {
+  assert.equal(reasonFor("Focused verifier passed."), "affirmative_completion_missing");
+  assert.equal(reasonFor("Review findings not covered by this run."), "negated_completion");
+  assert.equal(reasonFor("Only some review findings were covered by this run."), "partial_coverage");
+  assert.equal(reasonFor("All review findings will be repaired in the next run."), "future_completion");
+  assert.equal(reasonFor("1 of 2 review findings were covered by this run."), "fractional_count_mismatch");
+  assert.equal(reasonFor("Review findings were covered by this run.", { repairResidueThreadCount: 2 }), "multi_thread_scope_missing");
+});
+
+test("evaluateFindingSetProofText preserves record-processed evidence scope behavior", () => {
+  const summary = "Review findings were covered by the current-head verifier.";
+
+  assert.deepEqual(evaluateFindingSetProofText({
+    evidenceText: summary,
+    repairResidueThreadCount: 2,
+    recordProcessedEvidenceCoversThreadSet: true,
+  }), {
+    accepted: true,
+    reason: "accepted",
+  });
+  assert.equal(reasonFor(summary, {
+    repairResidueThreadCount: 2,
+    recordProcessedEvidenceCoversThreadSet: false,
+  }), "multi_thread_scope_missing");
+});

--- a/src/finding-set-proof-text-evaluator.ts
+++ b/src/finding-set-proof-text-evaluator.ts
@@ -1,0 +1,77 @@
+export type FindingSetProofTextEvaluationReason =
+  | "accepted"
+  | "affirmative_completion_missing"
+  | "negated_completion"
+  | "partial_coverage"
+  | "future_completion"
+  | "fractional_count_mismatch"
+  | "multi_thread_scope_missing";
+
+export type FindingSetProofTextEvaluation =
+  | { accepted: true; reason: "accepted" }
+  | { accepted: false; reason: Exclude<FindingSetProofTextEvaluationReason, "accepted"> };
+
+export function evaluateFindingSetProofText(args: {
+  evidenceText: string;
+  repairResidueThreadCount: number;
+  recordProcessedEvidenceCoversThreadSet: boolean;
+}): FindingSetProofTextEvaluation {
+  const normalizedEvidenceText = args.evidenceText.trim().toLowerCase();
+  const findingSetPhrase = args.repairResidueThreadCount > 1
+    ? String.raw`\b(?:finding[- ]set|review findings|connector findings)\b`
+    : String.raw`\b(?:finding[- ]set|review finding|review findings|connector finding|connector findings)\b`;
+  const wholeSetQualifiedFindingSetPhrase = String.raw`\b(?:all|every|each|entire|full|complete)\s+(?:current\s+|unresolved\s+|remaining\s+|outstanding\s+|open\s+)?(?:finding[- ]set|review finding|review findings|connector finding|connector findings)\b`;
+  const scopedFindingSetPhrase = String.raw`(?:${findingSetPhrase}|${wholeSetQualifiedFindingSetPhrase})`;
+  const completionPhrase = String.raw`\b(?:verified|covered|repaired)\b`;
+  const nearbyClauseText = String.raw`[^.;:\n]{0,120}?`;
+  const nearbyText = String.raw`[\s\S]{0,120}?`;
+  const nearbyShortText = String.raw`[\s\S]{0,40}?`;
+  const negationPhrase = String.raw`\b(?:not|never|no|none|neither|without|isn't|isnt|aren't|arent|wasn't|wasnt|weren't|werent|cannot|can't|cant|failed to|fails to)\b`;
+  const incompletePhrase = String.raw`\b(?:not all|partial|partially|incomplete|except|excluding|exclude|missing|remain|remains|unaddressed|subset)\b`;
+  const partialFindingSetPhrase = String.raw`\b(?:only\s+some|some)(?:\s+of\s+(?:the\s+)?)?\s+(?:finding[- ]set|review findings|connector findings)\b`;
+  const futureCompletionPhrase = String.raw`\b(?:will be|needs to be|need to be|should be|must be|to be)\b`;
+  const affirmativeCompletion = new RegExp(
+    `(?:${completionPhrase}${nearbyClauseText}${scopedFindingSetPhrase}|${scopedFindingSetPhrase}${nearbyClauseText}${completionPhrase})`,
+    "u",
+  );
+  if (!affirmativeCompletion.test(normalizedEvidenceText)) {
+    return { accepted: false, reason: "affirmative_completion_missing" };
+  }
+  if (new RegExp(
+    `(?:${scopedFindingSetPhrase}${nearbyText}${negationPhrase}${nearbyShortText}${completionPhrase}|${negationPhrase}${nearbyShortText}${completionPhrase}${nearbyText}${scopedFindingSetPhrase}|${negationPhrase}${nearbyShortText}${scopedFindingSetPhrase}${nearbyText}${completionPhrase})`,
+    "u",
+  ).test(normalizedEvidenceText)) {
+    return { accepted: false, reason: "negated_completion" };
+  }
+  if (new RegExp(
+    `(?:${partialFindingSetPhrase}|${incompletePhrase}${nearbyText}${findingSetPhrase}|${findingSetPhrase}${nearbyText}${incompletePhrase})`,
+    "u",
+  ).test(normalizedEvidenceText)) {
+    return { accepted: false, reason: "partial_coverage" };
+  }
+  if (new RegExp(
+    `(?:${scopedFindingSetPhrase}${nearbyText}${futureCompletionPhrase}${nearbyShortText}${completionPhrase}|${futureCompletionPhrase}${nearbyShortText}${completionPhrase}${nearbyText}${scopedFindingSetPhrase})`,
+    "u",
+  ).test(normalizedEvidenceText)) {
+    return { accepted: false, reason: "future_completion" };
+  }
+  const partialCountMatch = normalizedEvidenceText.match(
+    new RegExp(String.raw`\b(\d+)\s*(?:(?:out\s+)?of\s+(?:the\s+)?|/\s*)${args.repairResidueThreadCount}\b`, "u"),
+  );
+  if (partialCountMatch && Number(partialCountMatch[1]) !== args.repairResidueThreadCount) {
+    return { accepted: false, reason: "fractional_count_mismatch" };
+  }
+  if (args.repairResidueThreadCount <= 1 || args.recordProcessedEvidenceCoversThreadSet) {
+    return { accepted: true, reason: "accepted" };
+  }
+
+  const countPhrase = String.raw`\b${args.repairResidueThreadCount}\b`;
+  const wholeSetPhrase = String.raw`\b(?:all|every|entire|full|complete)\b`;
+  if (new RegExp(
+    `(?:\\bfinding[- ]set\\b|${wholeSetQualifiedFindingSetPhrase}|${wholeSetPhrase}${nearbyText}${findingSetPhrase}|${findingSetPhrase}${nearbyText}${wholeSetPhrase}|${countPhrase}${nearbyText}${findingSetPhrase}|${findingSetPhrase}${nearbyText}${countPhrase})`,
+    "u",
+  ).test(normalizedEvidenceText)) {
+    return { accepted: true, reason: "accepted" };
+  }
+  return { accepted: false, reason: "multi_thread_scope_missing" };
+}


### PR DESCRIPTION
## Summary
- Extract summary-only finding-set proof text evaluation into a dedicated typed evaluator
- Keep current-head repair proof callers delegated without changing structured or thread-scoped proof paths
- Add focused evaluator tests for accepted completion, negation, partial coverage, future-tense promises, fractional counts, and multi-thread scope rejection

## Verification
- npx tsx --test src/finding-set-proof-text-evaluator.test.ts
- npx tsx --test src/current-head-codex-repair-proof.test.ts
- npx tsx --test src/pull-request-state-policy.test.ts
- npm run build

Closes #2410