### PR TITLE
Treat Codex nitpick-only convergence as no-major

### DIFF
--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -468,14 +468,16 @@ export function hasActualCurrentHeadCodexNoMajorSupport(args: {
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
 }): boolean {
+  const currentHeadCodexObservedAt = validTimestamp(args.pr.configuredBotCurrentHeadCodexObservedAt);
   const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(
     args.config,
     args.pr,
     configuredBotReviewThreads(args.config, args.reviewThreads),
   );
   if (
+    currentHeadCodexObservedAt &&
     (codexConnectorPolicy?.outcome === "converged" || codexConnectorPolicy?.outcome === "nitpick_only") &&
-    currentHeadTimestampSatisfiesActiveWait(args.record, args.pr, codexConnectorPolicy.currentHeadObservedAt)
+    currentHeadTimestampSatisfiesActiveWait(args.record, args.pr, currentHeadCodexObservedAt)
   ) {
     return true;
   }

--- a/src/pull-request-state-codex-residue-policy.ts
+++ b/src/pull-request-state-codex-residue-policy.ts
@@ -468,6 +468,18 @@ export function hasActualCurrentHeadCodexNoMajorSupport(args: {
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
 }): boolean {
+  const codexConnectorPolicy = evaluateCodexConnectorConvergencePolicy(
+    args.config,
+    args.pr,
+    configuredBotReviewThreads(args.config, args.reviewThreads),
+  );
+  if (
+    (codexConnectorPolicy?.outcome === "converged" || codexConnectorPolicy?.outcome === "nitpick_only") &&
+    currentHeadTimestampSatisfiesActiveWait(args.record, args.pr, codexConnectorPolicy.currentHeadObservedAt)
+  ) {
+    return true;
+  }
+
   if (
     hasFreshCurrentHeadCodexSuccessReviewedCommit(args.pr, args.reviewThreads) &&
     currentHeadTimestampSatisfiesActiveWait(

--- a/src/pull-request-state-policy.test.ts
+++ b/src/pull-request-state-policy.test.ts
@@ -31,6 +31,7 @@ import {
 import { codexConnectorTopLevelReviewFindingRetryTarget } from "./codex-connector-top-level-review";
 import {
   currentHeadRepairProofSatisfiesConfiguredProviderSignal,
+  hasActualCurrentHeadCodexNoMajorSupport,
   hasConfiguredProviderSuccess,
   hasVerifiedCurrentHeadRepairReviewMetadataResidue,
 } from "./pull-request-state-codex-residue-policy";
@@ -932,6 +933,54 @@ test("verified current-head repair residue evidence can replace Codex no-major e
   );
   assert.equal(inferStateFromPullRequest(config, record, pr, scenario.passingChecks, []), "ready_to_merge");
   assert.equal(inferGitHubWaitStep(config, record, pr, scenario.passingChecks, []), null);
+});
+
+test("Codex convergence no-major support requires a Codex-owned current-head observation", () => {
+  const config = createConfig({
+    reviewBotLogins: [CODEX_CONNECTOR_REVIEW_BOT_LOGIN, "coderabbitai"],
+    configuredBotRequireCurrentHeadSignal: true,
+    codexConnectorAutoMergeEnabled: true,
+  });
+  const record = createRecord({
+    state: "ready_to_merge",
+    last_head_sha: "head-codex-gated",
+    provider_success_head_sha: "head-codex-gated",
+    provider_success_observed_at: "2026-03-13T06:30:00Z",
+    review_wait_started_at: "2026-03-13T06:20:00Z",
+    review_wait_head_sha: "head-codex-gated",
+  });
+  const aggregateOnlyPr = createPullRequest({
+    headRefOid: "head-codex-gated",
+    configuredBotCurrentHeadObservedAt: "2026-03-13T06:30:00Z",
+    configuredBotCurrentHeadObservationAuthorLogin: "coderabbitai",
+    configuredBotCurrentHeadObservationSource: "review_thread_comment",
+    configuredBotCurrentHeadCodexObservedAt: null,
+  });
+  const codexObservedPr = createPullRequest({
+    ...aggregateOnlyPr,
+    configuredBotCurrentHeadCodexObservedAt: "2026-03-13T06:31:00Z",
+  });
+
+  assert.equal(
+    hasActualCurrentHeadCodexNoMajorSupport({
+      config,
+      record,
+      pr: aggregateOnlyPr,
+      checks: passingChecks(),
+      reviewThreads: [],
+    }),
+    false,
+  );
+  assert.equal(
+    hasActualCurrentHeadCodexNoMajorSupport({
+      config,
+      record,
+      pr: codexObservedPr,
+      checks: passingChecks(),
+      reviewThreads: [],
+    }),
+    true,
+  );
 });
 
 test("thread-scoped current-head verification artifact proves repaired Codex P2 residue", () => {

--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -1575,6 +1575,8 @@ test("handlePostTurnMergeAndCompletion blocks auto-merge when required check evi
   assert.equal(result.state, "blocked");
   assert.equal(result.blocked_reason, "verification");
   assert.equal(result.last_failure_context?.signature, "auto-merge-refused:head-122:required_checks_missing");
+  assert.equal(result.last_error, "Final auto-merge guard refused PR #122.");
+  assert.equal(result.last_auto_merge_guard_context?.summary, "Final auto-merge guard evaluated PR #122.");
   assert.equal(autoMergeCalls, 0);
 });
 
@@ -1681,6 +1683,144 @@ test("handlePostTurnMergeAndCompletion uses effective Codex thread blockers at t
   assert.equal(result.state, "merging");
   assert.equal(result.last_auto_merge_guard_context?.details.includes("configured_bot_blockers=0"), true);
   assert.equal(autoMergeCalls, 1);
+});
+
+test("handlePostTurnMergeAndCompletion accepts current-head Codex nitpick-only convergence as no-major evidence", async () => {
+  const fixture = await createSupervisorFixture();
+  const config = createConfig({
+    ...fixture.config,
+    codexConnectorAutoMergeEnabled: true,
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    localCiCommand: "npm run verify:pre-pr",
+  });
+  const issueNumber = 2433;
+  const headSha = "head-codex-nitpick-only";
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: {
+      [String(issueNumber)]: createRecord({
+        issue_number: issueNumber,
+        state: "ready_to_merge",
+        last_head_sha: headSha,
+        provider_success_observed_at: "2026-03-13T06:30:00Z",
+        provider_success_head_sha: headSha,
+        review_wait_started_at: "2026-03-13T06:20:00Z",
+        review_wait_head_sha: headSha,
+        blocked_reason: null,
+        last_error: null,
+        last_failure_context: null,
+        last_failure_signature: null,
+        latest_local_ci_result: {
+          outcome: "passed",
+          summary: "Configured local CI command passed before auto-merging PR #254.",
+          ran_at: "2026-03-13T06:32:00Z",
+          head_sha: headSha,
+          execution_mode: "shell",
+          command: "npm run verify:pre-pr",
+          failure_class: null,
+          remediation_target: null,
+        },
+      }),
+    },
+  };
+  const issue: GitHubIssue = {
+    number: issueNumber,
+    title: "Auto-merge Codex nitpick-only convergence",
+    body: "",
+    createdAt: "2026-03-13T00:00:00Z",
+    updatedAt: "2026-03-13T00:00:00Z",
+    url: `https://example.test/issues/${issueNumber}`,
+    state: "OPEN",
+  };
+  const pr: GitHubPullRequest = {
+    number: 254,
+    title: "Codex nitpick-only ready PR",
+    url: "https://example.test/pr/254",
+    state: "OPEN",
+    createdAt: "2026-03-13T06:20:00Z",
+    isDraft: false,
+    reviewDecision: null,
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+    headRefName: "codex/issue-249",
+    headRefOid: headSha,
+    mergedAt: null,
+    configuredBotCurrentHeadObservedAt: "2026-03-13T06:30:00Z",
+    configuredBotCurrentHeadObservationSource: "review_thread_comment",
+    configuredBotTopLevelReviewStrength: "nitpick_only",
+    currentHeadCiGreenAt: "2026-03-13T06:31:00Z",
+  };
+  const nitpickCodexThread: ReviewThread = {
+    id: "thread-codex-nitpick-only",
+    isResolved: false,
+    isOutdated: false,
+    path: "src/file.ts",
+    line: 12,
+    comments: {
+      nodes: [
+        {
+          id: "comment-codex-nitpick-only",
+          body: "P3: Nitpick: Preserve success styling for completed jobs.",
+          createdAt: "2026-03-13T06:30:00Z",
+          url: "https://example.test/pr/254#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  };
+
+  let autoMergeCalls = 0;
+  const comments: Array<{ issueNumber: number; body: string }> = [];
+  const supervisor = new Supervisor(config);
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    getPullRequest: async (prNumber: number) => {
+      assert.equal(prNumber, 254);
+      return pr;
+    },
+    getChecks: async (prNumber: number) => {
+      assert.equal(prNumber, 254);
+      return passingChecks("Minimal checks");
+    },
+    getUnresolvedReviewThreads: async (prNumber: number) => {
+      assert.equal(prNumber, 254);
+      return [nitpickCodexThread];
+    },
+    addIssueComment: async (commentIssueNumber: number, body: string) => {
+      comments.push({ issueNumber: commentIssueNumber, body });
+    },
+    enableAutoMerge: async (prNumber: number, mergeHeadSha: string) => {
+      assert.equal(prNumber, 254);
+      assert.equal(mergeHeadSha, headSha);
+      autoMergeCalls += 1;
+    },
+  };
+
+  const result = await (
+    supervisor as unknown as {
+      handlePostTurnMergeAndCompletion: (
+        state: SupervisorStateFile,
+        issue: GitHubIssue,
+        record: ReturnType<typeof createRecord>,
+        pr: GitHubPullRequest,
+        options: { dryRun: boolean },
+      ) => Promise<ReturnType<typeof createRecord>>;
+    }
+  ).handlePostTurnMergeAndCompletion(state, issue, state.issues[String(issueNumber)]!, pr, { dryRun: false });
+
+  assert.equal(result.state, "merging");
+  assert.equal(result.blocked_reason, null);
+  assert.equal(result.last_error, null);
+  assert.equal(result.last_failure_context, null);
+  assert.equal(result.last_failure_signature, null);
+  assert.equal(result.last_auto_merge_guard_context?.details.includes("codex_current_head_no_major=yes"), true);
+  assert.equal(result.last_auto_merge_guard_context?.details.includes("codex_current_head_merge_proof=connector_no_major"), true);
+  assert.equal(result.last_auto_merge_guard_context?.details.includes("configured_bot_blockers=0"), true);
+  assert.equal(result.last_auto_merge_guard_context?.details.includes("local_ci=passed head_sha=head-codex-nitpick-only"), true);
+  assert.equal(autoMergeCalls, 1);
+  assert.equal(comments.length, 1);
 });
 
 test("handlePostTurnMergeAndCompletion blocks Codex auto-merge on aggregate human review decisions", async () => {

--- a/src/supervisor/supervisor-pr-readiness.test.ts
+++ b/src/supervisor/supervisor-pr-readiness.test.ts
@@ -1746,6 +1746,7 @@ test("handlePostTurnMergeAndCompletion accepts current-head Codex nitpick-only c
     headRefOid: headSha,
     mergedAt: null,
     configuredBotCurrentHeadObservedAt: "2026-03-13T06:30:00Z",
+    configuredBotCurrentHeadCodexObservedAt: "2026-03-13T06:30:00Z",
     configuredBotCurrentHeadObservationSource: "review_thread_comment",
     configuredBotTopLevelReviewStrength: "nitpick_only",
     currentHeadCiGreenAt: "2026-03-13T06:31:00Z",

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -221,10 +221,13 @@ interface FinalAutoMergeGuardResult {
   refusal: FailureContext | null;
 }
 
-function buildAutoMergeEvidenceContext(details: string[], pr: GitHubPullRequest): FailureContext {
+function buildAutoMergeEvidenceContext(details: string[], pr: GitHubPullRequest, outcome: "passed" | "refused"): FailureContext {
   return {
     category: null,
-    summary: `Final auto-merge guard passed for PR #${pr.number}.`,
+    summary:
+      outcome === "passed"
+        ? `Final auto-merge guard passed for PR #${pr.number}.`
+        : `Final auto-merge guard evaluated PR #${pr.number}.`,
     signature: `auto-merge-ready:${pr.headRefOid}`,
     command: null,
     details,
@@ -348,14 +351,13 @@ function finalAutoMergeGuard(args: {
     localCiMissing ? "missing_current_head_local_ci_success" : null,
   ].filter((detail): detail is string => detail !== null);
 
-  const evidence = buildAutoMergeEvidenceContext(evidenceDetails, currentPr);
-
   if (details.length === 0) {
+    const evidence = buildAutoMergeEvidenceContext(evidenceDetails, currentPr, "passed");
     return { evidence, refusal: null };
   }
 
   return {
-    evidence,
+    evidence: buildAutoMergeEvidenceContext(evidenceDetails, currentPr, "refused"),
     refusal: buildAutoMergeRefusalContext(
       `Final auto-merge guard refused PR #${currentPr.number}.`,
       details,


### PR DESCRIPTION
## Summary
- Fixes #2433
- Treat current-head Codex Connector `converged` and `nitpick_only` convergence as actual no-major support once the active same-head wait is satisfied
- Make final auto-merge refusal evidence say the guard evaluated the PR instead of reporting a passed summary
- Add a regression covering current-head Codex nitpick-only convergence reaching auto-merge

## Verification
- `rtk npx tsx --test src/supervisor/supervisor-pr-readiness.test.ts`
- `rtk npx tsx --test src/pull-request-state-policy.test.ts src/review-thread-reporting.test.ts`
- `rtk git diff --check -- src/pull-request-state-codex-residue-policy.ts src/supervisor/supervisor.ts src/supervisor/supervisor-pr-readiness.test.ts`
- `rtk npm run verify:supervisor-pre-pr`
