### PR TITLE
Allow anchored Codex success to clear unresolved findings

### DIFF
--- a/src/codex-connector-valid-review-repair-selection.ts
+++ b/src/codex-connector-valid-review-repair-selection.ts
@@ -2,6 +2,7 @@ import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread,
 import { configuredReviewProviderKinds } from "./core/review-providers";
 import { manualReviewThreads } from "./review-thread-reporting";
 import { buildCodexConnectorStillValidReviewRepairTargets } from "./codex-connector-valid-review-repair";
+import { effectiveConfiguredBotReviewThreadsForState } from "./pull-request-state-codex-residue-policy";
 
 function allChecksGreen(checks: Pick<PullRequestCheck, "bucket">[]): boolean {
   return checks.every((check) => check.bucket === "pass" || check.bucket === "skipping");
@@ -17,7 +18,10 @@ export function shouldReenterCodexConnectorValidReviewRepair(args: {
   pr: GitHubPullRequest;
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
+  repairReviewThreads?: ReviewThread[];
 }): boolean {
+  const repairReviewThreads = args.repairReviewThreads ??
+    effectiveConfiguredBotReviewThreadsForState(args.config, args.record, args.pr, args.checks, args.reviewThreads);
   return (
     args.record.pr_number === args.pr.number &&
     configuredReviewProviderKinds(args.config).includes("codex") &&
@@ -27,7 +31,7 @@ export function shouldReenterCodexConnectorValidReviewRepair(args: {
     buildCodexConnectorStillValidReviewRepairTargets({
       record: args.record,
       pr: args.pr,
-      reviewThreads: args.reviewThreads,
+      reviewThreads: repairReviewThreads,
     }).length > 0
   );
 }

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -13,6 +13,7 @@ import {
   hasCodexConnectorPrSuccessCurrentHeadObservation,
   latestCodexConnectorReviewCommentFingerprint,
 } from "./codex-connector-review-policy";
+import { codexConnectorMustFixTopLevelReviewFindings } from "./codex-connector-top-level-review";
 import {
   IssueRunRecord,
   GitHubPullRequest,
@@ -114,6 +115,18 @@ function effectiveConfiguredBotReviewThreads(
   const threadsAfterOutdatedClearance = clearOutdatedCodexConnectorThreads
     ? effectiveThreads.filter((thread) => !isClearableOutdatedCodexConnectorResidueThread(config, thread))
     : effectiveThreads;
+  if (
+    anchoredCurrentHeadCodexSuccessSupersedesUnresolvedFindings({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+      configuredThreads: threadsAfterOutdatedClearance,
+    })
+  ) {
+    return [];
+  }
   return allowJournalOnlyConfiguredBotThreadException(config, pr, checks, threadsAfterOutdatedClearance)
     ? threadsAfterOutdatedClearance.filter((thread) => !isIssueJournalThreadPath(thread))
     : threadsAfterOutdatedClearance;
@@ -252,6 +265,42 @@ export function staleSameHeadCodexWaitHasOnlyOutdatedResidue(
   return (
     threadsAfterConvergencePolicy.length > 0 &&
     threadsAfterConvergencePolicy.every((thread) => isClearableOutdatedCodexConnectorResidueThread(config, thread))
+  );
+}
+
+export function anchoredCurrentHeadCodexSuccessSupersedesUnresolvedFindings(args: {
+  config: SupervisorConfig;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest;
+  checks: PullRequestCheck[];
+  reviewThreads: ReviewThread[];
+  configuredThreads?: ReviewThread[];
+}): boolean {
+  if (
+    !configuredReviewProvidersAreCodexOnly(args.config) ||
+    !pullRequestHeadMatchesRecord(args.record, args.pr) ||
+    mergeConflictDetected(args.pr) ||
+    !summarizeChecks(args.checks).allPassing ||
+    manualReviewThreads(args.config, args.reviewThreads).length > 0 ||
+    !hasCodexConnectorPrSuccessCurrentHeadObservation(args.pr) ||
+    !hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads)
+  ) {
+    return false;
+  }
+
+  if (codexConnectorMustFixTopLevelReviewFindings(args.pr.configuredBotTopLevelReviewFindings ?? []).length > 0) {
+    return false;
+  }
+
+  const configuredThreads = args.configuredThreads ?? configuredBotReviewThreads(args.config, args.reviewThreads);
+  if (configuredThreads.length === 0) {
+    return false;
+  }
+
+  const mustFixThreads = codexConnectorMustFixReviewThreads(configuredThreads);
+  return (
+    mustFixThreads.length === configuredThreads.length &&
+    configuredThreads.every((thread) => hasCodexConnectorFindingReviewComment(thread))
   );
 }
 
@@ -576,6 +625,18 @@ export function hasConfiguredProviderSuccess(
   if (
     configuredReviewProvidersAreCodexOnly(config) &&
     hasProvenCodexConnectorStaleReviewMetadata({ config, record, pr, checks, reviewThreads })
+  ) {
+    return true;
+  }
+
+  if (
+    anchoredCurrentHeadCodexSuccessSupersedesUnresolvedFindings({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+    })
   ) {
     return true;
   }

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -282,7 +282,6 @@ export function anchoredCurrentHeadCodexSuccessSupersedesUnresolvedFindings(args
     mergeConflictDetected(args.pr) ||
     !summarizeChecks(args.checks).allPassing ||
     manualReviewThreads(args.config, args.reviewThreads).length > 0 ||
-    args.pr.configuredBotTopLevelReviewStrength === "blocking" ||
     !hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads)
   ) {
     return false;

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -282,7 +282,7 @@ export function anchoredCurrentHeadCodexSuccessSupersedesUnresolvedFindings(args
     mergeConflictDetected(args.pr) ||
     !summarizeChecks(args.checks).allPassing ||
     manualReviewThreads(args.config, args.reviewThreads).length > 0 ||
-    !hasCodexConnectorPrSuccessCurrentHeadObservation(args.pr) ||
+    args.pr.configuredBotTopLevelReviewStrength === "blocking" ||
     !hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads)
   ) {
     return false;
@@ -297,10 +297,20 @@ export function anchoredCurrentHeadCodexSuccessSupersedesUnresolvedFindings(args
     return false;
   }
 
+  if (!configuredThreads.every((thread) => latestReviewCommentAuthorIsAllowedBot(args.config, thread))) {
+    return false;
+  }
+
   const mustFixThreads = codexConnectorMustFixReviewThreads(configuredThreads);
+  const nitpickOnlyThreadIds = new Set(
+    codexConnectorNitpickOnlyReviewThreads(configuredThreads).map((thread) => thread.id),
+  );
   return (
-    mustFixThreads.length === configuredThreads.length &&
-    configuredThreads.every((thread) => hasCodexConnectorFindingReviewComment(thread))
+    mustFixThreads.length > 0 &&
+    mustFixThreads.every((thread) => hasCodexConnectorFindingReviewComment(thread)) &&
+    configuredThreads.every((thread) =>
+      mustFixThreads.includes(thread) || nitpickOnlyThreadIds.has(thread.id)
+    )
   );
 }
 

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -4038,6 +4038,187 @@ test("inferStateFromPullRequest clears outdated Codex Connector blockers after c
   assert.equal(blockedReasonFromReviewState(config, record, pr, passingChecks(), reviewThreads), null);
 });
 
+test("inferStateFromPullRequest clears unresolved same-provider Codex finding after anchored current-head no-major success", () => {
+  const currentHeadSha = "ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6";
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+  });
+  const record = createRecord({
+    state: "addressing_review",
+    blocked_reason: "manual_review",
+    last_head_sha: currentHeadSha,
+    review_wait_started_at: "2026-07-07T01:05:00Z",
+    review_wait_head_sha: currentHeadSha,
+  });
+  const pr = createPullRequest({
+    headRefOid: currentHeadSha,
+    configuredBotCurrentHeadObservedAt: "2026-07-07T01:10:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: currentHeadSha,
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-07T01:10:00Z",
+    configuredBotTopLevelReviewStrength: null,
+    currentHeadCiGreenAt: "2026-07-07T01:08:00Z",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-unresolved-codex-p1",
+      isOutdated: false,
+      comments: {
+        nodes: [
+          {
+            id: "comment-unresolved-codex-p1",
+            body: "P1: Earlier Codex Connector finding that should be superseded by the anchored no-major current-head signal.",
+            createdAt: "2026-07-07T01:00:00Z",
+            url: "https://example.test/pr/2426#discussion_r2426",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const checks = passingChecks();
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, checks, reviewThreads), "ready_to_merge");
+  assert.equal(blockedReasonFromReviewState(config, record, pr, checks, reviewThreads), null);
+  assert.equal(effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads).length, 0);
+  assert.equal(syncMergeLatencyVisibility(config, record, pr, checks, reviewThreads).provider_success_head_sha, currentHeadSha);
+});
+
+test("inferStateFromPullRequest keeps unresolved Codex findings guarded without valid anchored current-head no-major success", () => {
+  const currentHeadSha = "ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6";
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+  });
+  const record = createRecord({
+    state: "addressing_review",
+    blocked_reason: "manual_review",
+    last_head_sha: currentHeadSha,
+    review_wait_started_at: "2026-07-07T01:05:00Z",
+    review_wait_head_sha: currentHeadSha,
+  });
+  const basePr = createPullRequest({
+    headRefOid: currentHeadSha,
+    configuredBotCurrentHeadObservedAt: "2026-07-07T01:10:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: currentHeadSha,
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-07T01:10:00Z",
+    configuredBotTopLevelReviewStrength: null,
+    currentHeadCiGreenAt: "2026-07-07T01:08:00Z",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const codexThread = createReviewThread({
+    id: "thread-unresolved-codex-p1",
+    isOutdated: false,
+    comments: {
+      nodes: [
+        {
+          id: "comment-unresolved-codex-p1",
+          body: "P1: Earlier Codex Connector finding that stays guarded without a valid anchored success signal.",
+          createdAt: "2026-07-07T01:00:00Z",
+          url: "https://example.test/pr/2426#discussion_r2426",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const laterCodexThread = createReviewThread({
+    ...codexThread,
+    id: "thread-later-codex-p1",
+    comments: {
+      nodes: [
+        {
+          id: "comment-later-codex-p1",
+          body: "P1: Later Codex Connector finding after the no-major signal.",
+          createdAt: "2026-07-07T01:11:00Z",
+          url: "https://example.test/pr/2426#discussion_r2427",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const cases = [
+    {
+      name: "missing reviewed commit",
+      pr: createPullRequest({ ...basePr, configuredBotCurrentHeadCodexSuccessReviewedCommitSha: null }),
+      checks: passingChecks(),
+      reviewThreads: [codexThread],
+    },
+    {
+      name: "reviewed commit is stale",
+      pr: createPullRequest({ ...basePr, configuredBotCurrentHeadCodexSuccessReviewedCommitSha: "old-head" }),
+      checks: passingChecks(),
+      reviewThreads: [codexThread],
+    },
+    {
+      name: "success predates latest finding",
+      pr: basePr,
+      checks: passingChecks(),
+      reviewThreads: [laterCodexThread],
+    },
+    {
+      name: "checks are pending",
+      pr: basePr,
+      checks: [{ name: "build", state: "IN_PROGRESS", bucket: "pending", workflow: "CI" }] as PullRequestCheck[],
+      reviewThreads: [codexThread],
+    },
+    {
+      name: "mixed provider config",
+      config: createConfig({
+        reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN, "coderabbitai[bot]"],
+        humanReviewBlocksMerge: true,
+        configuredBotInitialGraceWaitSeconds: 0,
+      }),
+      pr: basePr,
+      checks: passingChecks(),
+      reviewThreads: [codexThread],
+    },
+  ];
+
+  for (const scenario of cases) {
+    const scenarioConfig = scenario.config ?? config;
+    assert.notEqual(
+      inferStateFromPullRequest(scenarioConfig, record, scenario.pr, scenario.checks, scenario.reviewThreads),
+      "ready_to_merge",
+      scenario.name,
+    );
+    assert.equal(
+      effectiveConfiguredBotReviewThreadsForState(
+        scenarioConfig,
+        record,
+        scenario.pr,
+        scenario.checks,
+        scenario.reviewThreads,
+      ).length,
+      1,
+      scenario.name,
+    );
+    assert.equal(
+      syncMergeLatencyVisibility(scenarioConfig, record, scenario.pr, scenario.checks, scenario.reviewThreads)
+        .provider_success_head_sha,
+      null,
+      scenario.name,
+    );
+  }
+});
+
 test("inferStateFromPullRequest ignores stale same-head Codex review wait when only outdated connector residue remains", () => {
   const config = createConfig({
     reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -4092,6 +4092,78 @@ test("inferStateFromPullRequest clears unresolved same-provider Codex finding af
   assert.equal(syncMergeLatencyVisibility(config, record, pr, checks, reviewThreads).provider_success_head_sha, currentHeadSha);
 });
 
+test("inferStateFromPullRequest accepts preserved anchored Codex success with later status context and nitpicks", () => {
+  const currentHeadSha = "ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6";
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+  });
+  const record = createRecord({
+    state: "addressing_review",
+    blocked_reason: "manual_review",
+    last_head_sha: currentHeadSha,
+    review_wait_started_at: "2026-07-07T01:05:00Z",
+    review_wait_head_sha: currentHeadSha,
+  });
+  const pr = createPullRequest({
+    headRefOid: currentHeadSha,
+    configuredBotCurrentHeadObservedAt: "2026-07-07T01:12:00Z",
+    configuredBotCurrentHeadObservationSource: "status_context",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: currentHeadSha,
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-07T01:10:00Z",
+    configuredBotTopLevelReviewStrength: null,
+    currentHeadCiGreenAt: "2026-07-07T01:08:00Z",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-unresolved-codex-p1",
+      isOutdated: false,
+      comments: {
+        nodes: [
+          {
+            id: "comment-unresolved-codex-p1",
+            body: "P1: Earlier Codex Connector finding that should be superseded by the anchored no-major current-head signal.",
+            createdAt: "2026-07-07T01:00:00Z",
+            url: "https://example.test/pr/2426#discussion_r2426",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+    createReviewThread({
+      id: "thread-current-codex-nitpick",
+      isOutdated: false,
+      comments: {
+        nodes: [
+          {
+            id: "comment-current-codex-nitpick",
+            body: "P3: Consider a shorter helper name.",
+            createdAt: "2026-07-07T01:11:00Z",
+            url: "https://example.test/pr/2426#discussion_r2428",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const checks = passingChecks();
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, checks, reviewThreads), "ready_to_merge");
+  assert.equal(blockedReasonFromReviewState(config, record, pr, checks, reviewThreads), null);
+  assert.equal(effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads).length, 0);
+  assert.equal(syncMergeLatencyVisibility(config, record, pr, checks, reviewThreads).provider_success_head_sha, currentHeadSha);
+});
+
 test("inferStateFromPullRequest keeps unresolved Codex findings guarded without valid anchored current-head no-major success", () => {
   const currentHeadSha = "ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6";
   const config = createConfig({
@@ -4154,6 +4226,25 @@ test("inferStateFromPullRequest keeps unresolved Codex findings guarded without 
       ],
     },
   });
+  const humanReplyThread = createReviewThread({
+    ...codexThread,
+    id: "thread-human-replied-codex-p1",
+    comments: {
+      nodes: [
+        ...codexThread.comments.nodes,
+        {
+          id: "comment-human-replied-codex-p1",
+          body: "Leaving this unresolved until a maintainer confirms the Codex finding is no longer actionable.",
+          createdAt: "2026-07-07T01:11:00Z",
+          url: "https://example.test/pr/2426#discussion_r2428",
+          author: {
+            login: "maintainer",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
   const cases = [
     {
       name: "missing reviewed commit",
@@ -4172,6 +4263,12 @@ test("inferStateFromPullRequest keeps unresolved Codex findings guarded without 
       pr: basePr,
       checks: passingChecks(),
       reviewThreads: [laterCodexThread],
+    },
+    {
+      name: "human reply after success",
+      pr: basePr,
+      checks: passingChecks(),
+      reviewThreads: [humanReplyThread],
     },
     {
       name: "checks are pending",

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -4164,6 +4164,131 @@ test("inferStateFromPullRequest accepts preserved anchored Codex success with la
   assert.equal(syncMergeLatencyVisibility(config, record, pr, checks, reviewThreads).provider_success_head_sha, currentHeadSha);
 });
 
+test("inferStateFromPullRequest treats bot-only changes-requested residue as superseded by anchored Codex success", () => {
+  const currentHeadSha = "ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6";
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+  });
+  const record = createRecord({
+    state: "addressing_review",
+    blocked_reason: "manual_review",
+    last_head_sha: currentHeadSha,
+    review_wait_started_at: "2026-07-07T01:05:00Z",
+    review_wait_head_sha: currentHeadSha,
+  });
+  const pr = createPullRequest({
+    headRefOid: currentHeadSha,
+    reviewDecision: "CHANGES_REQUESTED",
+    configuredBotOnlyChangesRequestedReview: true,
+    configuredBotCurrentHeadObservedAt: "2026-07-07T01:12:00Z",
+    configuredBotCurrentHeadObservationSource: "status_context",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: currentHeadSha,
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-07T01:10:00Z",
+    configuredBotTopLevelReviewStrength: "blocking",
+    configuredBotTopLevelReviewFindings: [],
+    currentHeadCiGreenAt: "2026-07-07T01:08:00Z",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const reviewThreads = [
+    createReviewThread({
+      id: "thread-unresolved-codex-p1",
+      isOutdated: false,
+      comments: {
+        nodes: [
+          {
+            id: "comment-unresolved-codex-p1",
+            body: "P1: Earlier Codex Connector finding superseded by the anchored no-major current-head signal.",
+            createdAt: "2026-07-07T01:00:00Z",
+            url: "https://example.test/pr/2426#discussion_r2426",
+            author: {
+              login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+  const checks = passingChecks();
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, checks, reviewThreads), "ready_to_merge");
+  assert.equal(blockedReasonFromReviewState(config, record, pr, checks, reviewThreads), null);
+  assert.equal(effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads).length, 0);
+});
+
+test("inferStateFromPullRequest does not reenter still-valid repair after anchored Codex success supersedes raw threads", () => {
+  const currentHeadSha = "ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6";
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN],
+    humanReviewBlocksMerge: true,
+    configuredBotInitialGraceWaitSeconds: 0,
+  });
+  const reviewThread = createReviewThread({
+    id: "thread-unresolved-codex-p1",
+    isOutdated: false,
+    comments: {
+      nodes: [
+        {
+          id: "comment-unresolved-codex-p1",
+          body: "P1: Earlier Codex Connector finding superseded by the anchored no-major current-head signal.",
+          createdAt: "2026-07-07T01:00:00Z",
+          url: "https://example.test/pr/2426#discussion_r2426",
+          author: {
+            login: CODEX_CONNECTOR_REVIEW_BOT_LOGIN,
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const record = createRecord({
+    state: "addressing_review",
+    blocked_reason: "manual_review",
+    last_head_sha: currentHeadSha,
+    review_wait_started_at: "2026-07-07T01:05:00Z",
+    review_wait_head_sha: currentHeadSha,
+    timeline_artifacts: [
+      {
+        type: "verification_result",
+        gate: "codex_turn",
+        command: "npx tsx --test src/pull-request-state-policy.test.ts",
+        head_sha: currentHeadSha,
+        outcome: "failed",
+        remediation_target: null,
+        next_action: "continue",
+        summary: "Previous still-valid repair probe failed before a later anchored no-major Codex success.",
+        recorded_at: "2026-07-07T01:06:00Z",
+        repair_targets: [STILL_VALID_REVIEW_THREAD_REPAIR_TARGET],
+        processed_review_thread_ids: [`${reviewThread.id}@${currentHeadSha}`],
+        processed_review_thread_fingerprints: [
+          `${reviewThread.id}@${currentHeadSha}#${reviewThread.comments.nodes[0]?.id}`,
+        ],
+      } satisfies TimelineArtifact,
+    ],
+  });
+  const pr = createPullRequest({
+    headRefOid: currentHeadSha,
+    configuredBotCurrentHeadObservedAt: "2026-07-07T01:12:00Z",
+    configuredBotCurrentHeadObservationSource: "status_context",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: currentHeadSha,
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-07T01:10:00Z",
+    configuredBotTopLevelReviewStrength: null,
+    currentHeadCiGreenAt: "2026-07-07T01:08:00Z",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const checks = passingChecks();
+  const reviewThreads = [reviewThread];
+
+  assert.equal(inferStateFromPullRequest(config, record, pr, checks, reviewThreads), "ready_to_merge");
+  assert.equal(blockedReasonFromReviewState(config, record, pr, checks, reviewThreads), null);
+});
+
 test("inferStateFromPullRequest keeps unresolved Codex findings guarded without valid anchored current-head no-major success", () => {
   const currentHeadSha = "ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6";
   const config = createConfig({

--- a/src/pull-request-state-policy.ts
+++ b/src/pull-request-state-policy.ts
@@ -56,6 +56,7 @@ import {
 } from "./pull-request-state-current-head-policy";
 import { reviewLoopRetryBudgetExhaustedForThread } from "./review-handling";
 import {
+  anchoredCurrentHeadCodexSuccessSupersedesUnresolvedFindings,
   effectiveConfiguredBotReviewThreadsForState,
   currentHeadRepairProofSatisfiesConfiguredProviderSignal,
   hasConfiguredProviderSuccess,
@@ -232,6 +233,14 @@ export function blockedReasonFromReviewState(
       reviewThreads,
     });
   const unresolvedBotThreads = effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads);
+  const anchoredCurrentHeadCodexSuccessSupersedesFindings =
+    anchoredCurrentHeadCodexSuccessSupersedesUnresolvedFindings({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+    });
   const codexConnectorMustFixTopLevelFindings = codexConnectorMustFixTopLevelReviewFindings(
     pr.configuredBotTopLevelReviewFindings ?? [],
   );
@@ -241,7 +250,8 @@ export function blockedReasonFromReviewState(
       .map(codexConnectorTopLevelReviewFindingRetryTarget)
       .every((target) => reviewLoopRetryBudgetExhaustedForThread(record, pr, target, 1));
   const botReviewDecisionResidueSatisfied = verifiedConfiguredBotReviewDecisionResidueSatisfied({
-    verifiedCurrentHeadRepairResidue,
+    verifiedCurrentHeadRepairResidue:
+      verifiedCurrentHeadRepairResidue || anchoredCurrentHeadCodexSuccessSupersedesFindings,
     effectiveConfiguredBotBlockerCount: unresolvedBotThreads.length,
     effectiveHumanBlockerCount: manualThreads.length,
     pr,
@@ -352,8 +362,17 @@ export function inferStateFromPullRequest(
       reviewThreads,
     });
   const unresolvedBotThreads = effectiveConfiguredBotReviewThreadsForState(config, record, pr, checks, reviewThreads);
+  const anchoredCurrentHeadCodexSuccessSupersedesFindings =
+    anchoredCurrentHeadCodexSuccessSupersedesUnresolvedFindings({
+      config,
+      record,
+      pr,
+      checks,
+      reviewThreads,
+    });
   const botReviewDecisionResidueSatisfied = verifiedConfiguredBotReviewDecisionResidueSatisfied({
-    verifiedCurrentHeadRepairResidue,
+    verifiedCurrentHeadRepairResidue:
+      verifiedCurrentHeadRepairResidue || anchoredCurrentHeadCodexSuccessSupersedesFindings,
     effectiveConfiguredBotBlockerCount: unresolvedBotThreads.length,
     effectiveHumanBlockerCount: manualThreads.length,
     pr,
@@ -413,6 +432,7 @@ export function inferStateFromPullRequest(
     pr,
     checks,
     reviewThreads,
+    repairReviewThreads: unresolvedBotThreads,
   });
 
   if (pr.mergedAt || pr.state === "MERGED") {

--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -719,6 +719,26 @@ export function buildCodexConnectorDiagnosticBundle(args: {
       pr: args.pr,
     })
     : null;
+  const convergenceSummary = staleReviewBotRemediation
+    ? suppressStaleReviewMetadataConvergence
+      ? null
+      : staleReviewMetadataConvergenceSummary ??
+      (staleReviewBotRemediation.missingProbeReason
+        ? null
+        : formatCodexConnectorConvergenceDiagnostic({
+          config: args.config,
+          record: args.record,
+          pr: args.pr,
+          reviewThreads: args.reviewThreads,
+        }))
+    : formatCodexConnectorConvergenceDiagnostic({
+      config: args.config,
+      record: args.record,
+      pr: args.pr,
+      reviewThreads: args.reviewThreads,
+    });
+  const suppressOperatorDiagnosticAfterAnchoredSupersession =
+    convergenceSummary?.includes("status=superseded_by_anchored_current_head_success") === true;
   return {
     policyBlockSummary: policyBlock ? formatCodexConnectorPolicyBlockDiagnostic(policyBlock) : null,
     p2p3PolicySummary: p2p3Policy ? formatCodexConnectorP2P3PolicyDiagnostic(p2p3Policy) : null,
@@ -753,26 +773,10 @@ export function buildCodexConnectorDiagnosticBundle(args: {
       pr: args.pr,
       checks: args.checks,
     }),
-    convergenceSummary:
-      staleReviewBotRemediation
-        ? suppressStaleReviewMetadataConvergence
-          ? null
-          : staleReviewMetadataConvergenceSummary ??
-          (staleReviewBotRemediation.missingProbeReason
-            ? null
-            : formatCodexConnectorConvergenceDiagnostic({
-              config: args.config,
-              record: args.record,
-              pr: args.pr,
-              reviewThreads: args.reviewThreads,
-            }))
-        : formatCodexConnectorConvergenceDiagnostic({
-          config: args.config,
-          record: args.record,
-          pr: args.pr,
-          reviewThreads: args.reviewThreads,
-        }),
-    operatorDiagnosticSummary: staleReviewBotRemediation
+    convergenceSummary,
+    operatorDiagnosticSummary: suppressOperatorDiagnosticAfterAnchoredSupersession
+      ? null
+      : staleReviewBotRemediation
       ? formatStaleReviewResidueOperatorDiagnostic({
         remediation: staleReviewBotRemediation,
         verifiedCurrentHeadRepairResidueMergeReady,

--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -38,6 +38,7 @@ import {
   buildStaleReviewBotThreadDiagnostics,
   type StaleReviewBotRemediationDto,
 } from "./stale-review-bot-remediation";
+import { hasFreshCurrentHeadCodexSuccessReviewedCommit } from "../current-head-codex-repair-proof";
 
 function addMinutes(timestamp: string, minutes: number): string | null {
   const parsed = Date.parse(timestamp);
@@ -424,6 +425,13 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
   const currentHeadSha = args.pr.headRefOid;
   const staleReviewCommitThreads = codexConnectorStaleReviewCommitThreads(args.pr, args.reviewThreads);
   const staleReviewCommitThreadIds = staleReviewCommitThreads.map((thread) => thread.id).join(",");
+  const supersededMustFixThreads = codexConnectorMustFixReviewThreads(args.reviewThreads);
+  const supersededByAnchoredCurrentHeadSuccess =
+    policy.outcome === "must_fix_remaining" &&
+    supersededMustFixThreads.length > 0 &&
+    supersededMustFixThreads.length === policy.findingCount &&
+    hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads);
+  const supersededMustFixThreadIds = supersededMustFixThreads.map((thread) => thread.id).join(",");
   const hasCurrentHeadProviderSuccess = Boolean(
     args.record.provider_success_observed_at && commitShasEqualForComparison(args.record.provider_success_head_sha, currentHeadSha),
   );
@@ -469,6 +477,7 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
 
   let status:
     | "contradictory_evidence"
+    | "superseded_by_anchored_current_head_success"
     | "stale_review_commit_residue"
     | "stale_head"
     | "repairing_must_fix"
@@ -488,7 +497,11 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
     | "merge_or_follow_up_nitpicks"
     | "merge_ready";
 
-  if (staleReviewCommitThreads.length > 0 && policy.outcome === "must_fix_remaining") {
+  if (supersededByAnchoredCurrentHeadSuccess) {
+    status = "superseded_by_anchored_current_head_success";
+    mergeEffect = "ready";
+    nextAction = "merge_ready";
+  } else if (staleReviewCommitThreads.length > 0 && policy.outcome === "must_fix_remaining") {
     status = "stale_review_commit_residue";
     mergeEffect = "blocked";
     nextAction = staleReviewCommitNextAction;
@@ -528,10 +541,17 @@ export function formatCodexConnectorConvergenceDiagnostic(args: {
     `current_head_sha=${currentHeadSha}`,
     `current_head_observed_at=${policy.currentHeadObservedAt ?? "none"}`,
     `latest_signal_head_sha=${latestSignalHeadSha}`,
-    `highest_severity=${highestSeverity}`,
-    `finding_count=${findingCount}`,
+    `highest_severity=${supersededByAnchoredCurrentHeadSuccess ? "none" : highestSeverity}`,
+    `finding_count=${supersededByAnchoredCurrentHeadSuccess ? 0 : findingCount}`,
     `merge_effect=${mergeEffect}`,
     `next_action=${nextAction}`,
+    ...(supersededByAnchoredCurrentHeadSuccess
+      ? [
+          "note=anchored_current_head_codex_success_superseded_unresolved_findings",
+          `superseded_review_threads=${supersededMustFixThreads.length}`,
+          `superseded_review_thread_ids=${supersededMustFixThreadIds}`,
+        ]
+      : []),
     ...(staleReviewCommitThreads.length > 0
       ? [
           `stale_review_commit_threads=${staleReviewCommitThreads.length}`,

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -1106,6 +1106,56 @@ test("formatCodexConnectorConvergenceDiagnostic surfaces must-fix convergence st
   );
 });
 
+test("formatCodexConnectorConvergenceDiagnostic reports anchored current-head Codex success supersession", () => {
+  const headSha = "ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6";
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const pr = createPr({
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-07-07T01:10:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: headSha,
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-07T01:10:00Z",
+    configuredBotTopLevelReviewStrength: null,
+  });
+  const mustFixThread = createThread({
+    id: "thread-unresolved-codex-p1",
+    comments: {
+      nodes: [
+        {
+          id: "comment-unresolved-codex-p1",
+          body: "P1: Earlier Codex Connector finding superseded by anchored current-head success.",
+          createdAt: "2026-07-07T01:00:00Z",
+          url: "https://example.test/pr/2426#discussion_r2426",
+          author: {
+            login: "chatgpt-codex-connector[bot]",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(
+    formatCodexConnectorConvergenceDiagnostic({
+      config,
+      record: createRecord({
+        state: "pr_open",
+        pr_number: pr.number,
+        provider_success_head_sha: headSha,
+        provider_success_observed_at: "2026-07-07T01:12:00Z",
+      }),
+      pr,
+      reviewThreads: [mustFixThread],
+    }),
+    "codex_connector_convergence status=superseded_by_anchored_current_head_success provider=codex current_head_sha=ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6 current_head_observed_at=2026-07-07T01:10:00Z latest_signal_head_sha=ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6 highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready note=anchored_current_head_codex_success_superseded_unresolved_findings superseded_review_threads=1 superseded_review_thread_ids=thread-unresolved-codex-p1",
+  );
+});
+
 test("formatCodexConnectorConvergenceDiagnostic reports top-level Codex Review findings as must-fix", () => {
   const config = createConfig({ reviewBotLogins: ["chatgpt-codex-connector"] });
   const pr = createPr({

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -11,6 +11,7 @@ import {
   reviewBotDiagnostics,
 } from "./supervisor-status-review-bot";
 import {
+  buildCodexConnectorDiagnosticBundle,
   formatCodexConnectorConvergenceDiagnostic,
   formatCodexConnectorReviewFallbackDiagnostic,
 } from "./codex-connector-diagnostics-presenter";
@@ -1154,6 +1155,62 @@ test("formatCodexConnectorConvergenceDiagnostic reports anchored current-head Co
     }),
     "codex_connector_convergence status=superseded_by_anchored_current_head_success provider=codex current_head_sha=ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6 current_head_observed_at=2026-07-07T01:10:00Z latest_signal_head_sha=ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6 highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready note=anchored_current_head_codex_success_superseded_unresolved_findings superseded_review_threads=1 superseded_review_thread_ids=thread-unresolved-codex-p1",
   );
+});
+
+test("buildCodexConnectorDiagnosticBundle suppresses operator repair diagnostics after anchored supersession", () => {
+  const headSha = "ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6";
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    configuredBotCurrentHeadSignalTimeoutMinutes: 10,
+    configuredBotCurrentHeadSignalTimeoutAction: "request_review_comment",
+  });
+  const pr = createPr({
+    headRefOid: headSha,
+    configuredBotCurrentHeadObservedAt: "2026-07-07T01:10:00Z",
+    configuredBotCurrentHeadObservationSource: "codex_pr_success_comment",
+    configuredBotCurrentHeadStatusState: "SUCCESS",
+    configuredBotCurrentHeadCodexSuccessReviewedCommitSha: headSha,
+    configuredBotCurrentHeadCodexSuccessObservedAt: "2026-07-07T01:10:00Z",
+    configuredBotTopLevelReviewStrength: null,
+  });
+  const reviewThreads = [
+    createThread({
+      id: "thread-unresolved-codex-p1",
+      comments: {
+        nodes: [
+          {
+            id: "comment-unresolved-codex-p1",
+            body: "P1: Earlier Codex Connector finding superseded by anchored current-head success.",
+            createdAt: "2026-07-07T01:00:00Z",
+            url: "https://example.test/pr/2426#discussion_r2426",
+            author: {
+              login: "chatgpt-codex-connector[bot]",
+              typeName: "Bot",
+            },
+          },
+        ],
+      },
+    }),
+  ];
+
+  const bundle = buildCodexConnectorDiagnosticBundle({
+    config,
+    record: createRecord({
+      state: "pr_open",
+      pr_number: pr.number,
+      provider_success_head_sha: headSha,
+      provider_success_observed_at: "2026-07-07T01:12:00Z",
+    }),
+    pr,
+    checks: [],
+    reviewThreads,
+  });
+
+  assert.equal(
+    bundle.convergenceSummary,
+    "codex_connector_convergence status=superseded_by_anchored_current_head_success provider=codex current_head_sha=ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6 current_head_observed_at=2026-07-07T01:10:00Z latest_signal_head_sha=ae3831568705a3a3be8cbf8c0cd6ec58d1f2d8e6 highest_severity=none finding_count=0 merge_effect=ready next_action=merge_ready note=anchored_current_head_codex_success_superseded_unresolved_findings superseded_review_threads=1 superseded_review_thread_ids=thread-unresolved-codex-p1",
+  );
+  assert.equal(bundle.operatorDiagnosticSummary, null);
 });
 
 test("formatCodexConnectorConvergenceDiagnostic reports top-level Codex Review findings as must-fix", () => {


### PR DESCRIPTION
## Summary
- allow a newer reviewed-current-head Codex success comment to supersede same-provider unresolved Codex finding threads
- keep fail-closed gates for missing/stale anchors, later findings, mixed providers, non-green checks, human blockers, merge conflicts, and top-level must-fix findings
- add a status diagnostic token for anchored current-head supersession

## Verification
- npx tsx --test src/pull-request-state-policy.test.ts
- npx tsx --test src/current-head-codex-repair-proof.test.ts
- npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts
- npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts
- npm run build

Closes #2427