### PR TITLE
Consolidate stale-review and current-head repair coverage helpers

### DIFF
--- a/src/codex-connector-review-repair-coverage.ts
+++ b/src/codex-connector-review-repair-coverage.ts
@@ -1,0 +1,86 @@
+import type { GitHubPullRequest, IssueRunRecord, ReviewThread, TimelineArtifact } from "./core/types";
+import {
+  latestReviewThreadCommentFingerprint,
+  processedReviewThreadFingerprintKey,
+  processedReviewThreadKey,
+} from "./review-handling";
+import { latestCodexConnectorPSeverity } from "./codex-connector-review-policy";
+
+export interface ReviewThreadCoverageFingerprint {
+  fingerprint: string;
+}
+
+export function headScopedProcessedThreadEvidenceCount(
+  source: Pick<
+    IssueRunRecord | TimelineArtifact,
+    "processed_review_thread_ids" | "processed_review_thread_fingerprints"
+  >,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+): number {
+  const headToken = `@${pr.headRefOid}`;
+  return (
+    (source.processed_review_thread_ids ?? []).filter((key) => key.includes(headToken)).length +
+    (source.processed_review_thread_fingerprints ?? []).filter((key) => key.includes(headToken)).length
+  );
+}
+
+export function allCodexConnectorRepairResidueThreadsAreP2(reviewThreads: ReviewThread[]): boolean {
+  return reviewThreads.length > 0 && reviewThreads.every((thread) => latestCodexConnectorPSeverity(thread) === "P2");
+}
+
+export function timelineArtifactCoversReviewThread(args: {
+  artifact: Pick<TimelineArtifact, "processed_review_thread_ids" | "processed_review_thread_fingerprints">;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  thread: Pick<ReviewThread, "id" | "comments">;
+  acceptedFingerprints?: ReviewThreadCoverageFingerprint[];
+  allowHeadScopedIdWhenFingerprintsExist?: boolean;
+}): boolean {
+  const processedThreadIds = args.artifact.processed_review_thread_ids ?? [];
+  const processedThreadFingerprints = args.artifact.processed_review_thread_fingerprints ?? [];
+  const headScopedKey = processedReviewThreadKey(args.thread.id, args.pr.headRefOid);
+  const latestFingerprint = latestReviewThreadCommentFingerprint(args.thread);
+  const acceptedFingerprints =
+    args.acceptedFingerprints ?? (latestFingerprint ? [{ fingerprint: latestFingerprint }] : []);
+  const matchedFingerprint = acceptedFingerprints.find((candidate) =>
+    processedThreadFingerprints.includes(
+      processedReviewThreadFingerprintKey(args.thread.id, args.pr.headRefOid, candidate.fingerprint),
+    )
+  );
+  if (matchedFingerprint) {
+    return true;
+  }
+
+  if (!processedThreadIds.includes(headScopedKey)) {
+    return false;
+  }
+  if (acceptedFingerprints.length === 0) {
+    return true;
+  }
+  if (args.allowHeadScopedIdWhenFingerprintsExist !== true) {
+    return false;
+  }
+
+  const threadFingerprintPrefix = `${headScopedKey}#`;
+  return !processedThreadFingerprints.some((key) => key.startsWith(threadFingerprintPrefix));
+}
+
+export function timelineArtifactCoversReviewThreads(args: {
+  artifact: Pick<TimelineArtifact, "processed_review_thread_ids" | "processed_review_thread_fingerprints">;
+  pr: Pick<GitHubPullRequest, "headRefOid">;
+  reviewThreads: ReviewThread[];
+  acceptedFingerprints?: (thread: ReviewThread) => ReviewThreadCoverageFingerprint[];
+  allowHeadScopedIdWhenFingerprintsExist?: boolean;
+}): boolean {
+  if (args.reviewThreads.length === 0) {
+    return false;
+  }
+  return args.reviewThreads.every((thread) =>
+    timelineArtifactCoversReviewThread({
+      artifact: args.artifact,
+      pr: args.pr,
+      thread,
+      acceptedFingerprints: args.acceptedFingerprints?.(thread),
+      allowHeadScopedIdWhenFingerprintsExist: args.allowHeadScopedIdWhenFingerprintsExist,
+    })
+  );
+}

