### PR TITLE
Split stale-review diagnostics assembly

### DIFF
--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -262,6 +262,7 @@ const EXPECTED_FAMILY_FILES = {
     "stale-diagnostic-recoverability.ts",
     "stale-review-bot-classification-policy.ts",
     "stale-review-bot-diagnostics-presenter.ts",
+    "stale-review-bot-diagnostics.ts",
     "stale-review-bot-recovery.ts",
     "stale-review-bot-remediation.ts",
     "stale-review-current-head-evidence.ts",

--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -35,9 +35,9 @@ import {
   verifiedCurrentHeadRepairResidueAllowsMergeReadyAction,
 } from "./stale-review-bot-diagnostics-presenter";
 import {
-  buildStaleReviewBotThreadDiagnostics,
   type StaleReviewBotRemediationDto,
 } from "./stale-review-bot-remediation";
+import { buildStaleReviewBotThreadDiagnostics } from "./stale-review-bot-diagnostics";
 
 function addMinutes(timestamp: string, minutes: number): string | null {
   const parsed = Date.parse(timestamp);

--- a/src/supervisor/stale-review-bot-diagnostics-presenter.ts
+++ b/src/supervisor/stale-review-bot-diagnostics-presenter.ts
@@ -1,9 +1,11 @@
 import {
   isProvenStaleReviewMetadataClassification,
-  formatStaleReviewBotTokenValue,
   type StaleReviewBotRemediationDto,
-  type StaleReviewBotThreadDiagnosticsDto,
 } from "./stale-review-bot-remediation";
+import {
+  formatStaleReviewBotTokenValue,
+  type StaleReviewBotThreadDiagnosticsDto,
+} from "./stale-review-bot-diagnostics";
 import type { CodexConnectorValidReviewRepairTarget } from "../codex-connector-valid-review-repair";
 import { GitHubPullRequest, PullRequestCheck } from "../core/types";
 

--- a/src/supervisor/stale-review-bot-diagnostics.ts
+++ b/src/supervisor/stale-review-bot-diagnostics.ts
@@ -1,0 +1,171 @@
+import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "../core/types";
+import { reviewLoopRetryBudgetExhaustedForThread } from "../review-handling";
+import {
+  codexConnectorMustFixReviewThreads,
+  latestCodexConnectorReviewCommentFingerprint,
+} from "../codex-connector-review-policy";
+import {
+  configuredBotReviewFollowUpState,
+  configuredBotReviewThreads,
+  pendingBotReviewThreads,
+} from "../review-thread-reporting";
+import { configuredReviewProviderKinds } from "../core/review-providers";
+import { currentHeadCodexRepairProofRejectionReasons } from "../current-head-codex-repair-proof";
+import {
+  buildCodexConnectorStillValidReviewRepairTargets,
+  type CodexConnectorValidReviewRepairTarget,
+} from "../codex-connector-valid-review-repair";
+import { hasCurrentHeadSuccessSignal } from "./stale-review-current-head-evidence";
+import type { RepositoryFileContents } from "./stale-review-repository-path-repair-evidence";
+import {
+  classifyStaleReviewBotAutoRepairSuppression,
+  isVerifiedStaleResidueClassification,
+  type StaleReviewBotAutoRepairSuppressedReason,
+} from "./stale-review-bot-classification-policy";
+import {
+  buildStaleReviewBotRemediation,
+  type StaleReviewBotRemediationDto,
+} from "./stale-review-bot-remediation";
+
+export interface StaleReviewBotThreadDiagnosticsDto {
+  issueNumber: number;
+  prNumber: number | null;
+  currentHeadSuccess: "yes" | "no" | "unknown";
+  unresolvedCurrentThreads: number;
+  actionableMustFixThreads: number;
+  verifiedStaleResidueThreads: number;
+  missingVerificationEvidenceThreads: number;
+  repeatStopExhausted: "yes" | "no";
+  autoRepairSuppressedReason: StaleReviewBotAutoRepairSuppressedReason;
+  currentHeadRepairProofRejectionReasons?: string[];
+  validRepairTargets?: CodexConnectorValidReviewRepairTarget[];
+}
+
+export function formatStaleReviewBotTokenValue(value: string): string {
+  return value.replace(/\r?\n/gu, "\\n");
+}
+
+function currentHeadSuccess(pr: GitHubPullRequest | null): StaleReviewBotThreadDiagnosticsDto["currentHeadSuccess"] {
+  if (!pr) {
+    return "unknown";
+  }
+  return hasCurrentHeadSuccessSignal(pr) ? "yes" : "no";
+}
+
+export function buildStaleReviewBotThreadDiagnostics(args: {
+  config?: SupervisorConfig | null;
+  record: IssueRunRecord;
+  pr: GitHubPullRequest | null;
+  checks: PullRequestCheck[];
+  reviewThreads?: ReviewThread[];
+  remediation?: StaleReviewBotRemediationDto | null;
+  repositoryFileContents?: RepositoryFileContents;
+}): StaleReviewBotThreadDiagnosticsDto | null {
+  const remediation =
+    args.remediation ??
+    buildStaleReviewBotRemediation({
+      config: args.config,
+      record: args.record,
+      pr: args.pr,
+      checks: args.checks,
+      reviewThreads: args.reviewThreads,
+      repositoryFileContents: args.repositoryFileContents,
+    });
+  if (!remediation) {
+    return null;
+  }
+
+  const config = args.config ?? null;
+  const reviewThreads = args.reviewThreads ?? [];
+  const configuredThreads = config ? configuredBotReviewThreads(config, reviewThreads) : [];
+  const unresolvedConfiguredThreads = configuredThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
+  const codexConfigured = config ? configuredReviewProviderKinds(config).includes("codex") : false;
+  const actionableMustFixThreads = config && codexConfigured
+    ? codexConnectorMustFixReviewThreads(reviewThreads)
+    : config && args.pr
+      ? pendingBotReviewThreads(config, args.record, args.pr, configuredThreads)
+      : [];
+  const currentHeadReviewRequestPending =
+    remediation.classification === "metadata_only_missing_current_head_review" &&
+    remediation.codexCurrentHeadReviewState === "missing";
+  const isVerifiedResidue = isVerifiedStaleResidueClassification(remediation.classification);
+  const reviewLoopRetryExhausted =
+    config && args.pr && actionableMustFixThreads.length > 0
+      ? actionableMustFixThreads.every((thread) =>
+          reviewLoopRetryBudgetExhaustedForThread(
+            args.record,
+            args.pr!,
+            thread,
+            1,
+            codexConfigured ? latestCodexConnectorReviewCommentFingerprint(thread) : undefined,
+          ),
+        )
+      : false;
+  const repeatStopExhausted =
+    currentHeadReviewRequestPending || isVerifiedResidue
+      ? false
+      : reviewLoopRetryExhausted ||
+        args.record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" ||
+        (config && args.pr
+          ? configuredBotReviewFollowUpState(config, args.record, args.pr, configuredThreads) === "exhausted"
+          : false);
+  const verifiedStaleResidueThreads = isVerifiedResidue
+    ? unresolvedConfiguredThreads.length
+    : 0;
+  const validRepairTargets =
+    config && args.pr
+      ? buildCodexConnectorStillValidReviewRepairTargets({
+          record: args.record,
+          pr: args.pr,
+          reviewThreads: actionableMustFixThreads,
+        })
+      : [];
+  const missingVerificationEvidenceThreads = remediation.missingProbeReason
+    ? Math.max(actionableMustFixThreads.length - validRepairTargets.length, validRepairTargets.length > 0 ? 0 : 1)
+    : 0;
+  const currentHeadRepairProofRejectionReasons =
+    config &&
+    args.pr &&
+    codexConfigured &&
+    args.record.blocked_reason === "manual_review" &&
+    args.record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
+    !isVerifiedResidue &&
+    actionableMustFixThreads.length > 0
+      ? currentHeadCodexRepairProofRejectionReasons({
+          config,
+          record: args.record,
+          pr: args.pr,
+          checks: args.checks,
+          reviewThreads,
+        })
+      : [];
+  const reportableCurrentHeadRepairProofRejectionReasons = currentHeadRepairProofRejectionReasons.filter(
+    (reason) => reason !== "current_head_repair_proof_structured_artifact_missing",
+  );
+
+  return {
+    issueNumber: args.record.issue_number,
+    prNumber: args.record.pr_number,
+    currentHeadSuccess: currentHeadSuccess(args.pr),
+    unresolvedCurrentThreads: unresolvedConfiguredThreads.length,
+    actionableMustFixThreads: actionableMustFixThreads.length,
+    verifiedStaleResidueThreads,
+    missingVerificationEvidenceThreads,
+    repeatStopExhausted: repeatStopExhausted ? "yes" : "no",
+    autoRepairSuppressedReason: classifyStaleReviewBotAutoRepairSuppression({
+      config,
+      record: args.record,
+      pr: args.pr,
+      checks: args.checks,
+      reviewThreads,
+      classification: remediation.classification,
+      missingProbeReason: remediation.missingProbeReason,
+      actionableMustFixThreads,
+      repeatStopExhausted,
+    }),
+    ...(reportableCurrentHeadRepairProofRejectionReasons.length > 0
+      ? { currentHeadRepairProofRejectionReasons: reportableCurrentHeadRepairProofRejectionReasons }
+      : {}),
+    validRepairTargets,
+  };
+}

--- a/src/supervisor/stale-review-bot-remediation.test.ts
+++ b/src/supervisor/stale-review-bot-remediation.test.ts
@@ -7,10 +7,10 @@ import {
 } from "../codex-connector-tracked-pr-test-helpers";
 import {
   buildStaleReviewBotRemediation,
-  buildStaleReviewBotThreadDiagnostics,
   shouldAutoResolveVerifiedStaleReviewResidue,
   VERIFIED_CURRENT_HEAD_REPAIR_REVIEW_THREAD_RESIDUE_TARGET,
 } from "./stale-review-bot-remediation";
+import { buildStaleReviewBotThreadDiagnostics } from "./stale-review-bot-diagnostics";
 import { STILL_VALID_REVIEW_THREAD_REPAIR_TARGET } from "../codex-connector-valid-review-repair";
 import {
   classifyStaleReviewBotRemediation,

--- a/src/supervisor/stale-review-bot-remediation.ts
+++ b/src/supervisor/stale-review-bot-remediation.ts
@@ -1,31 +1,16 @@
 import type { GitHubPullRequest, IssueRunRecord, PullRequestCheck, ReviewThread, SupervisorConfig } from "../core/types";
 import {
-  reviewLoopRetryBudgetExhaustedForThread,
-} from "../review-handling";
-import {
-  codexConnectorMustFixReviewThreads,
   hasCodexConnectorFindingReviewComment,
-  latestCodexConnectorReviewCommentFingerprint,
 } from "../codex-connector-review-policy";
 import {
-  configuredBotReviewFollowUpState,
   configuredBotReviewThreads,
   manualReviewThreads,
-  pendingBotReviewThreads,
 } from "../review-thread-reporting";
 import { isRecoverableVerifiedCodexStaleResidueThread } from "./verified-stale-residue-review-thread";
 import { configuredReviewProviderKinds } from "../core/review-providers";
 import {
-  currentHeadCodexRepairProofRejectionReasons,
   projectCurrentHeadCodexRepairProof,
 } from "../current-head-codex-repair-proof";
-import {
-  buildCodexConnectorStillValidReviewRepairTargets,
-  type CodexConnectorValidReviewRepairTarget,
-} from "../codex-connector-valid-review-repair";
-import {
-  hasCurrentHeadSuccessSignal,
-} from "./stale-review-current-head-evidence";
 import {
   type RepositoryFileContents,
 } from "./stale-review-repository-path-repair-evidence";
@@ -33,12 +18,10 @@ import {
   STALE_REVIEW_BOT_MANUAL_NEXT_STEP,
   VERIFIED_CURRENT_HEAD_REPAIR_MANUAL_NEXT_STEP,
   VERIFIED_NO_SOURCE_CHANGE_MANUAL_NEXT_STEP,
-  classifyStaleReviewBotAutoRepairSuppression,
   classifyStaleReviewBotRemediation,
   codexConnectorCurrentHeadReviewState,
   isPolicyResolvableStaleReviewBotClassification,
   isVerifiedStaleResidueClassification,
-  type StaleReviewBotAutoRepairSuppressedReason,
   type StaleReviewBotClassificationOutcome,
   verifiedStaleReviewResidueAutoResolveEnabled,
 } from "./stale-review-bot-classification-policy";
@@ -72,24 +55,6 @@ export interface StaleReviewBotRemediationDto {
   missingProbeReason: string | null;
   manualNextStep: string;
   summary: string;
-}
-
-export interface StaleReviewBotThreadDiagnosticsDto {
-  issueNumber: number;
-  prNumber: number | null;
-  currentHeadSuccess: "yes" | "no" | "unknown";
-  unresolvedCurrentThreads: number;
-  actionableMustFixThreads: number;
-  verifiedStaleResidueThreads: number;
-  missingVerificationEvidenceThreads: number;
-  repeatStopExhausted: "yes" | "no";
-  autoRepairSuppressedReason: StaleReviewBotAutoRepairSuppressedReason;
-  currentHeadRepairProofRejectionReasons?: string[];
-  validRepairTargets?: CodexConnectorValidReviewRepairTarget[];
-}
-
-export function formatStaleReviewBotTokenValue(value: string): string {
-  return value.replace(/\r?\n/gu, "\\n");
 }
 
 function processedOnCurrentHead(record: Pick<IssueRunRecord, "last_failure_context">): "yes" | "no" | "unknown" {
@@ -147,13 +112,6 @@ function hasAutoResolvableMergeState(pr: GitHubPullRequest): boolean {
     pr.mergeable === "MERGEABLE" &&
     (pr.mergeStateStatus === "CLEAN" || pr.mergeStateStatus === "BLOCKED")
   );
-}
-
-function currentHeadSuccess(pr: GitHubPullRequest | null): StaleReviewBotThreadDiagnosticsDto["currentHeadSuccess"] {
-  if (!pr) {
-    return "unknown";
-  }
-  return hasCurrentHeadSuccessSignal(pr) ? "yes" : "no";
 }
 
 function hasRecoverableStaleReviewThreadContext(args: {
@@ -300,122 +258,4 @@ export function shouldAutoResolveVerifiedStaleReviewResidue(args: {
         (isPolicyResolvableStaleReviewBotClassification(args.remediation.classification) &&
           args.config.staleConfiguredBotReviewPolicy === "reply_and_resolve")),
   );
-}
-
-export function buildStaleReviewBotThreadDiagnostics(args: {
-  config?: SupervisorConfig | null;
-  record: IssueRunRecord;
-  pr: GitHubPullRequest | null;
-  checks: PullRequestCheck[];
-  reviewThreads?: ReviewThread[];
-  remediation?: StaleReviewBotRemediationDto | null;
-  repositoryFileContents?: RepositoryFileContents;
-}): StaleReviewBotThreadDiagnosticsDto | null {
-  const remediation =
-    args.remediation ??
-    buildStaleReviewBotRemediation({
-      config: args.config,
-      record: args.record,
-      pr: args.pr,
-      checks: args.checks,
-      reviewThreads: args.reviewThreads,
-      repositoryFileContents: args.repositoryFileContents,
-    });
-  if (!remediation) {
-    return null;
-  }
-
-  const config = args.config ?? null;
-  const reviewThreads = args.reviewThreads ?? [];
-  const configuredThreads = config ? configuredBotReviewThreads(config, reviewThreads) : [];
-  const unresolvedConfiguredThreads = configuredThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
-  const codexConfigured = config ? configuredReviewProviderKinds(config).includes("codex") : false;
-  const actionableMustFixThreads = config && codexConfigured
-    ? codexConnectorMustFixReviewThreads(reviewThreads)
-    : config && args.pr
-      ? pendingBotReviewThreads(config, args.record, args.pr, configuredThreads)
-      : [];
-  const currentHeadReviewRequestPending =
-    remediation.classification === "metadata_only_missing_current_head_review" &&
-    remediation.codexCurrentHeadReviewState === "missing";
-  const isVerifiedResidue = isVerifiedStaleResidueClassification(remediation.classification);
-  const reviewLoopRetryExhausted =
-    config && args.pr && actionableMustFixThreads.length > 0
-      ? actionableMustFixThreads.every((thread) =>
-          reviewLoopRetryBudgetExhaustedForThread(
-            args.record,
-            args.pr!,
-            thread,
-            1,
-            codexConfigured ? latestCodexConnectorReviewCommentFingerprint(thread) : undefined,
-          ),
-        )
-      : false;
-  const repeatStopExhausted =
-    currentHeadReviewRequestPending || isVerifiedResidue
-      ? false
-      : reviewLoopRetryExhausted ||
-        args.record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" ||
-        (config && args.pr
-          ? configuredBotReviewFollowUpState(config, args.record, args.pr, configuredThreads) === "exhausted"
-          : false);
-  const verifiedStaleResidueThreads = isVerifiedResidue
-    ? unresolvedConfiguredThreads.length
-    : 0;
-  const validRepairTargets =
-    config && args.pr
-      ? buildCodexConnectorStillValidReviewRepairTargets({
-          record: args.record,
-          pr: args.pr,
-          reviewThreads: actionableMustFixThreads,
-        })
-      : [];
-  const missingVerificationEvidenceThreads = remediation.missingProbeReason
-    ? Math.max(actionableMustFixThreads.length - validRepairTargets.length, validRepairTargets.length > 0 ? 0 : 1)
-    : 0;
-  const currentHeadRepairProofRejectionReasons =
-    config &&
-    args.pr &&
-    codexConfigured &&
-    args.record.blocked_reason === "manual_review" &&
-    args.record.last_tracked_pr_repeat_failure_decision === "stop_no_progress" &&
-    !isVerifiedResidue &&
-    actionableMustFixThreads.length > 0
-      ? currentHeadCodexRepairProofRejectionReasons({
-          config,
-          record: args.record,
-          pr: args.pr,
-          checks: args.checks,
-          reviewThreads,
-        })
-      : [];
-  const reportableCurrentHeadRepairProofRejectionReasons = currentHeadRepairProofRejectionReasons.filter(
-    (reason) => reason !== "current_head_repair_proof_structured_artifact_missing",
-  );
-
-  return {
-    issueNumber: args.record.issue_number,
-    prNumber: args.record.pr_number,
-    currentHeadSuccess: currentHeadSuccess(args.pr),
-    unresolvedCurrentThreads: unresolvedConfiguredThreads.length,
-    actionableMustFixThreads: actionableMustFixThreads.length,
-    verifiedStaleResidueThreads,
-    missingVerificationEvidenceThreads,
-    repeatStopExhausted: repeatStopExhausted ? "yes" : "no",
-    autoRepairSuppressedReason: classifyStaleReviewBotAutoRepairSuppression({
-      config,
-      record: args.record,
-      pr: args.pr,
-      checks: args.checks,
-      reviewThreads,
-      classification: remediation.classification,
-      missingProbeReason: remediation.missingProbeReason,
-      actionableMustFixThreads,
-      repeatStopExhausted,
-    }),
-    ...(reportableCurrentHeadRepairProofRejectionReasons.length > 0
-      ? { currentHeadRepairProofRejectionReasons: reportableCurrentHeadRepairProofRejectionReasons }
-      : {}),
-    validRepairTargets,
-  };
 }

--- a/src/supervisor/supervisor-active-detailed-status-presenters.ts
+++ b/src/supervisor/supervisor-active-detailed-status-presenters.ts
@@ -28,9 +28,9 @@ import {
 } from "./supervisor-status-review-bot";
 import {
   buildStaleReviewBotRemediation,
-  buildStaleReviewBotThreadDiagnostics,
   isProvenStaleReviewMetadataClassification,
 } from "./stale-review-bot-remediation";
+import { buildStaleReviewBotThreadDiagnostics } from "./stale-review-bot-diagnostics";
 import {
   formatStaleReviewBotRemediationLine,
   formatStaleReviewBotRepairTargetLine,

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -6,10 +6,10 @@ import {
   buildCodexConnectorDiagnosticBundle,
 } from "./supervisor-status-review-bot";
 import {
-  buildStaleReviewBotThreadDiagnostics,
   buildStaleReviewBotRemediation,
   currentHeadVerifiedRepairResidueArtifactEvidenceSummary,
 } from "./stale-review-bot-remediation";
+import { buildStaleReviewBotThreadDiagnostics } from "./stale-review-bot-diagnostics";
 import {
   formatStaleReviewBotRemediationLine,
   formatStaleReviewBotRepairTargetLine,

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -75,12 +75,14 @@ import {
   recoverabilityStatusToken,
 } from "./stale-diagnostic-recoverability";
 import {
-  buildStaleReviewBotThreadDiagnostics,
   buildStaleReviewBotRemediation,
   isProvenStaleReviewMetadataClassification,
   type StaleReviewBotRemediationDto,
-  type StaleReviewBotThreadDiagnosticsDto,
 } from "./stale-review-bot-remediation";
+import {
+  buildStaleReviewBotThreadDiagnostics,
+  type StaleReviewBotThreadDiagnosticsDto,
+} from "./stale-review-bot-diagnostics";
 import {
   formatStaleReviewBotRemediationLine,
   formatStaleReviewBotRepairTargetLine,


### PR DESCRIPTION
## Summary
- move stale-review thread diagnostics DTO assembly into a focused diagnostics module
- keep remediation decision and auto-resolve code in the remediation module
- retarget status/reporting callers and focused tests to the diagnostics boundary

## Verification
- npx tsx --test src/supervisor/stale-review-bot-remediation.test.ts
- npm run build

Part of #2420
Closes #2424