### PR TITLE
Extract dashboard panel order helpers

### DIFF
--- a/src/backend/webui-dashboard-browser-logic.test.ts
+++ b/src/backend/webui-dashboard-browser-logic.test.ts
@@ -18,6 +18,10 @@ import {
   formatRecoveryLoopSummary,
   formatRetryContextSummary,
   formatTrackedIssues,
+  normalizeDashboardPanelOrder,
+  restoreDashboardPanelOrder,
+  serializeDashboardPanelOrder,
+  applyDashboardPanelDrop,
   parseRenderedOperatorAction,
   parseSelectedIssueNumber,
   type DashboardStatusLike,
@@ -27,6 +31,60 @@ import {
   DEFAULT_DASHBOARD_PANEL_LAYOUT,
   resolveDashboardPanelLayout,
 } from "./webui-dashboard-panel-layout";
+
+test("dashboard panel order helpers normalize stored layouts before rendering", () => {
+  const defaultOrder = ["status", "doctor", "issue-details", "tracked-history"] as const;
+
+  assert.deepEqual(
+    normalizeDashboardPanelOrder(["tracked-history", "unknown", "doctor", "doctor"], defaultOrder),
+    ["tracked-history", "doctor", "status", "issue-details"],
+  );
+  assert.deepEqual(restoreDashboardPanelOrder(JSON.stringify({ order: ["issue-details", "status"] }), defaultOrder), [
+    "issue-details",
+    "status",
+    "doctor",
+    "tracked-history",
+  ]);
+  assert.deepEqual(restoreDashboardPanelOrder(JSON.stringify(["doctor", "status"]), defaultOrder), [
+    "doctor",
+    "status",
+    "issue-details",
+    "tracked-history",
+  ]);
+  assert.deepEqual(restoreDashboardPanelOrder("{not-json", defaultOrder), [
+    "status",
+    "doctor",
+    "issue-details",
+    "tracked-history",
+  ]);
+  assert.equal(
+    serializeDashboardPanelOrder(["tracked-history", "unknown", "status"], defaultOrder),
+    JSON.stringify({ order: ["tracked-history", "status", "doctor", "issue-details"] }),
+  );
+});
+
+test("dashboard panel order helpers apply safe drag and drop reordering", () => {
+  const defaultOrder = ["status", "doctor", "issue-details", "tracked-history"] as const;
+
+  assert.deepEqual(applyDashboardPanelDrop(["status", "doctor", "issue-details"], "issue-details", "status", defaultOrder), [
+    "issue-details",
+    "status",
+    "doctor",
+    "tracked-history",
+  ]);
+  assert.deepEqual(applyDashboardPanelDrop(["status", "doctor"], "missing", "status", defaultOrder), [
+    "status",
+    "doctor",
+    "issue-details",
+    "tracked-history",
+  ]);
+  assert.deepEqual(applyDashboardPanelDrop(["status", "doctor"], "doctor", "doctor", defaultOrder), [
+    "status",
+    "doctor",
+    "issue-details",
+    "tracked-history",
+  ]);
+});
 
 test("buildStatusLines summarizes tracked history as a count instead of dumping each tracked issue", () => {
   const lines = buildStatusLines({

--- a/src/backend/webui-dashboard-browser-logic.ts
+++ b/src/backend/webui-dashboard-browser-logic.ts
@@ -4,6 +4,12 @@ import {
   validOperatorActions,
   type OperatorActionToken,
 } from "../operator-actions";
+export {
+  applyDashboardPanelDrop,
+  normalizeDashboardPanelOrder,
+  restoreDashboardPanelOrder,
+  serializeDashboardPanelOrder,
+} from "./webui-dashboard-panel-order";
 
 type DashboardOperatorActionToken = OperatorActionToken;
 
@@ -235,82 +241,6 @@ export interface DashboardIssueShortcut {
   issueNumber: number;
   label: string;
   detail: string;
-}
-
-export function normalizeDashboardPanelOrder<TPanelId extends string>(
-  requestedOrder: readonly string[] | null | undefined,
-  defaultOrder: readonly TPanelId[],
-): TPanelId[] {
-  const knownPanelIds = new Set(defaultOrder);
-  const normalizedOrder: TPanelId[] = [];
-
-  for (const candidate of Array.isArray(requestedOrder) ? requestedOrder : []) {
-    if (!knownPanelIds.has(candidate as TPanelId) || normalizedOrder.includes(candidate as TPanelId)) {
-      continue;
-    }
-    normalizedOrder.push(candidate as TPanelId);
-  }
-
-  for (const panelId of defaultOrder) {
-    if (!normalizedOrder.includes(panelId)) {
-      normalizedOrder.push(panelId);
-    }
-  }
-
-  return normalizedOrder;
-}
-
-export function restoreDashboardPanelOrder<TPanelId extends string>(
-  serializedLayout: string | null | undefined,
-  defaultOrder: readonly TPanelId[],
-): TPanelId[] {
-  if (typeof serializedLayout !== "string" || serializedLayout.trim() === "") {
-    return normalizeDashboardPanelOrder(null, defaultOrder);
-  }
-
-  try {
-    const parsed = JSON.parse(serializedLayout) as { order?: readonly string[] | null } | readonly string[] | null;
-    if (Array.isArray(parsed)) {
-      return normalizeDashboardPanelOrder(parsed, defaultOrder);
-    }
-    if (parsed && typeof parsed === "object" && "order" in parsed) {
-      return normalizeDashboardPanelOrder(parsed.order, defaultOrder);
-    }
-  } catch {}
-
-  return normalizeDashboardPanelOrder(null, defaultOrder);
-}
-
-export function serializeDashboardPanelOrder<TPanelId extends string>(
-  currentOrder: readonly string[] | null | undefined,
-  defaultOrder: readonly TPanelId[],
-): string {
-  return JSON.stringify({
-    order: normalizeDashboardPanelOrder(currentOrder, defaultOrder),
-  });
-}
-
-export function applyDashboardPanelDrop<TPanelId extends string>(
-  currentOrder: readonly string[] | null | undefined,
-  draggedPanelId: TPanelId | null | undefined,
-  targetPanelId: TPanelId | null | undefined,
-  defaultOrder: readonly TPanelId[],
-): TPanelId[] {
-  const normalizedOrder = normalizeDashboardPanelOrder(currentOrder, defaultOrder);
-  if (!draggedPanelId || !targetPanelId || draggedPanelId === targetPanelId) {
-    return normalizedOrder;
-  }
-  if (!normalizedOrder.includes(draggedPanelId) || !normalizedOrder.includes(targetPanelId)) {
-    return normalizedOrder;
-  }
-
-  const nextOrder = normalizedOrder.filter((panelId) => panelId !== draggedPanelId);
-  const targetIndex = nextOrder.indexOf(targetPanelId);
-  if (targetIndex < 0) {
-    return normalizedOrder;
-  }
-  nextOrder.splice(targetIndex, 0, draggedPanelId);
-  return nextOrder;
 }
 
 export interface DashboardTrackedIssueFormatOptions {

--- a/src/backend/webui-dashboard-panel-order.ts
+++ b/src/backend/webui-dashboard-panel-order.ts
@@ -1,0 +1,75 @@
+export function normalizeDashboardPanelOrder<TPanelId extends string>(
+  requestedOrder: readonly string[] | null | undefined,
+  defaultOrder: readonly TPanelId[],
+): TPanelId[] {
+  const knownPanelIds = new Set(defaultOrder);
+  const normalizedOrder: TPanelId[] = [];
+
+  for (const candidate of Array.isArray(requestedOrder) ? requestedOrder : []) {
+    if (!knownPanelIds.has(candidate as TPanelId) || normalizedOrder.includes(candidate as TPanelId)) {
+      continue;
+    }
+    normalizedOrder.push(candidate as TPanelId);
+  }
+
+  for (const panelId of defaultOrder) {
+    if (!normalizedOrder.includes(panelId)) {
+      normalizedOrder.push(panelId);
+    }
+  }
+
+  return normalizedOrder;
+}
+
+export function restoreDashboardPanelOrder<TPanelId extends string>(
+  serializedLayout: string | null | undefined,
+  defaultOrder: readonly TPanelId[],
+): TPanelId[] {
+  if (typeof serializedLayout !== "string" || serializedLayout.trim() === "") {
+    return normalizeDashboardPanelOrder(null, defaultOrder);
+  }
+
+  try {
+    const parsed = JSON.parse(serializedLayout) as { order?: readonly string[] | null } | readonly string[] | null;
+    if (Array.isArray(parsed)) {
+      return normalizeDashboardPanelOrder(parsed, defaultOrder);
+    }
+    if (parsed && typeof parsed === "object" && "order" in parsed) {
+      return normalizeDashboardPanelOrder(parsed.order, defaultOrder);
+    }
+  } catch {}
+
+  return normalizeDashboardPanelOrder(null, defaultOrder);
+}
+
+export function serializeDashboardPanelOrder<TPanelId extends string>(
+  currentOrder: readonly string[] | null | undefined,
+  defaultOrder: readonly TPanelId[],
+): string {
+  return JSON.stringify({
+    order: normalizeDashboardPanelOrder(currentOrder, defaultOrder),
+  });
+}
+
+export function applyDashboardPanelDrop<TPanelId extends string>(
+  currentOrder: readonly string[] | null | undefined,
+  draggedPanelId: TPanelId | null | undefined,
+  targetPanelId: TPanelId | null | undefined,
+  defaultOrder: readonly TPanelId[],
+): TPanelId[] {
+  const normalizedOrder = normalizeDashboardPanelOrder(currentOrder, defaultOrder);
+  if (!draggedPanelId || !targetPanelId || draggedPanelId === targetPanelId) {
+    return normalizedOrder;
+  }
+  if (!normalizedOrder.includes(draggedPanelId) || !normalizedOrder.includes(targetPanelId)) {
+    return normalizedOrder;
+  }
+
+  const nextOrder = normalizedOrder.filter((panelId) => panelId !== draggedPanelId);
+  const targetIndex = nextOrder.indexOf(targetPanelId);
+  if (targetIndex < 0) {
+    return normalizedOrder;
+  }
+  nextOrder.splice(targetIndex, 0, draggedPanelId);
+  return nextOrder;
+}


### PR DESCRIPTION
## Summary
- Extract dashboard panel-order normalization, restore, serialization, and drag/drop helpers into `src/backend/webui-dashboard-panel-order.ts`
- Re-export the helpers from `webui-dashboard-browser-logic.ts` to keep the existing public import surface stable
- Add focused regression coverage for stored layout normalization and safe drag/drop handling

Closes #2414

## Verification
- `npx tsx --test src/backend/webui-dashboard-browser-logic.test.ts`
- `npm run build`
- `git diff --check`