### PR TITLE
Treat Codex nitpick residue as non-blocking status

### DIFF
--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -364,6 +364,7 @@ export function applyConfiguredBotReviewSummary(
     codexConnectorReviewRequestCommentUrl: summary?.codexConnectorReviewRequest?.commentUrl ?? null,
     configuredBotCurrentHeadObservedAt: summary?.currentHeadObservedAt ?? null,
     configuredBotCurrentHeadObservationSource: summary?.currentHeadObservationSource ?? null,
+    configuredBotCurrentHeadObservationAuthorLogin: summary?.currentHeadObservationAuthorLogin ?? null,
     configuredBotCurrentHeadActionableObservedAt: summary?.currentHeadActionableObservedAt ?? null,
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha:
       summary?.currentHeadCodexSuccessReviewedCommitSha ?? null,

--- a/src/github/github-hydration.ts
+++ b/src/github/github-hydration.ts
@@ -365,6 +365,7 @@ export function applyConfiguredBotReviewSummary(
     configuredBotCurrentHeadObservedAt: summary?.currentHeadObservedAt ?? null,
     configuredBotCurrentHeadObservationSource: summary?.currentHeadObservationSource ?? null,
     configuredBotCurrentHeadObservationAuthorLogin: summary?.currentHeadObservationAuthorLogin ?? null,
+    configuredBotCurrentHeadCodexObservedAt: summary?.currentHeadCodexObservedAt ?? null,
     configuredBotCurrentHeadActionableObservedAt: summary?.currentHeadActionableObservedAt ?? null,
     configuredBotCurrentHeadCodexSuccessReviewedCommitSha:
       summary?.currentHeadCodexSuccessReviewedCommitSha ?? null,

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -982,6 +982,43 @@ test("buildConfiguredBotReviewSummary extends current-head observation with late
   });
 });
 
