### PR TITLE
Resolve Codex CLI through PATH after desktop app rename

### DIFF
--- a/docs/examples/atlaspm.md
+++ b/docs/examples/atlaspm.md
@@ -12,7 +12,7 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
   "workspaceRoot": "/Users/yourname/Dev/atlaspm-worktrees",
   "stateBackend": "json",
   "stateFile": "/Users/yourname/Dev/codex-supervisor/.local/state.json",
-  "codexBinary": "/Applications/Codex.app/Contents/Resources/codex",
+  "codexBinary": "codex",
   "codexModelStrategy": "inherit",
   "codexModel": "",
   "boundedRepairModelStrategy": "",

--- a/docs/examples/atlaspm.supervisor.config.example.json
+++ b/docs/examples/atlaspm.supervisor.config.example.json
@@ -5,7 +5,7 @@
   "workspaceRoot": "/Users/yourname/Dev/atlaspm-worktrees",
   "stateBackend": "json",
   "stateFile": "/Users/yourname/Dev/codex-supervisor/.local/state.json",
-  "codexBinary": "/Applications/Codex.app/Contents/Resources/codex",
+  "codexBinary": "codex",
   "codexModelStrategy": "inherit",
   "codexModel": "",
   "boundedRepairModelStrategy": "",

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1937,12 +1937,39 @@ test("shipped CodeRabbit starter profile uses a fail-fast repoSlug placeholder",
   assertCodeRabbitStarterRepoSlugPlaceholder(raw);
 });
 
+test("shipped Codex profiles and AtlasPM examples resolve codexBinary through PATH", async () => {
+  const rootDir = path.resolve(__dirname, "..");
+  const jsonPaths = [
+    "supervisor.config.codex.json",
+    "supervisor.config.coderabbit.json",
+    path.join("docs", "examples", "atlaspm.supervisor.config.example.json"),
+  ];
+
+  for (const relativePath of jsonPaths) {
+    const raw = await readShippedProfileJson(rootDir, relativePath);
+    assert.equal(
+      raw.codexBinary,
+      "codex",
+      `${relativePath} should resolve the Codex CLI through PATH`,
+    );
+  }
+
+  const markdownPath = path.join(rootDir, "docs", "examples", "atlaspm.md");
+  const markdown = await fs.readFile(markdownPath, "utf8");
+  assert.match(markdown, /"codexBinary": "codex"/u);
+  assert.doesNotMatch(
+    markdown,
+    /\/Applications\/(?:Codex|ChatGPT)\.app\/Contents\/Resources\/codex/u,
+    "the AtlasPM example should not pin the Codex CLI to a desktop application bundle",
+  );
+});
+
 test("shipped starter profiles fail closed with first-run placeholder guidance", async () => {
   const rootDir = path.resolve(__dirname, "..");
   const expectedInvalidFields = new Map<string, string[]>([
     ["supervisor.config.example.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
     ["supervisor.config.copilot.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
-    ["supervisor.config.codex.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
+    ["supervisor.config.codex.json", ["repoPath", "repoSlug", "workspaceRoot"]],
     ["supervisor.config.coderabbit.json", ["repoSlug"]],
     ["supervisor.config.typescript-node.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],
     ["supervisor.config.nextjs.json", ["repoPath", "repoSlug", "workspaceRoot", "codexBinary"]],

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -110,6 +110,52 @@ test("diagnoseSupervisorHost reports representative auth, state, and workspace f
   );
 });
 
+test("diagnoseSupervisorHost resolves bare Codex commands on PATH and reports missing commands", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const stateFile = path.join(root, "state.json");
+  await fs.mkdir(repoPath, { recursive: true });
+  await fs.mkdir(workspaceRoot, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+
+  const diagnose = (codexBinary: string) => diagnoseSupervisorHost({
+    config: createConfig({
+      repoPath,
+      workspaceRoot,
+      stateFile,
+      codexBinary,
+    }),
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => ({ activeIssueNumber: null, issues: {} }),
+    github: {
+      getCandidateDiscoveryDiagnostics: async () => ({
+        fetchWindow: 250,
+        observedMatchingOpenIssues: 0,
+        truncated: false,
+      }),
+    },
+  });
+
+  const resolved = await diagnose("node");
+  const resolvedCheck = resolved.checks.find((check) => check.name === "codex_cli");
+  assert.equal(resolvedCheck?.status, "pass");
+  assert.match(resolvedCheck?.summary ?? "", /^Resolved node on PATH: /u);
+
+  const missingCommand = `codex-supervisor-missing-command-${process.pid}`;
+  const missing = await diagnose(missingCommand);
+  const missingCheck = missing.checks.find((check) => check.name === "codex_cli");
+  assert.equal(missingCheck?.status, "fail");
+  assert.equal(
+    missingCheck?.summary,
+    `Configured Codex binary was not found on PATH: ${missingCommand}`,
+  );
+});
+
 test("renderDoctorReport surfaces explicit release publication gate posture", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
   t.after(async () => {

--- a/supervisor.config.codex.json
+++ b/supervisor.config.codex.json
@@ -6,7 +6,7 @@
   "stateBackend": "json",
   "stateFile": "./.local/state.json",
   "stateBootstrapFile": "",
-  "codexBinary": "/absolute/path/to/codex",
+  "codexBinary": "codex",
   "trustMode": "trusted_repo_and_authors",
   "executionSafetyMode": "unsandboxed_autonomous",
   "codexModelStrategy": "inherit",


### PR DESCRIPTION
## Summary

- make the shipped Codex Connector profile and AtlasPM examples resolve `codexBinary` through PATH
- remove the obsolete dependency on `/Applications/Codex.app/Contents/Resources/codex`
- add regression coverage for portable shipped profile/example values
- cover doctor behavior for both PATH-resolved and missing bare commands

## Why

The updated macOS desktop app is installed as `ChatGPT.app`, so configurations that pin the former `Codex.app` bundle path fail even though the bundled `codex` CLI remains available on PATH. Using `"codex"` preserves the existing CLI contract while decoupling codex-supervisor from desktop bundle names.

The Codex Connector starter profile remains fail-closed on its repository/workspace placeholders; only the executable placeholder becomes the portable PATH command.

## User impact

Operators can keep using the Codex CLI bundled with the renamed ChatGPT desktop app without rewriting an application-specific absolute path. Explicit absolute and relative executable paths remain supported.

## Validation

- `npm run verify:supervisor-pre-pr` — passed
  - workstation path verification passed
  - subprocess safety verification passed
  - TypeScript production build passed
- `npx tsx --test src/config.test.ts src/doctor.test.ts` — 145 passed
- live doctor smoke — `Resolved codex on PATH: /Applications/ChatGPT.app/Contents/Resources/codex`
- stale bundle-path repository scan — no matches

## Baseline test note

The full suite reached 2843/2845 passing. The two remaining failures are existing `recovery-blocked-issue-reconciliation.test.ts` expectations and reproduce unchanged in a clean `origin/main` worktree (55/57 in that file). They are outside this PR's config/example/doctor scope.

Fixes #2436