--- a/src/codex-connector-valid-review-repair.ts
+++ b/src/codex-connector-valid-review-repair.ts
@@ -1,17 +1,14 @@
 import type { GitHubPullRequest, IssueRunRecord, ReviewThread, TimelineArtifact } from "./core/types";
 import { VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET } from "./current-head-codex-repair-proof";
 import {
-  latestReviewThreadCommentFingerprint,
-  processedReviewThreadFingerprintKey,
-  processedReviewThreadKey,
-} from "./review-handling";
-import {
   codexConnectorMustFixReviewThreads,
   latestCodexConnectorPSeverity,
   latestCodexConnectorReviewComment,
   latestCodexConnectorReviewCommentFingerprint,
   latestCodexConnectorReviewCommentNode,
 } from "./codex-connector-review-policy";
+import { timelineArtifactCoversReviewThread } from "./codex-connector-review-repair-coverage";
+import { latestReviewThreadCommentFingerprint } from "./review-handling";
 
 export const STILL_VALID_REVIEW_THREAD_REPAIR_TARGET =
   "still_valid_review_thread_repair";
@@ -28,38 +25,6 @@ export interface CodexConnectorValidReviewRepairTarget {
   evidenceSummary: string;
 }
 
-function timelineArtifactCoversReviewThread(args: {
-  artifact: TimelineArtifact;
-  pr: Pick<GitHubPullRequest, "headRefOid">;
-  thread: Pick<ReviewThread, "id" | "comments">;
-}): boolean {
-  const processedThreadIds = args.artifact.processed_review_thread_ids ?? [];
-  const processedThreadFingerprints = args.artifact.processed_review_thread_fingerprints ?? [];
-  const headScopedThreadId = processedReviewThreadKey(args.thread.id, args.pr.headRefOid);
-  const latestCommentFingerprints = [
-    latestCodexConnectorReviewCommentFingerprint(args.thread as ReviewThread),
-    latestReviewThreadCommentFingerprint(args.thread),
-  ].filter((fingerprint): fingerprint is string => Boolean(fingerprint));
-  const acceptedFingerprintKeys = new Set(
-    latestCommentFingerprints.map((fingerprint) =>
-      processedReviewThreadFingerprintKey(args.thread.id, args.pr.headRefOid, fingerprint),
-    ),
-  );
-  if (processedThreadFingerprints.some((fingerprint) => acceptedFingerprintKeys.has(fingerprint))) {
-    return true;
-  }
-
-  if (!processedThreadIds.includes(headScopedThreadId)) {
-    return false;
-  }
-  if (latestCommentFingerprints.length === 0) {
-    return true;
-  }
-
-  const threadFingerprintPrefix = `${headScopedThreadId}#`;
-  return !processedThreadFingerprints.some((key) => key.startsWith(threadFingerprintPrefix));
-}
-
 function isCurrentHeadCodexTurnArtifact(args: {
   artifact: TimelineArtifact;
   pr: Pick<GitHubPullRequest, "headRefOid">;
@@ -69,7 +34,14 @@ function isCurrentHeadCodexTurnArtifact(args: {
     args.artifact.type === "verification_result" &&
     args.artifact.gate === "codex_turn" &&
     args.artifact.head_sha === args.pr.headRefOid &&
-    timelineArtifactCoversReviewThread(args)
+    timelineArtifactCoversReviewThread({
+      ...args,
+      acceptedFingerprints: [
+        latestCodexConnectorReviewCommentFingerprint(args.thread),
+        latestReviewThreadCommentFingerprint(args.thread),
+      ].filter((fingerprint): fingerprint is string => Boolean(fingerprint)).map((fingerprint) => ({ fingerprint })),
+      allowHeadScopedIdWhenFingerprintsExist: true,
+    })
   );
 }
 

--- a/src/current-head-codex-repair-proof.ts
+++ b/src/current-head-codex-repair-proof.ts
@@ -20,8 +20,12 @@ import {
 import {
   hasProcessedReviewThread,
   processedReviewThreadFingerprintKey,
-  processedReviewThreadKey,
 } from "./review-handling";
+import {
+  allCodexConnectorRepairResidueThreadsAreP2,
+  headScopedProcessedThreadEvidenceCount,
+  timelineArtifactCoversReviewThread,
+} from "./codex-connector-review-repair-coverage";
 import { reviewDecisionBlocksCurrentHeadRepairProjection } from "./review-decision-blocking-policy";
 import {
   configuredBotReviewThreads,
@@ -129,10 +133,6 @@ function timestampAtOrAfter(value: string | null | undefined, floor: string | nu
   return !Number.isNaN(parsedFloor) && parsedValue >= parsedFloor;
 }
 
-function allCodexConnectorRepairResidueThreadsAreP2(reviewThreads: ReviewThread[]): boolean {
-  return reviewThreads.length > 0 && reviewThreads.every((thread) => latestCodexConnectorPSeverity(thread) === "P2");
-}
-
 function artifactDeclaresFindingSetScope(
   config: SupervisorConfig,
   artifact: TimelineArtifact,
@@ -140,7 +140,7 @@ function artifactDeclaresFindingSetScope(
   repairResidueThreads: ReviewThread[],
   recordProcessedEvidenceCoversThreadSet: boolean,
 ): boolean {
-  if (artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0) {
+  if (headScopedProcessedThreadEvidenceCount(artifact, pr) > 0) {
     return repairArtifactCoversCurrentThreads(config, artifact, pr, repairResidueThreads);
   }
 
@@ -206,7 +206,7 @@ function currentHeadThreadScopedVerificationArtifacts(
       artifact.head_sha === pr.headRefOid &&
       artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") !== true &&
       artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) !== true &&
-      artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0 &&
+      headScopedProcessedThreadEvidenceCount(artifact, pr) > 0 &&
       repairArtifactCoversCurrentThreads(config, artifact, pr, currentThreads),
   );
 }
@@ -223,19 +223,8 @@ function currentHeadVerifiedRepairResidueArtifacts(
       artifact.outcome === "passed" &&
       artifact.head_sha === pr.headRefOid &&
       artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
-      artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0 &&
+      headScopedProcessedThreadEvidenceCount(artifact, pr) > 0 &&
       (!currentThreads || repairArtifactCoversCurrentThreads(config, artifact, pr, currentThreads)),
-  );
-}
-
-function artifactHeadScopedProcessedThreadEvidenceCount(
-  artifact: Pick<TimelineArtifact, "processed_review_thread_ids" | "processed_review_thread_fingerprints">,
-  pr: Pick<GitHubPullRequest, "headRefOid">,
-): number {
-  const headToken = `@${pr.headRefOid}`;
-  return (
-    (artifact.processed_review_thread_ids ?? []).filter((key) => key.includes(headToken)).length +
-    (artifact.processed_review_thread_fingerprints ?? []).filter((key) => key.includes(headToken)).length
   );
 }
 
@@ -246,13 +235,22 @@ function repairArtifactCoversCurrentThreads(
   currentThreads: ReviewThread[],
 ): boolean {
   if (currentThreads.length === 0) {
-    return artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0;
+    return headScopedProcessedThreadEvidenceCount(artifact, pr) > 0;
   }
-  const processedThreadIds = artifact.processed_review_thread_ids ?? [];
   const processedThreadFingerprints = artifact.processed_review_thread_fingerprints ?? [];
   return currentThreads.every((thread) => {
-    const headScopedKey = processedReviewThreadKey(thread.id, pr.headRefOid);
     const acceptedFingerprints = currentHeadRepairProofThreadFingerprints(config, pr, thread);
+    if (
+      !timelineArtifactCoversReviewThread({
+        artifact,
+        pr,
+        thread,
+        acceptedFingerprints,
+        allowHeadScopedIdWhenFingerprintsExist: true,
+      })
+    ) {
+      return false;
+    }
     const matchedFingerprint = acceptedFingerprints.find((candidate) =>
       processedThreadFingerprints.includes(
         processedReviewThreadFingerprintKey(thread.id, pr.headRefOid, candidate.fingerprint),
@@ -261,18 +259,10 @@ function repairArtifactCoversCurrentThreads(
     if (matchedFingerprint) {
       return reviewThreadCommentPredatesArtifact(matchedFingerprint.comment, artifact);
     }
-    if (!processedThreadIds.includes(headScopedKey)) {
-      return false;
-    }
     if (acceptedFingerprints.length === 0) {
       return true;
     }
-
-    const threadFingerprintPrefix = `${headScopedKey}#`;
-    return (
-      !processedThreadFingerprints.some((key) => key.startsWith(threadFingerprintPrefix)) &&
-      latestReviewThreadCommentPredatesArtifact(config, pr, thread, artifact)
-    );
+    return latestReviewThreadCommentPredatesArtifact(config, pr, thread, artifact);
   });
 }
 
@@ -439,17 +429,6 @@ export function currentHeadRepairProofThreadFingerprint(
   thread: ReviewThread,
 ): string | null {
   return currentHeadRepairProofThreadFingerprints(config, pr, thread)[0]?.fingerprint ?? null;
-}
-
-function headScopedProcessedThreadEvidenceCount(
-  record: Pick<IssueRunRecord, "processed_review_thread_ids" | "processed_review_thread_fingerprints">,
-  pr: Pick<GitHubPullRequest, "headRefOid">,
-): number {
-  const headToken = `@${pr.headRefOid}`;
-  return (
-    (record.processed_review_thread_ids ?? []).filter((key) => key.includes(headToken)).length +
-    (record.processed_review_thread_fingerprints ?? []).filter((key) => key.includes(headToken)).length
-  );
 }
 
 function currentRepairResidueThreads(currentThreads: ReviewThread[], p1ProofAllowed: boolean): ReviewThread[] | null {
@@ -1032,6 +1011,6 @@ function currentHeadVerifiedRepairResidueArtifactsPresent(
       artifact.outcome === "passed" &&
       artifact.head_sha === pr.headRefOid &&
       artifact.repair_targets?.includes(VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET) === true &&
-      artifactHeadScopedProcessedThreadEvidenceCount(artifact, pr) > 0,
+      headScopedProcessedThreadEvidenceCount(artifact, pr) > 0,
   );
 }

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -2077,6 +2077,72 @@ test("buildStaleReviewBotRemediation fails closed when current-head no-major has
   assert.equal(remediation?.missingProbeReason, null);
 });
 
+test("buildStaleReviewBotRemediation accepts repair-proof fingerprints after trusted supervisor stale reply", () => {
+  const issueNumber = 2413;
+  const prNumber = 2418;
+  const headSha = "1c8ff7429f8c2e2787d15fa4b9d3718a70e30c1a";
+  const scenario = createCodexConnectorTrackedReviewResidueScenario({
+    issueNumber,
+    prNumber,
+    headSha,
+    threadId: "PRRT_processed_codex_then_supervisor",
+    commentId: "comment-codex-before-supervisor",
+    path: "src/supervisor/stale-review-bot-remediation.ts",
+    line: 1096,
+    severity: "P2",
+    commentBody: "P2: Use repair-proof fingerprints for processed must-fix checks.",
+    discussionUrl: "https://example.test/pr/2418#discussion_processed_codex_then_supervisor",
+    verifiedRepair: {
+      summary: "Current-head stale-review repair proof covered the processed P2 residue.",
+      ranAt: "2026-07-07T00:20:00Z",
+      command: "npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts",
+      evidenceSource: "codex_turn_timeline_artifact",
+    },
+    currentHeadNoMajorReview: {
+      requestedAt: "2026-07-07T00:12:00Z",
+      observedAt: "2026-07-07T00:19:00Z",
+    },
+  });
+  scenario.reviewThread.comments.nodes.push({
+    id: "comment-supervisor-stale-reply-latest",
+    body: [
+      `The supervisor reprocessed this configured-bot finding on the current head \`${headSha}\` and classified it as stale.`,
+      `Audit: issue=#${issueNumber} pr=#${prNumber} head=${headSha} thread=${scenario.reviewThread.id} reason=stale_review_bot.`,
+      "Evidence: location=src/supervisor/stale-review-bot-remediation.ts:1096 processed_on_current_head=yes.",
+    ].join("\n\n"),
+    createdAt: "2026-07-07T00:21:00Z",
+    url: "https://example.test/pr/2418#discussion_processed_codex_then_supervisor_followup",
+    author: {
+      login: "TommyKammy",
+      typeName: "User",
+    },
+  });
+  const config = createConfig({
+    repoSlug: "TommyKammy/codex-supervisor",
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+  });
+  const record = createRecord(scenario.recordPatch);
+  const pr = createPullRequest({
+    ...scenario.pullRequestPatch,
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: headSha,
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-07T00:19:00Z",
+  });
+
+  const remediation = buildStaleReviewBotRemediation({
+    config,
+    record,
+    pr,
+    checks: scenario.passingChecks,
+    reviewThreads: [scenario.reviewThread],
+  });
+
+  assert.equal(remediation?.classification, "verified_current_head_repair_pending_thread_resolution");
+  assert.match(
+    remediation?.verificationEvidenceSummary ?? "",
+    /Current-head stale-review repair proof covered the processed P2 residue/u,
+  );
+});
+
 test("buildStaleReviewBotRemediation ignores unprocessed outdated Codex threads when probing missing verification", () => {
   const issueNumber = 1701;
   const prNumber = 1801;

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -1,14 +1,11 @@
 import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "../core/types";
 import {
   hasProcessedReviewThread,
-  latestReviewThreadCommentFingerprint,
   localReviewBlocksMerge,
   localReviewDegradedNeedsBlock,
   localReviewHighSeverityNeedsBlock,
   localReviewHighSeverityNeedsRetry,
   localReviewRequiresManualReview,
-  processedReviewThreadFingerprintKey,
-  processedReviewThreadKey,
   reviewLoopRetryBudgetExhaustedForThread,
 } from "../review-handling";
 import { reviewDecisionBlocksCurrentHeadRepairProjection } from "../review-decision-blocking-policy";
@@ -22,7 +19,6 @@ import {
   hasCodexConnectorFindingReviewComment,
   latestCodexConnectorReviewCommentNode,
   latestCodexConnectorReviewCommentFingerprint,
-  latestCodexConnectorPSeverity,
   latestCodexConnectorReviewComment,
 } from "../codex-connector-review-policy";
 import {
@@ -47,6 +43,10 @@ import {
   buildCodexConnectorStillValidReviewRepairTargets,
   type CodexConnectorValidReviewRepairTarget,
 } from "../codex-connector-valid-review-repair";
+import {
+  allCodexConnectorRepairResidueThreadsAreP2,
+  timelineArtifactCoversReviewThreads,
+} from "../codex-connector-review-repair-coverage";
 import {
   STALE_REVIEW_BOT_MANUAL_NEXT_STEP,
   VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
@@ -389,7 +389,11 @@ function hasCurrentHeadNoSourceChangeCodexTurnVerification(
       artifact.outcome === "passed" &&
       artifact.head_sha === pr.headRefOid &&
       artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") === true &&
-      noSourceChangeArtifactCoversReviewThreads(artifact, pr, reviewThreads),
+      timelineArtifactCoversReviewThreads({
+        artifact,
+        pr,
+        reviewThreads,
+      }),
   );
 }
 
@@ -405,34 +409,6 @@ function hasCurrentHeadMarkedNoSourceChangeCodexTurnVerification(
       artifact.head_sha === pr.headRefOid &&
       artifact.repair_targets?.includes("verified_no_source_change_review_thread_residue") === true,
   );
-}
-
-function allCodexConnectorRepairResidueThreadsAreP2(reviewThreads: ReviewThread[]): boolean {
-  return reviewThreads.length > 0 && reviewThreads.every((thread) => latestCodexConnectorPSeverity(thread) === "P2");
-}
-
-function noSourceChangeArtifactCoversReviewThreads(
-  artifact: NonNullable<IssueRunRecord["timeline_artifacts"]>[number],
-  pr: Pick<GitHubPullRequest, "headRefOid">,
-  reviewThreads: ReviewThread[],
-): boolean {
-  if (reviewThreads.length === 0) {
-    return false;
-  }
-  const processedThreadIds = artifact.processed_review_thread_ids ?? [];
-  const processedThreadFingerprints = artifact.processed_review_thread_fingerprints ?? [];
-  if (processedThreadIds.length === 0 && processedThreadFingerprints.length === 0) {
-    return false;
-  }
-  return reviewThreads.every((thread) => {
-    const latestFingerprint = latestReviewThreadCommentFingerprint(thread);
-    if (latestFingerprint) {
-      return processedThreadFingerprints.includes(
-        processedReviewThreadFingerprintKey(thread.id, pr.headRefOid, latestFingerprint),
-      );
-    }
-    return processedThreadIds.includes(processedReviewThreadKey(thread.id, pr.headRefOid));
-  });
 }
 
 function normalizeRepositoryPath(value: string): string {
@@ -1115,7 +1091,16 @@ function classifyCodexMetadataOnly(args: {
   );
   const verifiedRepairArtifactEvidenceSummary =
     currentHeadVerifiedRepairResidueArtifactEvidenceSummary(args);
-  if (verifiedRepairArtifactEvidenceSummary) {
+  const hasUnprocessedMustFix = mustFixReviewThreads.some((thread) =>
+    !hasProcessedReviewThread(args.record, args.pr, thread)
+  );
+  const unprocessedMustFixCanUseRepairProof =
+    allCodexConnectorRepairResidueThreadsAreP2(mustFixReviewThreads) &&
+    projectCurrentHeadCodexRepairProof(args)?.source === "finding_set_verification_artifact";
+  if (
+    verifiedRepairArtifactEvidenceSummary &&
+    (!hasUnprocessedMustFix || unprocessedMustFixCanUseRepairProof)
+  ) {
     return {
       classification: "verified_current_head_repair_pending_thread_resolution",
       summary: VERIFIED_CURRENT_HEAD_REPAIR_SUMMARY,
@@ -1138,7 +1123,7 @@ function classifyCodexMetadataOnly(args: {
       hasProcessedReviewThread(args.record, args.pr, thread),
     ),
     convergenceOutcome: policy?.outcome ?? null,
-    hasUnprocessedMustFix: mustFixReviewThreads.some((thread) => !hasProcessedReviewThread(args.record, args.pr, thread)),
+    hasUnprocessedMustFix,
     verificationEvidenceSummary,
     noMajorSignalEvidence: currentHeadCodexNoMajorSignalEvidence({
       record: args.record,

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -34,6 +34,7 @@ import { isRecoverableVerifiedCodexStaleResidueThread } from "./verified-stale-r
 import { configuredReviewProviderKinds } from "../core/review-providers";
 import {
   currentHeadCodexRepairProofRejectionReasons,
+  currentHeadRepairProofThreadFingerprint,
   hasFreshCurrentHeadCodexSuccessReviewedCommit,
   projectCurrentHeadCodexRepairProof,
 } from "../current-head-codex-repair-proof";
@@ -395,6 +396,25 @@ function hasCurrentHeadNoSourceChangeCodexTurnVerification(
         reviewThreads,
       }),
   );
+}
+
+function hasProcessedCurrentHeadRepairProofReviewThread(
+  config: SupervisorConfig,
+  record: Pick<
+    IssueRunRecord,
+    "processed_review_thread_ids" | "processed_review_thread_fingerprints" | "last_head_sha"
+  >,
+  pr: Pick<GitHubPullRequest, "headRefOid">,
+  thread: ReviewThread,
+): boolean {
+  if (hasProcessedReviewThread(record, pr, thread)) {
+    return true;
+  }
+
+  const repairProofFingerprint = currentHeadRepairProofThreadFingerprint(config, pr, thread);
+  return repairProofFingerprint
+    ? hasProcessedReviewThread(record, pr, thread, repairProofFingerprint)
+    : false;
 }
 
 function hasCurrentHeadMarkedNoSourceChangeCodexTurnVerification(
@@ -1092,7 +1112,7 @@ function classifyCodexMetadataOnly(args: {
   const verifiedRepairArtifactEvidenceSummary =
     currentHeadVerifiedRepairResidueArtifactEvidenceSummary(args);
   const hasUnprocessedMustFix = mustFixReviewThreads.some((thread) =>
-    !hasProcessedReviewThread(args.record, args.pr, thread)
+    !hasProcessedCurrentHeadRepairProofReviewThread(args.config, args.record, args.pr, thread)
   );
   const unprocessedMustFixCanUseRepairProof =
     allCodexConnectorRepairResidueThreadsAreP2(mustFixReviewThreads) &&
@@ -1120,7 +1140,7 @@ function classifyCodexMetadataOnly(args: {
     pendingBotThreadCount: pendingBotReviewThreads(args.config, args.record, args.pr, currentConfiguredThreads).length,
     followUpState: configuredBotReviewFollowUpState(args.config, args.record, args.pr, currentConfiguredThreads),
     allCurrentConfiguredThreadsProcessed: currentConfiguredThreads.every((thread) =>
-      hasProcessedReviewThread(args.record, args.pr, thread),
+      hasProcessedCurrentHeadRepairProofReviewThread(args.config, args.record, args.pr, thread),
     ),
     convergenceOutcome: policy?.outcome ?? null,
     hasUnprocessedMustFix,


### PR DESCRIPTION
## Summary
- Add shared Codex Connector repair coverage helpers for head-scoped processed evidence, exact thread coverage, and P2 repair residue checks.
- Reuse the shared helpers in current-head proof, stale-review remediation, and still-valid repair target detection while preserving policy-specific timestamp and exact-coverage rules.
- Keep stale-review fail-closed behavior for unprocessed higher-severity must-fix threads while preserving P2 finding-set proof behavior.

## Verification
- npx tsx --test src/current-head-codex-repair-proof.test.ts
- npx tsx --test src/pull-request-state-policy.test.ts
- npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts
- npm run build

Fixes #2413