### PR TITLE
Share current-head proof artifact gating

### DIFF
--- a/src/current-head-codex-repair-proof.test.ts
+++ b/src/current-head-codex-repair-proof.test.ts
@@ -208,6 +208,17 @@ test("projectCurrentHeadCodexRepairProof accepts record-scoped processed evidenc
       {
         type: "verification_result",
         gate: "codex_turn",
+        command: "npm run build",
+        head_sha: headSha,
+        outcome: "passed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Generic build passed but did not satisfy configured local CI.",
+        recorded_at: "2026-07-01T06:51:31Z",
+      },
+      {
+        type: "verification_result",
+        gate: "codex_turn",
         command: "python3 -m pytest tests/test_desktop_api_auth.py tests/test_poc_web_api.py -q",
         head_sha: headSha,
         outcome: "passed",
@@ -243,6 +254,7 @@ test("projectCurrentHeadCodexRepairProof accepts record-scoped processed evidenc
   assert.equal(proof?.source, "record_processed_thread_evidence");
   assert.equal(proof?.localVerificationEvidenceSource, "scoped_repair_timeline_artifact_with_non_review_checks");
   assert.equal(proof?.processedThreadEvidenceCount, 4);
+  assert.match(proof?.summary ?? "", /Focused current-head probe covered the stale Connector findings/);
   assert.match(proof?.summary ?? "", /codex_no_major_support=codex_pr_success_comment_reviewed_current_head/);
 });
 

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -663,6 +663,38 @@ function formatThreadScopedVerificationSummary(args: {
   return details.join(";");
 }
 
+function firstProofArtifactWithRequiredLocalCiEvidence(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  artifacts: TimelineArtifact[];
+  configuredLocalCiRequired: boolean;
+}): {
+  artifact: TimelineArtifact;
+  localVerificationEvidence: CurrentHeadLocalVerificationEvidence | null;
+} | null {
+  for (const artifact of args.artifacts) {
+    const localVerificationEvidence = args.configuredLocalCiRequired
+      ? currentHeadLocalVerificationEvidence({
+          config: args.config,
+          record: args.record,
+          pr: args.pr,
+          checks: args.checks,
+          scopedTimelineArtifact: artifact,
+        })
+      : null;
+    if (args.configuredLocalCiRequired && !localVerificationEvidence) {
+      continue;
+    }
+    return {
+      artifact,
+      localVerificationEvidence,
+    };
+  }
+  return null;
+}
+
 function humanReviewBlocksProjection(
   config: SupervisorConfig,
   pr: GitHubPullRequest,
@@ -725,64 +757,34 @@ export function projectCurrentHeadCodexRepairProof(args: {
       )
     : repairResidueThreads;
   const configuredLocalCiRequired = hasConfiguredLocalCiCommand(args.config);
-  const structuredProof = currentHeadVerifiedRepairResidueArtifacts(args.config, args.record, args.pr, proofCoverageThreads)
-    .map((structuredArtifact) => {
-      const localVerificationEvidence = configuredLocalCiRequired
-        ? currentHeadLocalVerificationEvidence({
-            config: args.config,
-            record: args.record,
-            pr: args.pr,
-            checks: args.checks,
-            scopedTimelineArtifact: structuredArtifact,
-          })
-        : null;
-      if (configuredLocalCiRequired && !localVerificationEvidence) {
-        return null;
-      }
-      return {
-        structuredArtifact,
-        localVerificationEvidence,
-      };
-    })
-    .find((proof): proof is {
-      structuredArtifact: TimelineArtifact;
-      localVerificationEvidence: CurrentHeadLocalVerificationEvidence | null;
-    } => proof !== null);
+  const structuredProof = firstProofArtifactWithRequiredLocalCiEvidence({
+    config: args.config,
+    record: args.record,
+    pr: args.pr,
+    checks: args.checks,
+    artifacts: currentHeadVerifiedRepairResidueArtifacts(args.config, args.record, args.pr, proofCoverageThreads),
+    configuredLocalCiRequired,
+  });
   if (structuredProof) {
     return {
       source: "structured_artifact",
-      summary: structuredProof.structuredArtifact.summary || "verified_current_head_repair_review_thread_residue_artifact",
+      summary: structuredProof.artifact.summary || "verified_current_head_repair_review_thread_residue_artifact",
       localVerificationEvidenceSource: structuredProof.localVerificationEvidence?.source ?? null,
       localVerificationEvidenceSummary: structuredProof.localVerificationEvidence?.summary ?? null,
-      processedThreadEvidenceCount: structuredProof.structuredArtifact.processed_review_thread_ids?.length ?? 0,
+      processedThreadEvidenceCount: structuredProof.artifact.processed_review_thread_ids?.length ?? 0,
       currentConfiguredThreadCount: repairResidueThreads.length,
     };
   }
 
   const threadScopedProof = noMajorSupport
-    ? currentHeadThreadScopedVerificationArtifacts(args.config, args.record, args.pr, proofCoverageThreads)
-        .map((artifact) => {
-          const localVerificationEvidence = configuredLocalCiRequired
-            ? currentHeadLocalVerificationEvidence({
-                config: args.config,
-                record: args.record,
-                pr: args.pr,
-                checks: args.checks,
-                scopedTimelineArtifact: artifact,
-              })
-            : null;
-          if (configuredLocalCiRequired && !localVerificationEvidence) {
-            return null;
-          }
-          return {
-            artifact,
-            localVerificationEvidence,
-          };
-        })
-        .find((proof): proof is {
-          artifact: TimelineArtifact;
-          localVerificationEvidence: CurrentHeadLocalVerificationEvidence | null;
-        } => proof !== null)
+    ? firstProofArtifactWithRequiredLocalCiEvidence({
+        config: args.config,
+        record: args.record,
+        pr: args.pr,
+        checks: args.checks,
+        artifacts: currentHeadThreadScopedVerificationArtifacts(args.config, args.record, args.pr, proofCoverageThreads),
+        configuredLocalCiRequired,
+      })
     : null;
   if (threadScopedProof) {
     return {
@@ -809,35 +811,20 @@ export function projectCurrentHeadCodexRepairProof(args: {
     noMajorSupport &&
     allCodexConnectorRepairResidueThreadsAreP2(proofCoverageThreads)
   ) {
-    const findingSetProof = currentHeadFindingSetVerificationArtifacts(
-      args.config,
-      args.record,
-      args.pr,
-      proofCoverageThreads,
-      recordProcessedEvidenceCoversProofCoverageThreads,
-    )
-      .map((artifact) => {
-        const localVerificationEvidence = configuredLocalCiRequired
-          ? currentHeadLocalVerificationEvidence({
-              config: args.config,
-              record: args.record,
-              pr: args.pr,
-              checks: args.checks,
-              scopedTimelineArtifact: artifact,
-            })
-          : null;
-        if (configuredLocalCiRequired && !localVerificationEvidence) {
-          return null;
-        }
-        return {
-          artifact,
-          localVerificationEvidence,
-        };
-      })
-      .find((proof): proof is {
-        artifact: TimelineArtifact;
-        localVerificationEvidence: CurrentHeadLocalVerificationEvidence | null;
-      } => proof !== null);
+    const findingSetProof = firstProofArtifactWithRequiredLocalCiEvidence({
+      config: args.config,
+      record: args.record,
+      pr: args.pr,
+      checks: args.checks,
+      artifacts: currentHeadFindingSetVerificationArtifacts(
+        args.config,
+        args.record,
+        args.pr,
+        proofCoverageThreads,
+        recordProcessedEvidenceCoversProofCoverageThreads,
+      ),
+      configuredLocalCiRequired,
+    });
     if (findingSetProof) {
       return {
         source: "finding_set_verification_artifact",
@@ -861,34 +848,18 @@ export function projectCurrentHeadCodexRepairProof(args: {
     recordProcessedThreadEvidenceCount > 0 &&
     recordProcessedEvidenceCoversProofCoverageThreads
   ) {
-    const recordScopedProof = currentHeadPassedCodexTurnArtifacts(args.record, args.pr)
-      .filter((artifact) =>
+    const recordScopedProof = firstProofArtifactWithRequiredLocalCiEvidence({
+      config: args.config,
+      record: args.record,
+      pr: args.pr,
+      checks: args.checks,
+      artifacts: currentHeadPassedCodexTurnArtifacts(args.record, args.pr).filter((artifact) =>
         proofCoverageThreads.every((thread) =>
           latestReviewThreadCommentPredatesArtifact(args.config, args.pr, thread, artifact)
         )
-      )
-      .map((artifact) => {
-        const localVerificationEvidence = configuredLocalCiRequired
-          ? currentHeadLocalVerificationEvidence({
-              config: args.config,
-              record: args.record,
-              pr: args.pr,
-              checks: args.checks,
-              scopedTimelineArtifact: artifact,
-            })
-          : null;
-        if (configuredLocalCiRequired && !localVerificationEvidence) {
-          return null;
-        }
-        return {
-          artifact,
-          localVerificationEvidence,
-        };
-      })
-      .find((proof): proof is {
-        artifact: TimelineArtifact;
-        localVerificationEvidence: CurrentHeadLocalVerificationEvidence | null;
-      } => proof !== null);
+      ),
+      configuredLocalCiRequired,
+    });
     if (recordScopedProof) {
       return {
         source: "record_processed_thread_evidence",


### PR DESCRIPTION
## Summary
- Extract shared current-head proof artifact selection with required local-CI evidence gating.
- Apply it to structured, thread-scoped, finding-set, and record-scoped proof paths without changing precedence.
- Tighten record-scoped coverage to prove a non-local-CI artifact is skipped in favor of a later exact local-CI artifact.

## Verification
- npx tsx --test src/current-head-codex-repair-proof.test.ts
- npx tsx --test src/pull-request-state-policy.test.ts
- npm run build

Closes #2412