+test("buildConfiguredBotReviewSummary preserves earlier Codex current-head evidence after later CodeRabbit activity", () => {
+  const facts: CopilotReviewLifecycleFacts = {
+    reviewRequests: [],
+    reviews: [
+      {
+        authorLogin: "chatgpt-codex-connector",
+        submittedAt: "2026-03-13T02:02:00Z",
+        commitOid: "head-44",
+        state: "COMMENTED",
+        body: "Codex reviewed this pull request.",
+      },
+      {
+        authorLogin: "coderabbitai[bot]",
+        submittedAt: "2026-03-13T02:03:00Z",
+        commitOid: "head-44",
+        state: "COMMENTED",
+        body: "## Summary\nCodeRabbit reviewed this pull request and found no actionable issues.",
+      },
+    ],
+    comments: [
+      {
+        authorLogin: "coderabbitai[bot]",
+        createdAt: "2026-03-13T02:04:00Z",
+        originalCommitOid: null,
+      },
+    ],
+    issueComments: [],
+    timeline: [],
+  };
+
+  const summary = buildConfiguredBotReviewSummary(facts, ["chatgpt-codex-connector", "coderabbitai[bot]"], "head-44");
+
+  assert.equal(summary.currentHeadObservedAt, "2026-03-13T02:04:00Z");
+  assert.equal(summary.currentHeadObservationAuthorLogin, "coderabbitai[bot]");
+  assert.equal(summary.currentHeadCodexObservedAt, "2026-03-13T02:02:00Z");
+});
+
 test("buildConfiguredBotReviewSummary keeps weakly anchored CodeRabbit review comments from stale-head history out of current-head observation", () => {
   const facts: CopilotReviewLifecycleFacts = {
     reviewRequests: [],

--- a/src/github/github-review-signals.test.ts
+++ b/src/github/github-review-signals.test.ts
@@ -801,7 +801,9 @@ test("buildConfiguredBotReviewSummary records the latest configured-bot observat
     timeline: [],
   };
 
-  assert.deepEqual(buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"], "head-44"), {
+  const summary = buildConfiguredBotReviewSummary(facts, ["coderabbitai[bot]"], "head-44");
+
+  assert.deepEqual(summary, {
     lifecycle: {
       state: "arrived",
       requestedAt: null,
@@ -818,6 +820,7 @@ test("buildConfiguredBotReviewSummary records the latest configured-bot observat
     rateLimitWarningAt: null,
     draftSkipAt: null,
   });
+  assert.equal(summary.currentHeadObservationAuthorLogin, "coderabbitai[bot]");
 });
 
 test("buildConfiguredBotReviewSummary extracts Codex Connector reviewed commit from review body", () => {

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -90,6 +90,7 @@ export interface ConfiguredBotReviewSummary {
   codexConnectorReviewRequest?: CodexConnectorReviewRequestObservation | null;
   currentHeadObservedAt: string | null;
   currentHeadObservationSource: ConfiguredBotCurrentHeadObservationSource;
+  currentHeadObservationAuthorLogin?: string | null;
   currentHeadActionableObservedAt?: string | null;
   currentHeadCodexSuccessReviewedCommitSha?: string | null;
   currentHeadCodexSuccessObservedAt?: string | null;
@@ -687,20 +688,22 @@ function inferConfiguredBotCurrentHeadObservation(
 ): {
   observedAt: string | null;
   source: ConfiguredBotCurrentHeadObservationSource;
+  authorLogin: string | null;
 } {
   const normalizedCurrentHeadOid = currentHeadOid?.trim();
   if (!normalizedCurrentHeadOid) {
-    return { observedAt: null, source: null };
+    return { observedAt: null, source: null, authorLogin: null };
   }
 
   const configuredReviewBots = new Set(normalizeReviewBotLogins(reviewBotLogins));
   if (configuredReviewBots.size === 0) {
-    return { observedAt: null, source: null };
+    return { observedAt: null, source: null, authorLogin: null };
   }
 
   const currentHeadObservations: Array<{
     observedAt: string | null | undefined;
     source: NonNullable<ConfiguredBotCurrentHeadObservationSource>;
+    authorLogin: string | null;
   }> = [];
   for (const review of facts.reviews) {
     const authorLogin = normalizeLogin(review.authorLogin);
@@ -709,7 +712,7 @@ function inferConfiguredBotCurrentHeadObservation(
       configuredReviewBots.has(authorLogin) &&
       review.commitOid === normalizedCurrentHeadOid
     ) {
-      currentHeadObservations.push({ observedAt: review.submittedAt, source: "review" });
+      currentHeadObservations.push({ observedAt: review.submittedAt, source: "review", authorLogin });
     }
   }
 
@@ -720,7 +723,7 @@ function inferConfiguredBotCurrentHeadObservation(
       configuredReviewBots.has(authorLogin) &&
       comment.originalCommitOid === normalizedCurrentHeadOid
     ) {
-      currentHeadObservations.push({ observedAt: comment.createdAt, source: "review_thread_comment" });
+      currentHeadObservations.push({ observedAt: comment.createdAt, source: "review_thread_comment", authorLogin });
     }
   }
 
@@ -734,7 +737,11 @@ function inferConfiguredBotCurrentHeadObservation(
         configuredReviewBots,
       })
     ) {
-      currentHeadObservations.push({ observedAt: statusContext.createdAt, source: "status_context" });
+      currentHeadObservations.push({
+        observedAt: statusContext.createdAt,
+        source: "status_context",
+        authorLogin: normalizeLogin(statusContext.creatorLogin),
+      });
     }
   }
 
@@ -750,7 +757,11 @@ function inferConfiguredBotCurrentHeadObservation(
         if (reviewedCommitSha && !commitShaMatchesByPrefix(reviewedCommitSha, normalizedCurrentHeadOid)) {
           continue;
         }
-        currentHeadObservations.push({ observedAt: comment.createdAt, source: "codex_pr_success_comment" });
+        currentHeadObservations.push({
+          observedAt: comment.createdAt,
+          source: "codex_pr_success_comment",
+          authorLogin,
+        });
       }
     }
 
@@ -765,50 +776,49 @@ function inferConfiguredBotCurrentHeadObservation(
       currentHeadObservations.push({
         observedAt: finding.commentCreatedAt,
         source: "codex_top_level_review_comment",
+        authorLogin: finding.authorLogin,
       });
     }
   }
 
   const latestStrongCurrentHeadObservedAt = latestTimestamp(currentHeadObservations.map((observation) => observation.observedAt));
   if (!latestStrongCurrentHeadObservedAt) {
-    return { observedAt: null, source: null };
+    return { observedAt: null, source: null, authorLogin: null };
   }
-  const latestStrongCurrentHeadObservation =
-    currentHeadObservations
-      .filter((observation) => observation.observedAt === latestStrongCurrentHeadObservedAt)
-      .at(-1) ?? null;
-  const latestStrongCurrentHeadObservationSource = latestStrongCurrentHeadObservation?.source ?? null;
 
   const latestStrongCurrentHeadObservedAtMs = parseTimestamp(latestStrongCurrentHeadObservedAt);
-  const weaklyAnchoredCodeRabbitCommentTimes = facts.comments.flatMap((comment) => {
+  const weaklyAnchoredCodeRabbitComments = facts.comments.flatMap((comment) => {
     const authorLogin = normalizeLogin(comment.authorLogin);
     return authorLogin &&
       configuredReviewBots.has(authorLogin) &&
       isCodeRabbitLogin(authorLogin) &&
       !comment.originalCommitOid &&
       parseTimestamp(comment.createdAt) >= latestStrongCurrentHeadObservedAtMs
-      ? [comment.createdAt]
+      ? [{ observedAt: comment.createdAt, source: "review_thread_comment" as const, authorLogin }]
       : [];
   });
-  const followUpIssueCommentTimes = facts.issueComments.flatMap((comment) => {
+  const followUpIssueComments = facts.issueComments.flatMap((comment) => {
     const authorLogin = normalizeLogin(comment.authorLogin);
     return authorLogin &&
       configuredReviewBots.has(authorLogin) &&
       hasActionableReviewText(comment.body) &&
       parseTimestamp(comment.createdAt) >= latestStrongCurrentHeadObservedAtMs
-      ? [comment.createdAt]
+      ? [{ observedAt: comment.createdAt, source: "review_thread_comment" as const, authorLogin }]
       : [];
   });
 
+  const observations = [...currentHeadObservations, ...weaklyAnchoredCodeRabbitComments, ...followUpIssueComments];
   const latestObservedAt = latestTimestamp([
     latestStrongCurrentHeadObservedAt,
-    ...weaklyAnchoredCodeRabbitCommentTimes,
-    ...followUpIssueCommentTimes,
+    ...weaklyAnchoredCodeRabbitComments.map((observation) => observation.observedAt),
+    ...followUpIssueComments.map((observation) => observation.observedAt),
   ]);
+  const latestObservation = observations.filter((observation) => observation.observedAt === latestObservedAt).at(-1) ?? null;
 
   return {
     observedAt: latestObservedAt,
-    source: latestObservedAt === latestStrongCurrentHeadObservedAt ? latestStrongCurrentHeadObservationSource : "review_thread_comment",
+    source: latestObservation?.source ?? null,
+    authorLogin: latestObservation?.authorLogin ?? null,
   };
 }
 
@@ -1185,6 +1195,10 @@ export function buildConfiguredBotReviewSummary(
   Object.defineProperty(summary, "latestReviewedCommitSha", {
     enumerable: false,
     value: inferLatestConfiguredBotReviewedCommitSha(facts, reviewBotLogins),
+  });
+  Object.defineProperty(summary, "currentHeadObservationAuthorLogin", {
+    enumerable: false,
+    value: currentHeadObservation.authorLogin,
   });
   Object.defineProperty(summary, "currentHeadActionableObservedAt", {
     enumerable: false,

--- a/src/github/github-review-signals.ts
+++ b/src/github/github-review-signals.ts
@@ -91,6 +91,7 @@ export interface ConfiguredBotReviewSummary {
   currentHeadObservedAt: string | null;
   currentHeadObservationSource: ConfiguredBotCurrentHeadObservationSource;
   currentHeadObservationAuthorLogin?: string | null;
+  currentHeadCodexObservedAt?: string | null;
   currentHeadActionableObservedAt?: string | null;
   currentHeadCodexSuccessReviewedCommitSha?: string | null;
   currentHeadCodexSuccessObservedAt?: string | null;
@@ -689,15 +690,16 @@ function inferConfiguredBotCurrentHeadObservation(
   observedAt: string | null;
   source: ConfiguredBotCurrentHeadObservationSource;
   authorLogin: string | null;
+  codexObservedAt: string | null;
 } {
   const normalizedCurrentHeadOid = currentHeadOid?.trim();
   if (!normalizedCurrentHeadOid) {
-    return { observedAt: null, source: null, authorLogin: null };
+    return { observedAt: null, source: null, authorLogin: null, codexObservedAt: null };
   }
 
   const configuredReviewBots = new Set(normalizeReviewBotLogins(reviewBotLogins));
   if (configuredReviewBots.size === 0) {
-    return { observedAt: null, source: null, authorLogin: null };
+    return { observedAt: null, source: null, authorLogin: null, codexObservedAt: null };
   }
 
   const currentHeadObservations: Array<{
@@ -783,8 +785,14 @@ function inferConfiguredBotCurrentHeadObservation(
 
   const latestStrongCurrentHeadObservedAt = latestTimestamp(currentHeadObservations.map((observation) => observation.observedAt));
   if (!latestStrongCurrentHeadObservedAt) {
-    return { observedAt: null, source: null, authorLogin: null };
+    return { observedAt: null, source: null, authorLogin: null, codexObservedAt: null };
   }
+  const latestCodexCurrentHeadObservedAt = latestTimestamp(
+    currentHeadObservations.flatMap((observation) => {
+      const authorLogin = normalizeLogin(observation.authorLogin);
+      return authorLogin && isCodexConnectorLogin(authorLogin) ? [observation.observedAt] : [];
+    }),
+  );
 
   const latestStrongCurrentHeadObservedAtMs = parseTimestamp(latestStrongCurrentHeadObservedAt);
   const weaklyAnchoredCodeRabbitComments = facts.comments.flatMap((comment) => {
@@ -819,6 +827,7 @@ function inferConfiguredBotCurrentHeadObservation(
     observedAt: latestObservedAt,
     source: latestObservation?.source ?? null,
     authorLogin: latestObservation?.authorLogin ?? null,
+    codexObservedAt: latestCodexCurrentHeadObservedAt,
   };
 }
 
@@ -1199,6 +1208,10 @@ export function buildConfiguredBotReviewSummary(
   Object.defineProperty(summary, "currentHeadObservationAuthorLogin", {
     enumerable: false,
     value: currentHeadObservation.authorLogin,
+  });
+  Object.defineProperty(summary, "currentHeadCodexObservedAt", {
+    enumerable: false,
+    value: currentHeadObservation.codexObservedAt,
   });
   Object.defineProperty(summary, "currentHeadActionableObservedAt", {
     enumerable: false,

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -41,6 +41,7 @@ export interface GitHubPullRequest {
   configuredBotCurrentHeadObservedAt?: string | null;
   configuredBotCurrentHeadObservationSource?: string | null;
   configuredBotCurrentHeadObservationAuthorLogin?: string | null;
+  configuredBotCurrentHeadCodexObservedAt?: string | null;
   configuredBotCurrentHeadActionableObservedAt?: string | null;
   configuredBotCurrentHeadCodexSuccessReviewedCommitSha?: string | null;
   configuredBotCurrentHeadCodexSuccessObservedAt?: string | null;

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -40,6 +40,7 @@ export interface GitHubPullRequest {
   codexConnectorReviewRequestCommentUrl?: string | null;
   configuredBotCurrentHeadObservedAt?: string | null;
   configuredBotCurrentHeadObservationSource?: string | null;
+  configuredBotCurrentHeadObservationAuthorLogin?: string | null;
   configuredBotCurrentHeadActionableObservedAt?: string | null;
   configuredBotCurrentHeadCodexSuccessReviewedCommitSha?: string | null;
   configuredBotCurrentHeadCodexSuccessObservedAt?: string | null;

--- a/src/supervisor/replay-corpus-validation.ts
+++ b/src/supervisor/replay-corpus-validation.ts
@@ -719,6 +719,10 @@ function validatePullRequest(raw: unknown, context: string): ReplayCorpusInputSn
       pullRequest.configuredBotCurrentHeadObservationAuthorLogin,
       `${context} configuredBotCurrentHeadObservationAuthorLogin`,
     ),
+    configuredBotCurrentHeadCodexObservedAt: expectOptionalNullableString(
+      pullRequest.configuredBotCurrentHeadCodexObservedAt,
+      `${context} configuredBotCurrentHeadCodexObservedAt`,
+    ),
     configuredBotCurrentHeadStatusState: expectOptionalNullableString(
       pullRequest.configuredBotCurrentHeadStatusState,
       `${context} configuredBotCurrentHeadStatusState`,

--- a/src/supervisor/replay-corpus-validation.ts
+++ b/src/supervisor/replay-corpus-validation.ts
@@ -715,6 +715,10 @@ function validatePullRequest(raw: unknown, context: string): ReplayCorpusInputSn
       pullRequest.configuredBotCurrentHeadObservationSource,
       `${context} configuredBotCurrentHeadObservationSource`,
     ),
+    configuredBotCurrentHeadObservationAuthorLogin: expectOptionalNullableString(
+      pullRequest.configuredBotCurrentHeadObservationAuthorLogin,
+      `${context} configuredBotCurrentHeadObservationAuthorLogin`,
+    ),
     configuredBotCurrentHeadStatusState: expectOptionalNullableString(
       pullRequest.configuredBotCurrentHeadStatusState,
       `${context} configuredBotCurrentHeadStatusState`,

--- a/src/supervisor/supervisor-active-detailed-status-presenters.ts
+++ b/src/supervisor/supervisor-active-detailed-status-presenters.ts
@@ -296,7 +296,7 @@ export function buildActiveReviewBotProviderLines(
   }
   lines.push(`pr_hydration provenance=${pr.hydrationProvenance ?? "unknown"} head_sha=${pr.headRefOid}`);
   lines.push(
-    `configured_bot_top_level_review ${configuredBotTopLevelReviewSummary(pr)} effect=${configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads)}`,
+    `configured_bot_top_level_review ${configuredBotTopLevelReviewSummary(pr)} effect=${configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads, activeRecord)}`,
   );
   const configuredBotRateLimit = configuredBotRateLimitWaitWindow(config, pr);
   if (configuredBotRateLimit.observedAt) {

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -666,6 +666,23 @@ test("externalSignalReadinessDiagnostics treats current-head Codex nitpick-only 
     "softened",
   );
   assert.deepEqual(
+    reviewBotDiagnostics(
+      createConfig({
+        repoPath,
+        reviewBotLogins: ["chatgpt-codex-connector"],
+      }),
+      createRecord(),
+      pr,
+      [nitpickThread],
+      configuredBotReviewThreads,
+    ),
+    {
+      status: "review_signal_observed",
+      observedReview: "review_thread",
+      nextCheck: "none",
+    },
+  );
+  assert.deepEqual(
     externalSignalReadinessDiagnostics(
       createConfig({
         repoPath,
@@ -681,6 +698,67 @@ test("externalSignalReadinessDiagnostics treats current-head Codex nitpick-only 
       status: "signals_observed",
       ci: "passing",
       review: "signal_observed",
+      workflows: "present",
+    },
+  );
+});
+
+test("externalSignalReadinessDiagnostics keeps Codex nitpick residue blocking before current-head review", async (t) => {
+  const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-codex-nitpick-stale-"));
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+  await fs.mkdir(path.join(repoPath, ".github", "workflows"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, ".github", "workflows", "ci.yml"), "name: CI\n");
+  const config = createConfig({
+    repoPath,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const pr = createPr({
+    configuredBotCurrentHeadObservedAt: null,
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-16T00:10:00Z",
+  });
+  const nitpickThread = createThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-codex-p3-stale",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-16T00:10:00Z",
+          url: "https://example.test/pr/340#discussion_r3",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(
+    configuredBotTopLevelReviewEffect(config, pr, [nitpickThread], configuredBotReviewThreads),
+    "awaiting_thread_resolution",
+  );
+  assert.deepEqual(reviewBotDiagnostics(config, createRecord(), pr, [nitpickThread], configuredBotReviewThreads), {
+    status: "actionable_provider_review",
+    observedReview: "review_thread",
+    nextCheck: "address_review",
+    recentObservation: "unresolved_threads:1",
+  });
+  assert.deepEqual(
+    externalSignalReadinessDiagnostics(
+      config,
+      createRecord(),
+      pr,
+      [{ bucket: "pass" }],
+      [nitpickThread],
+      configuredBotReviewThreads,
+    ),
+    {
+      status: "blocked_by_ci_or_review_feedback",
+      ci: "passing",
+      review: "feedback_present",
       workflows: "present",
     },
   );

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -820,6 +820,65 @@ test("externalSignalReadinessDiagnostics does not soften Codex nitpicks from non
   );
 });
 
+test("externalSignalReadinessDiagnostics softens Codex nitpicks from Codex inline current-head signals", async (t) => {
+  const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-mixed-provider-codex-inline-"));
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+  await fs.mkdir(path.join(repoPath, ".github", "workflows"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, ".github", "workflows", "ci.yml"), "name: CI\n");
+  const config = createConfig({
+    repoPath,
+    reviewBotLogins: ["chatgpt-codex-connector", "coderabbitai[bot]"],
+  });
+  const pr = createPr({
+    configuredBotCurrentHeadObservedAt: "2026-03-16T00:10:00Z",
+    configuredBotCurrentHeadObservationSource: "review_thread_comment",
+    configuredBotCurrentHeadObservationAuthorLogin: "chatgpt-codex-connector",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-16T00:10:00Z",
+  });
+  const nitpickThread = createThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-codex-p3-current-head",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-16T00:10:00Z",
+          url: "https://example.test/pr/340#discussion_r5",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(configuredBotTopLevelReviewEffect(config, pr, [nitpickThread], configuredBotReviewThreads), "softened");
+  assert.deepEqual(reviewBotDiagnostics(config, createRecord(), pr, [nitpickThread], configuredBotReviewThreads), {
+    status: "review_signal_observed",
+    observedReview: "review_thread",
+    nextCheck: "none",
+  });
+  assert.deepEqual(
+    externalSignalReadinessDiagnostics(
+      config,
+      createRecord(),
+      pr,
+      [{ bucket: "pass" }],
+      [nitpickThread],
+      configuredBotReviewThreads,
+    ),
+    {
+      status: "signals_observed",
+      ci: "passing",
+      review: "signal_observed",
+      workflows: "present",
+    },
+  );
+});
+
 test("externalSignalReadinessDiagnostics keeps Codex P3 threads blocking after newer non-Codex replies", async (t) => {
   const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-updated-codex-p3-"));
   t.after(async () => {

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -879,6 +879,122 @@ test("externalSignalReadinessDiagnostics softens Codex nitpicks from Codex inlin
   );
 });
 
+test("externalSignalReadinessDiagnostics preserves earlier Codex current-head evidence after later provider activity", async (t) => {
+  const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-mixed-provider-codex-preserved-"));
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+  await fs.mkdir(path.join(repoPath, ".github", "workflows"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, ".github", "workflows", "ci.yml"), "name: CI\n");
+  const config = createConfig({
+    repoPath,
+    reviewBotLogins: ["chatgpt-codex-connector", "coderabbitai[bot]"],
+  });
+  const pr = createPr({
+    configuredBotCurrentHeadObservedAt: "2026-03-16T00:12:00Z",
+    configuredBotCurrentHeadObservationSource: "status_context",
+    configuredBotCurrentHeadObservationAuthorLogin: "coderabbitai[bot]",
+    configuredBotCurrentHeadCodexObservedAt: "2026-03-16T00:10:00Z",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-16T00:10:00Z",
+  });
+  const nitpickThread = createThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-codex-p3-before-coderabbit",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-16T00:10:00Z",
+          url: "https://example.test/pr/340#discussion_r6",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(configuredBotTopLevelReviewEffect(config, pr, [nitpickThread], configuredBotReviewThreads), "softened");
+  assert.deepEqual(
+    externalSignalReadinessDiagnostics(
+      config,
+      createRecord(),
+      pr,
+      [{ bucket: "pass" }],
+      [nitpickThread],
+      configuredBotReviewThreads,
+    ),
+    {
+      status: "signals_observed",
+      ci: "passing",
+      review: "signal_observed",
+      workflows: "present",
+    },
+  );
+});
+
+test("externalSignalReadinessDiagnostics keeps Codex nitpicks blocking during same-head re-review waits", async (t) => {
+  const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-codex-rereview-wait-"));
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+  await fs.mkdir(path.join(repoPath, ".github", "workflows"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, ".github", "workflows", "ci.yml"), "name: CI\n");
+  const config = createConfig({
+    repoPath,
+    reviewBotLogins: ["chatgpt-codex-connector", "coderabbitai[bot]"],
+  });
+  const record = createRecord({
+    review_wait_started_at: "2026-03-16T00:11:00Z",
+    review_wait_head_sha: "head-sha",
+  });
+  const pr = createPr({
+    configuredBotCurrentHeadObservedAt: "2026-03-16T00:12:00Z",
+    configuredBotCurrentHeadObservationSource: "status_context",
+    configuredBotCurrentHeadObservationAuthorLogin: "coderabbitai[bot]",
+    configuredBotCurrentHeadCodexObservedAt: "2026-03-16T00:10:00Z",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-16T00:10:00Z",
+  });
+  const nitpickThread = createThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-codex-p3-before-rewait",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-16T00:10:00Z",
+          url: "https://example.test/pr/340#discussion_r7",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(
+    configuredBotTopLevelReviewEffect(config, pr, [nitpickThread], configuredBotReviewThreads, record),
+    "awaiting_thread_resolution",
+  );
+  assert.deepEqual(reviewBotDiagnostics(config, record, pr, [nitpickThread], configuredBotReviewThreads), {
+    status: "actionable_provider_review",
+    observedReview: "review_thread",
+    nextCheck: "address_review",
+    recentObservation: "unresolved_threads:1",
+  });
+  assert.deepEqual(
+    externalSignalReadinessDiagnostics(config, record, pr, [{ bucket: "pass" }], [nitpickThread], configuredBotReviewThreads),
+    {
+      status: "blocked_by_ci_or_review_feedback",
+      ci: "passing",
+      review: "feedback_present",
+      workflows: "present",
+    },
+  );
+});
+
 test("externalSignalReadinessDiagnostics keeps Codex P3 threads blocking after newer non-Codex replies", async (t) => {
   const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-updated-codex-p3-"));
   t.after(async () => {
@@ -939,6 +1055,69 @@ test("externalSignalReadinessDiagnostics keeps Codex P3 threads blocking after n
       status: "blocked_by_ci_or_review_feedback",
       ci: "passing",
       review: "feedback_present",
+      workflows: "present",
+    },
+  );
+});
+
+test("externalSignalReadinessDiagnostics softens Codex P3 threads after older human replies", async (t) => {
+  const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-human-before-codex-p3-"));
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+  await fs.mkdir(path.join(repoPath, ".github", "workflows"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, ".github", "workflows", "ci.yml"), "name: CI\n");
+  const config = createConfig({
+    repoPath,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const pr = createPr({
+    configuredBotCurrentHeadObservedAt: "2026-03-16T00:10:00Z",
+    configuredBotCurrentHeadCodexObservedAt: "2026-03-16T00:10:00Z",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-16T00:10:00Z",
+  });
+  const updatedThread = createThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-human-before-codex",
+          body: "Can you check this path?",
+          createdAt: "2026-03-16T00:09:00Z",
+          url: "https://example.test/pr/340#discussion_r8",
+          author: {
+            login: "reviewer",
+            typeName: "User",
+          },
+        },
+        {
+          id: "comment-codex-p3-after-human",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-16T00:10:00Z",
+          url: "https://example.test/pr/340#discussion_r9",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(configuredBotTopLevelReviewEffect(config, pr, [updatedThread], configuredBotReviewThreads), "softened");
+  assert.deepEqual(
+    externalSignalReadinessDiagnostics(
+      config,
+      createRecord(),
+      pr,
+      [{ bucket: "pass" }],
+      [updatedThread],
+      configuredBotReviewThreads,
+    ),
+    {
+      status: "signals_observed",
+      ci: "passing",
+      review: "signal_observed",
       workflows: "present",
     },
   );

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -624,6 +624,118 @@ test("externalSignalReadinessDiagnostics treats blocking configured-bot top-leve
   );
 });
 
+test("externalSignalReadinessDiagnostics treats current-head Codex nitpick-only residue as observed signal", async (t) => {
+  const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-codex-nitpick-"));
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+  await fs.mkdir(path.join(repoPath, ".github", "workflows"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, ".github", "workflows", "ci.yml"), "name: CI\n");
+  const pr = createPr({
+    configuredBotCurrentHeadObservedAt: "2026-03-16T00:10:00Z",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-16T00:10:00Z",
+  });
+  const nitpickThread = createThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-codex-p3",
+          body: "**<sub><sub>![P3 Badge](https://img.shields.io/badge/P3-lightgrey?style=flat)</sub></sub>  Prefer a shorter helper name**\n\nThis is a style-only suggestion.",
+          createdAt: "2026-03-16T00:10:00Z",
+          url: "https://example.test/pr/340#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(
+    configuredBotTopLevelReviewEffect(
+      createConfig({
+        repoPath,
+        reviewBotLogins: ["chatgpt-codex-connector"],
+      }),
+      pr,
+      [nitpickThread],
+      configuredBotReviewThreads,
+    ),
+    "softened",
+  );
+  assert.deepEqual(
+    externalSignalReadinessDiagnostics(
+      createConfig({
+        repoPath,
+        reviewBotLogins: ["chatgpt-codex-connector"],
+      }),
+      createRecord(),
+      pr,
+      [{ bucket: "pass" }],
+      [nitpickThread],
+      configuredBotReviewThreads,
+    ),
+    {
+      status: "signals_observed",
+      ci: "passing",
+      review: "signal_observed",
+      workflows: "present",
+    },
+  );
+});
+
+test("externalSignalReadinessDiagnostics keeps escalated Codex P3 residue blocking", async (t) => {
+  const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-codex-p3-risk-"));
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+  await fs.mkdir(path.join(repoPath, ".github", "workflows"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, ".github", "workflows", "ci.yml"), "name: CI\n");
+  const pr = createPr({
+    configuredBotCurrentHeadObservedAt: "2026-03-16T00:10:00Z",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-16T00:10:00Z",
+  });
+  const riskThread = createThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-codex-p3-risk",
+          body: "P3: Missing verification can cause a regression in the restore path.",
+          createdAt: "2026-03-16T00:10:00Z",
+          url: "https://example.test/pr/340#discussion_r2",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.deepEqual(
+    externalSignalReadinessDiagnostics(
+      createConfig({
+        repoPath,
+        reviewBotLogins: ["chatgpt-codex-connector"],
+      }),
+      createRecord(),
+      pr,
+      [{ bucket: "pass" }],
+      [riskThread],
+      configuredBotReviewThreads,
+    ),
+    {
+      status: "blocked_by_ci_or_review_feedback",
+      ci: "passing",
+      review: "feedback_present",
+      workflows: "present",
+    },
+  );
+});
+
 test("externalSignalReadinessDiagnostics preserves CI repo-readiness gaps after softened review signals arrive", async (t) => {
   const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-softened-review-"));
   t.after(async () => {

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -764,6 +764,127 @@ test("externalSignalReadinessDiagnostics keeps Codex nitpick residue blocking be
   );
 });
 
+test("externalSignalReadinessDiagnostics does not soften Codex nitpicks from non-Codex current-head signals", async (t) => {
+  const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-mixed-provider-nitpick-"));
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+  await fs.mkdir(path.join(repoPath, ".github", "workflows"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, ".github", "workflows", "ci.yml"), "name: CI\n");
+  const config = createConfig({
+    repoPath,
+    reviewBotLogins: ["chatgpt-codex-connector", "coderabbitai[bot]"],
+  });
+  const pr = createPr({
+    configuredBotCurrentHeadObservedAt: "2026-03-16T00:10:00Z",
+    configuredBotCurrentHeadObservationSource: "review_thread_comment",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-16T00:10:00Z",
+  });
+  const nitpickThread = createThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-codex-p3-mixed",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-16T00:10:00Z",
+          url: "https://example.test/pr/340#discussion_r4",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(
+    configuredBotTopLevelReviewEffect(config, pr, [nitpickThread], configuredBotReviewThreads),
+    "awaiting_thread_resolution",
+  );
+  assert.deepEqual(
+    externalSignalReadinessDiagnostics(
+      config,
+      createRecord(),
+      pr,
+      [{ bucket: "pass" }],
+      [nitpickThread],
+      configuredBotReviewThreads,
+    ),
+    {
+      status: "blocked_by_ci_or_review_feedback",
+      ci: "passing",
+      review: "feedback_present",
+      workflows: "present",
+    },
+  );
+});
+
+test("externalSignalReadinessDiagnostics keeps Codex P3 threads blocking after newer non-Codex replies", async (t) => {
+  const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-updated-codex-p3-"));
+  t.after(async () => {
+    await fs.rm(repoPath, { recursive: true, force: true });
+  });
+  await fs.mkdir(path.join(repoPath, ".github", "workflows"), { recursive: true });
+  await fs.writeFile(path.join(repoPath, ".github", "workflows", "ci.yml"), "name: CI\n");
+  const config = createConfig({
+    repoPath,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const pr = createPr({
+    configuredBotCurrentHeadObservedAt: "2026-03-16T00:10:00Z",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    configuredBotTopLevelReviewSubmittedAt: "2026-03-16T00:10:00Z",
+  });
+  const updatedThread = createThread({
+    comments: {
+      nodes: [
+        {
+          id: "comment-codex-p3-before-human",
+          body: "P3: Nitpick: prefer a shorter helper name for readability.",
+          createdAt: "2026-03-16T00:10:00Z",
+          url: "https://example.test/pr/340#discussion_r5",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+        {
+          id: "comment-human-after-codex",
+          body: "This still needs operator attention before merge.",
+          createdAt: "2026-03-16T00:11:00Z",
+          url: "https://example.test/pr/340#discussion_r6",
+          author: {
+            login: "reviewer",
+            typeName: "User",
+          },
+        },
+      ],
+    },
+  });
+
+  assert.equal(
+    configuredBotTopLevelReviewEffect(config, pr, [updatedThread], configuredBotReviewThreads),
+    "awaiting_thread_resolution",
+  );
+  assert.deepEqual(
+    externalSignalReadinessDiagnostics(
+      config,
+      createRecord(),
+      pr,
+      [{ bucket: "pass" }],
+      [updatedThread],
+      configuredBotReviewThreads,
+    ),
+    {
+      status: "blocked_by_ci_or_review_feedback",
+      ci: "passing",
+      review: "feedback_present",
+      workflows: "present",
+    },
+  );
+});
+
 test("externalSignalReadinessDiagnostics keeps escalated Codex P3 residue blocking", async (t) => {
   const repoPath = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-codex-p3-risk-"));
   t.after(async () => {

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -12,6 +12,7 @@ import {
   codexConnectorNitpickTopLevelReviewFindings,
   highestCodexConnectorPSeverity,
 } from "../codex-connector-top-level-review";
+import { codexConnectorNitpickOnlyReviewThreads } from "../codex-connector-review-policy";
 import { classifyStaleReviewBotRecoverability, recoverabilityStatusToken } from "./stale-diagnostic-recoverability";
 import {
   configuredBotCurrentHeadSignalWaitWindow,
@@ -104,6 +105,11 @@ export function configuredReviewStatusLabel(config: SupervisorConfig): string {
 
 function unresolvedReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
   return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
+}
+
+function blockingConfiguredBotReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
+  const nitpickOnlyThreads = new Set(codexConnectorNitpickOnlyReviewThreads(reviewThreads));
+  return reviewThreads.filter((thread) => !nitpickOnlyThreads.has(thread));
 }
 
 function staleProviderSignalObservation(activeRecord: IssueRunRecord, pr: GitHubPullRequest): string | null {
@@ -233,6 +239,7 @@ export function externalSignalReadinessDiagnostics(
   const hasPendingChecks = checks.some((check) => check.bucket === "pending" || check.bucket === "cancel");
   const hasPassingChecks = checks.some((check) => check.bucket === "pass" || check.bucket === "skipping");
   const unresolvedConfiguredThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
+  const blockingConfiguredThreads = blockingConfiguredBotReviewThreads(unresolvedConfiguredThreads);
   const observed = summarizeObservedReviewSignal(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);
   const topLevelReviewEffect = configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads);
   const hasExternalProviderActivity = hasAuthoritativeExternalProviderActivity(
@@ -265,7 +272,7 @@ export function externalSignalReadinessDiagnostics(
         ? "local_review_blocked"
       : configuredBotReviewNotExpectedWhileDraft(config, pr)
         ? "not_expected_while_draft"
-      : unresolvedConfiguredThreads.length > 0 || topLevelReviewEffect === "blocking"
+      : blockingConfiguredThreads.length > 0 || topLevelReviewEffect === "blocking"
         ? "feedback_present"
       : observed.hasSignal || topLevelReviewEffect !== "none"
           ? "signal_observed"
@@ -315,7 +322,8 @@ export function configuredBotTopLevelReviewEffect(
   }
 
   if (pr.configuredBotTopLevelReviewStrength === "nitpick_only") {
-    return unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads)).length === 0
+    const unresolvedConfiguredThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
+    return blockingConfiguredBotReviewThreads(unresolvedConfiguredThreads).length === 0
       ? "softened"
       : "awaiting_thread_resolution";
   }

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -8,6 +8,7 @@ import {
 } from "../core/review-providers";
 import { GitHubPullRequest, IssueRunRecord, ReviewThread, SupervisorConfig } from "../core/types";
 import { localReviewDegradedNeedsBlock } from "../review-handling";
+import { currentHeadTimestampSatisfiesActiveWait } from "../pull-request-state-current-head-policy";
 import {
   codexConnectorMustFixTopLevelReviewFindings,
   codexConnectorNitpickTopLevelReviewFindings,
@@ -120,14 +121,18 @@ function validStatusTimestamp(value: string | null | undefined): string | null {
   return Number.isNaN(Date.parse(value)) ? null : value;
 }
 
-function hasCodexCurrentHeadObservation(config: SupervisorConfig, pr: GitHubPullRequest): boolean {
-  if (!validStatusTimestamp(pr.configuredBotCurrentHeadObservedAt)) {
-    return false;
+function codexCurrentHeadObservedAt(config: SupervisorConfig, pr: GitHubPullRequest): string | null {
+  const codexObservedAt = validStatusTimestamp(pr.configuredBotCurrentHeadCodexObservedAt);
+  if (codexObservedAt) {
+    return codexObservedAt;
   }
-
+  const latestObservedAt = validStatusTimestamp(pr.configuredBotCurrentHeadObservedAt);
+  if (!latestObservedAt) {
+    return null;
+  }
   const providerKinds = configuredReviewProviderKinds(config);
   if (providerKinds.length > 0 && providerKinds.every((kind) => kind === "codex")) {
-    return true;
+    return latestObservedAt;
   }
 
   const observationAuthorLogin = pr.configuredBotCurrentHeadObservationAuthorLogin;
@@ -135,25 +140,37 @@ function hasCodexCurrentHeadObservation(config: SupervisorConfig, pr: GitHubPull
     return (
       pr.configuredBotCurrentHeadObservationSource === "review" ||
       pr.configuredBotCurrentHeadObservationSource === "review_thread_comment"
-    );
+    )
+      ? latestObservedAt
+      : null;
   }
 
   return (
     pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" ||
     pr.configuredBotCurrentHeadObservationSource === "codex_top_level_review_comment"
-  );
+  )
+    ? latestObservedAt
+    : null;
+}
+
+function hasCodexCurrentHeadObservation(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+  activeRecord?: Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha"> | null,
+): boolean {
+  const observedAt = codexCurrentHeadObservedAt(config, pr);
+  if (!observedAt) {
+    return false;
+  }
+
+  return activeRecord ? currentHeadTimestampSatisfiesActiveWait(activeRecord, pr, observedAt) : true;
 }
 
 function latestCommentIsSoftenedCodexP3Thread(thread: ReviewThread): boolean {
   const latestComment = thread.comments.nodes[thread.comments.nodes.length - 1] ?? null;
   const latestLogin = latestComment?.author?.login;
-  const allCommentsAreCodexConnector = thread.comments.nodes.every((comment) => {
-    const login = comment.author?.login;
-    return Boolean(login && isCodexConnectorReviewer(login));
-  });
   return Boolean(
-    allCommentsAreCodexConnector &&
-      latestLogin &&
+    latestLogin &&
       latestComment &&
       isCodexConnectorReviewer(latestLogin) &&
       extractCodexConnectorPSeverity(latestComment.body) === "P3" &&
@@ -165,8 +182,9 @@ function blockingConfiguredBotReviewThreads(
   config: SupervisorConfig,
   pr: GitHubPullRequest,
   reviewThreads: ReviewThread[],
+  activeRecord?: Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha"> | null,
 ): ReviewThread[] {
-  if (!hasCodexCurrentHeadObservation(config, pr)) {
+  if (!hasCodexCurrentHeadObservation(config, pr, activeRecord)) {
     return reviewThreads;
   }
 
@@ -223,8 +241,14 @@ export function reviewBotDiagnostics(
   }
 
   const unresolvedConfiguredThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
-  const blockingConfiguredThreads = blockingConfiguredBotReviewThreads(config, pr, unresolvedConfiguredThreads);
-  const topLevelReviewEffect = configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads);
+  const blockingConfiguredThreads = blockingConfiguredBotReviewThreads(config, pr, unresolvedConfiguredThreads, activeRecord);
+  const topLevelReviewEffect = configuredBotTopLevelReviewEffect(
+    config,
+    pr,
+    reviewThreads,
+    configuredBotReviewThreads,
+    activeRecord,
+  );
   if (blockingConfiguredThreads.length > 0 || topLevelReviewEffect === "blocking") {
     return {
       status: "actionable_provider_review",
@@ -301,9 +325,15 @@ export function externalSignalReadinessDiagnostics(
   const hasPendingChecks = checks.some((check) => check.bucket === "pending" || check.bucket === "cancel");
   const hasPassingChecks = checks.some((check) => check.bucket === "pass" || check.bucket === "skipping");
   const unresolvedConfiguredThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
-  const blockingConfiguredThreads = blockingConfiguredBotReviewThreads(config, pr, unresolvedConfiguredThreads);
+  const blockingConfiguredThreads = blockingConfiguredBotReviewThreads(config, pr, unresolvedConfiguredThreads, activeRecord);
   const observed = summarizeObservedReviewSignal(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);
-  const topLevelReviewEffect = configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads);
+  const topLevelReviewEffect = configuredBotTopLevelReviewEffect(
+    config,
+    pr,
+    reviewThreads,
+    configuredBotReviewThreads,
+    activeRecord,
+  );
   const hasExternalProviderActivity = hasAuthoritativeExternalProviderActivity(
     activeRecord,
     pr,
@@ -370,6 +400,7 @@ export function configuredBotTopLevelReviewEffect(
   pr: GitHubPullRequest,
   reviewThreads: ReviewThread[],
   configuredBotReviewThreads: ReviewThreadClassifier,
+  activeRecord?: Pick<IssueRunRecord, "review_wait_started_at" | "review_wait_head_sha"> | null,
 ): string {
   if (!repoExpectsConfiguredBotReview(config)) {
     return "none";
@@ -385,7 +416,7 @@ export function configuredBotTopLevelReviewEffect(
 
   if (pr.configuredBotTopLevelReviewStrength === "nitpick_only") {
     const unresolvedConfiguredThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
-    return blockingConfiguredBotReviewThreads(config, pr, unresolvedConfiguredThreads).length === 0
+    return blockingConfiguredBotReviewThreads(config, pr, unresolvedConfiguredThreads, activeRecord).length === 0
       ? "softened"
       : "awaiting_thread_resolution";
   }

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import {
   configuredReviewBotLogins,
+  configuredReviewProviderKinds,
   repoExpectsConfiguredBotReview,
   repoUsesCopilotOnlyReviewBot,
 } from "../core/review-providers";
@@ -12,7 +13,11 @@ import {
   codexConnectorNitpickTopLevelReviewFindings,
   highestCodexConnectorPSeverity,
 } from "../codex-connector-top-level-review";
-import { codexConnectorNitpickOnlyReviewThreads } from "../codex-connector-review-policy";
+import {
+  extractCodexConnectorPSeverity,
+  hasCodexConnectorStrongRiskWording,
+  isCodexConnectorReviewer,
+} from "../external-review/external-review-normalization";
 import { classifyStaleReviewBotRecoverability, recoverabilityStatusToken } from "./stale-diagnostic-recoverability";
 import {
   configuredBotCurrentHeadSignalWaitWindow,
@@ -115,13 +120,49 @@ function validStatusTimestamp(value: string | null | undefined): string | null {
   return Number.isNaN(Date.parse(value)) ? null : value;
 }
 
-function blockingConfiguredBotReviewThreads(pr: GitHubPullRequest, reviewThreads: ReviewThread[]): ReviewThread[] {
+function hasCodexCurrentHeadObservation(config: SupervisorConfig, pr: GitHubPullRequest): boolean {
   if (!validStatusTimestamp(pr.configuredBotCurrentHeadObservedAt)) {
+    return false;
+  }
+
+  const providerKinds = configuredReviewProviderKinds(config);
+  if (providerKinds.length > 0 && providerKinds.every((kind) => kind === "codex")) {
+    return true;
+  }
+
+  return (
+    pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" ||
+    pr.configuredBotCurrentHeadObservationSource === "codex_top_level_review_comment"
+  );
+}
+
+function latestCommentIsSoftenedCodexP3Thread(thread: ReviewThread): boolean {
+  const latestComment = thread.comments.nodes[thread.comments.nodes.length - 1] ?? null;
+  const latestLogin = latestComment?.author?.login;
+  const allCommentsAreCodexConnector = thread.comments.nodes.every((comment) => {
+    const login = comment.author?.login;
+    return Boolean(login && isCodexConnectorReviewer(login));
+  });
+  return Boolean(
+    allCommentsAreCodexConnector &&
+      latestLogin &&
+      latestComment &&
+      isCodexConnectorReviewer(latestLogin) &&
+      extractCodexConnectorPSeverity(latestComment.body) === "P3" &&
+      !hasCodexConnectorStrongRiskWording(latestComment.body),
+  );
+}
+
+function blockingConfiguredBotReviewThreads(
+  config: SupervisorConfig,
+  pr: GitHubPullRequest,
+  reviewThreads: ReviewThread[],
+): ReviewThread[] {
+  if (!hasCodexCurrentHeadObservation(config, pr)) {
     return reviewThreads;
   }
 
-  const nitpickOnlyThreads = new Set(codexConnectorNitpickOnlyReviewThreads(reviewThreads));
-  return reviewThreads.filter((thread) => !nitpickOnlyThreads.has(thread));
+  return reviewThreads.filter((thread) => !latestCommentIsSoftenedCodexP3Thread(thread));
 }
 
 function staleProviderSignalObservation(activeRecord: IssueRunRecord, pr: GitHubPullRequest): string | null {
@@ -174,7 +215,7 @@ export function reviewBotDiagnostics(
   }
 
   const unresolvedConfiguredThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
-  const blockingConfiguredThreads = blockingConfiguredBotReviewThreads(pr, unresolvedConfiguredThreads);
+  const blockingConfiguredThreads = blockingConfiguredBotReviewThreads(config, pr, unresolvedConfiguredThreads);
   const topLevelReviewEffect = configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads);
   if (blockingConfiguredThreads.length > 0 || topLevelReviewEffect === "blocking") {
     return {
@@ -252,7 +293,7 @@ export function externalSignalReadinessDiagnostics(
   const hasPendingChecks = checks.some((check) => check.bucket === "pending" || check.bucket === "cancel");
   const hasPassingChecks = checks.some((check) => check.bucket === "pass" || check.bucket === "skipping");
   const unresolvedConfiguredThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
-  const blockingConfiguredThreads = blockingConfiguredBotReviewThreads(pr, unresolvedConfiguredThreads);
+  const blockingConfiguredThreads = blockingConfiguredBotReviewThreads(config, pr, unresolvedConfiguredThreads);
   const observed = summarizeObservedReviewSignal(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);
   const topLevelReviewEffect = configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads);
   const hasExternalProviderActivity = hasAuthoritativeExternalProviderActivity(
@@ -336,7 +377,7 @@ export function configuredBotTopLevelReviewEffect(
 
   if (pr.configuredBotTopLevelReviewStrength === "nitpick_only") {
     const unresolvedConfiguredThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
-    return blockingConfiguredBotReviewThreads(pr, unresolvedConfiguredThreads).length === 0
+    return blockingConfiguredBotReviewThreads(config, pr, unresolvedConfiguredThreads).length === 0
       ? "softened"
       : "awaiting_thread_resolution";
   }

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -107,7 +107,19 @@ function unresolvedReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] 
   return reviewThreads.filter((thread) => !thread.isResolved && !thread.isOutdated);
 }
 
-function blockingConfiguredBotReviewThreads(reviewThreads: ReviewThread[]): ReviewThread[] {
+function validStatusTimestamp(value: string | null | undefined): string | null {
+  if (typeof value !== "string" || value.length === 0) {
+    return null;
+  }
+
+  return Number.isNaN(Date.parse(value)) ? null : value;
+}
+
+function blockingConfiguredBotReviewThreads(pr: GitHubPullRequest, reviewThreads: ReviewThread[]): ReviewThread[] {
+  if (!validStatusTimestamp(pr.configuredBotCurrentHeadObservedAt)) {
+    return reviewThreads;
+  }
+
   const nitpickOnlyThreads = new Set(codexConnectorNitpickOnlyReviewThreads(reviewThreads));
   return reviewThreads.filter((thread) => !nitpickOnlyThreads.has(thread));
 }
@@ -162,15 +174,16 @@ export function reviewBotDiagnostics(
   }
 
   const unresolvedConfiguredThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
+  const blockingConfiguredThreads = blockingConfiguredBotReviewThreads(pr, unresolvedConfiguredThreads);
   const topLevelReviewEffect = configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads);
-  if (unresolvedConfiguredThreads.length > 0 || topLevelReviewEffect === "blocking") {
+  if (blockingConfiguredThreads.length > 0 || topLevelReviewEffect === "blocking") {
     return {
       status: "actionable_provider_review",
-      observedReview: unresolvedConfiguredThreads.length > 0 ? "review_thread" : "top_level_review",
+      observedReview: blockingConfiguredThreads.length > 0 ? "review_thread" : "top_level_review",
       nextCheck: "address_review",
       recentObservation:
-        unresolvedConfiguredThreads.length > 0
-          ? `unresolved_threads:${unresolvedConfiguredThreads.length}`
+        blockingConfiguredThreads.length > 0
+          ? `unresolved_threads:${blockingConfiguredThreads.length}`
           : `top_level_review:${pr.configuredBotTopLevelReviewSubmittedAt ?? "unknown"}`,
     };
   }
@@ -239,7 +252,7 @@ export function externalSignalReadinessDiagnostics(
   const hasPendingChecks = checks.some((check) => check.bucket === "pending" || check.bucket === "cancel");
   const hasPassingChecks = checks.some((check) => check.bucket === "pass" || check.bucket === "skipping");
   const unresolvedConfiguredThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
-  const blockingConfiguredThreads = blockingConfiguredBotReviewThreads(unresolvedConfiguredThreads);
+  const blockingConfiguredThreads = blockingConfiguredBotReviewThreads(pr, unresolvedConfiguredThreads);
   const observed = summarizeObservedReviewSignal(config, activeRecord, pr, reviewThreads, configuredBotReviewThreads);
   const topLevelReviewEffect = configuredBotTopLevelReviewEffect(config, pr, reviewThreads, configuredBotReviewThreads);
   const hasExternalProviderActivity = hasAuthoritativeExternalProviderActivity(
@@ -323,7 +336,7 @@ export function configuredBotTopLevelReviewEffect(
 
   if (pr.configuredBotTopLevelReviewStrength === "nitpick_only") {
     const unresolvedConfiguredThreads = unresolvedReviewThreads(configuredBotReviewThreads(config, reviewThreads));
-    return blockingConfiguredBotReviewThreads(unresolvedConfiguredThreads).length === 0
+    return blockingConfiguredBotReviewThreads(pr, unresolvedConfiguredThreads).length === 0
       ? "softened"
       : "awaiting_thread_resolution";
   }

--- a/src/supervisor/supervisor-status-review-bot.ts
+++ b/src/supervisor/supervisor-status-review-bot.ts
@@ -130,6 +130,14 @@ function hasCodexCurrentHeadObservation(config: SupervisorConfig, pr: GitHubPull
     return true;
   }
 
+  const observationAuthorLogin = pr.configuredBotCurrentHeadObservationAuthorLogin;
+  if (observationAuthorLogin && isCodexConnectorReviewer(observationAuthorLogin)) {
+    return (
+      pr.configuredBotCurrentHeadObservationSource === "review" ||
+      pr.configuredBotCurrentHeadObservationSource === "review_thread_comment"
+    );
+  }
+
   return (
     pr.configuredBotCurrentHeadObservationSource === "codex_pr_success_comment" ||
     pr.configuredBotCurrentHeadObservationSource === "codex_top_level_review_comment"


### PR DESCRIPTION
## Summary

Treat Codex Connector P3 nitpick-only unresolved review threads as non-blocking in supervisor status diagnostics, matching the existing final auto-merge guard behavior.

Closes #2431.

## Root Cause

`externalSignalReadinessDiagnostics` counted any unresolved configured-bot thread as `feedback_present`, while Codex Connector convergence and final auto-merge guard logic already classify softened P3 nitpick-only residue as non-blocking. That could produce mixed status lines such as `ready_to_merge` plus `blocked_by_ci_or_review_feedback` for the same PR facts.

## Changes

- Added a blocking-thread filter that excludes Codex Connector nitpick-only review threads.
- Reused that filter for external signal readiness and nitpick-only top-level review effect reporting.
- Added regression coverage for current-head Codex nitpick-only residue becoming `signals_observed`.
- Added guard coverage that escalated P3 risk wording still remains blocking feedback.

## Verification

- `npx tsx --test src/supervisor/supervisor-status-review-bot.test.ts`
- `npx tsx --test src/supervisor/supervisor-status-rendering-supervisor-review-bot.test.ts src/supervisor/supervisor-status-model-supervisor.test.ts src/supervisor/supervisor-status-model.test.ts src/supervisor/supervisor-status-rendering.test.ts`
- `npm run verify:supervisor-pre-pr`

Note: `verify:supervisor-pre-pr` initially failed because host-local `supervisor.config.*.json` files contain `/Users/...` paths. I temporarily stashed only those local config changes, reran the standard verification successfully, then restored the config changes. Those config files are not included in this PR.