### PR TITLE
Add capability-aware GPT-5.6 max reasoning support

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -675,6 +675,9 @@ Practical rule of thumb:
 - use `inherit` unless you have a strong reason not to
 - leave `boundedRepairModelStrategy` unset unless you intentionally want smaller models for repair turns
 - reserve `xhigh` for escalation paths rather than using it everywhere
+- reasoning escalation follows `none < low < medium < high < xhigh < max`
+- `max` is currently emitted only for `gpt-5.6-sol`; unsupported models fall back to `xhigh`, while GPT-5 Pro remains capped at `high`
+- `status` and `doctor` report the requested and effective efforts when capability clamping changes the request
 
 ## Operator Dashboard
 

--- a/src/codex/codex-model-policy.ts
+++ b/src/codex/codex-model-policy.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { resolveCodexExecutionPolicy } from "./codex-policy";
-import { CodexExecutionTarget, CodexModelStrategy, IssueRunRecord, RunState, SupervisorConfig } from "../core/types";
+import { CodexExecutionTarget, CodexModelStrategy, IssueRunRecord, ReasoningEffort, RunState, SupervisorConfig } from "../core/types";
 
 export interface HostCodexDefaultModelResolution {
   model: string | null;
@@ -30,7 +30,8 @@ export interface CodexModelPolicySnapshot {
   activeRoute: CodexModelRouteResolution & {
     state: RunState;
     target: CodexExecutionTarget;
-    reasoningEffort: string;
+    requestedReasoningEffort: ReasoningEffort;
+    reasoningEffort: ReasoningEffort;
   };
 }
 
@@ -220,28 +221,26 @@ export async function buildCodexModelPolicySnapshot(args: {
   const activeTarget: CodexExecutionTarget = args.activeState === "local_review"
     ? "local_review_generic"
     : "supervisor";
-  const activePolicy = resolveCodexExecutionPolicy(args.config, args.activeState, args.activeRecord, activeTarget);
-  const activeRoute =
+  const activeBaseRoute =
     args.activeState === "repairing_ci" || args.activeState === "addressing_review"
-      ? {
-        ...boundedRepairRoute,
-        state: args.activeState,
-        target: activeTarget,
-        reasoningEffort: activePolicy.reasoningEffort,
-      }
+      ? boundedRepairRoute
       : args.activeState === "local_review"
-      ? {
-        ...localReviewRoute,
-        state: args.activeState,
-        target: activeTarget,
-        reasoningEffort: activePolicy.reasoningEffort,
-      }
-      : {
-        ...defaultRoute,
-        state: args.activeState,
-        target: activeTarget,
-        reasoningEffort: activePolicy.reasoningEffort,
-      };
+      ? localReviewRoute
+      : defaultRoute;
+  const activePolicy = resolveCodexExecutionPolicy(
+    args.config,
+    args.activeState,
+    args.activeRecord,
+    activeTarget,
+    { inheritedModel: hostDefault.model },
+  );
+  const activeRoute = {
+    ...activeBaseRoute,
+    state: args.activeState,
+    target: activeTarget,
+    requestedReasoningEffort: activePolicy.requestedReasoningEffort ?? activePolicy.reasoningEffort,
+    reasoningEffort: activePolicy.reasoningEffort,
+  };
 
   return {
     hostDefault,
@@ -257,12 +256,16 @@ export function renderDoctorCodexModelPolicyLines(snapshot: CodexModelPolicySnap
     `doctor_codex_model_policy default=${summarizeRoute(snapshot.defaultRoute)}`,
     `doctor_codex_route_overrides repair=${summarizeRoute(snapshot.boundedRepairRoute)} local_review=${summarizeRoute(snapshot.localReviewRoute)}`,
     `doctor_codex_host_default model=${snapshot.hostDefault.model ?? "unresolved"} source=${snapshot.hostDefault.source ?? "unresolved"}`,
+    `doctor_codex_reasoning active=${snapshot.activeRoute.target} requested=${snapshot.activeRoute.requestedReasoningEffort} effective=${snapshot.activeRoute.reasoningEffort}`,
   ];
 }
 
 export function renderStatusCodexModelPolicyLines(snapshot: CodexModelPolicySnapshot): string[] {
+  const requestedSuffix = snapshot.activeRoute.requestedReasoningEffort === snapshot.activeRoute.reasoningEffort
+    ? ""
+    : ` requested_reasoning=${snapshot.activeRoute.requestedReasoningEffort}`;
   return [
-    `codex_execution_policy active=${snapshot.activeRoute.target}:${summarizeRoute(snapshot.activeRoute)} reasoning=${snapshot.activeRoute.reasoningEffort}`,
+    `codex_execution_policy active=${snapshot.activeRoute.target}:${summarizeRoute(snapshot.activeRoute)} reasoning=${snapshot.activeRoute.reasoningEffort}${requestedSuffix}`,
     `codex_route_overrides repair=${summarizeRoute(snapshot.boundedRepairRoute)} local_review=${summarizeRoute(snapshot.localReviewRoute)}`,
   ];
 }

--- a/src/codex/codex-policy.test.ts
+++ b/src/codex/codex-policy.test.ts
@@ -178,3 +178,65 @@ test("resolveCodexExecutionPolicy escalates only an unconsumed stable Codex Conn
     },
   );
 });
+
+test("resolveCodexExecutionPolicy escalates xhigh to max for GPT-5.6 Sol", () => {
+  const config = createConfig({
+    codexModel: "gpt-5.6-sol",
+    codexReasoningEffortByState: { implementing: "xhigh" },
+  });
+
+  assert.deepEqual(
+    resolveCodexExecutionPolicy(config, "implementing", {
+      repeated_failure_signature_count: 1,
+      blocked_verification_retry_count: 0,
+      timeout_retry_count: 0,
+    }),
+    {
+      model: "gpt-5.6-sol",
+      reasoningEffort: "max",
+    },
+  );
+});
+
+test("resolveCodexExecutionPolicy clamps max to each model family's highest supported effort", () => {
+  const maxConfig = {
+    codexReasoningEffortByState: { implementing: "max" as const },
+  };
+
+  assert.deepEqual(resolveCodexExecutionPolicy(createConfig(maxConfig), "implementing"), {
+    model: "gpt-5-codex",
+    reasoningEffort: "xhigh",
+    requestedReasoningEffort: "max",
+  });
+  assert.deepEqual(
+    resolveCodexExecutionPolicy(createConfig({ ...maxConfig, codexModel: "gpt-5-pro" }), "implementing"),
+    {
+      model: "gpt-5-pro",
+      reasoningEffort: "high",
+      requestedReasoningEffort: "max",
+    },
+  );
+});
+
+test("resolveCodexExecutionPolicy applies inherited host-model capabilities without forcing a model override", () => {
+  const config = createConfig({
+    codexModelStrategy: "inherit",
+    codexModel: undefined,
+    codexReasoningEffortByState: { implementing: "max" },
+  });
+
+  assert.deepEqual(
+    resolveCodexExecutionPolicy(config, "implementing", undefined, "supervisor", {
+      inheritedModel: "gpt-5.6-sol",
+    }),
+    {
+      model: null,
+      reasoningEffort: "max",
+    },
+  );
+  assert.deepEqual(resolveCodexExecutionPolicy(config, "implementing"), {
+    model: null,
+    reasoningEffort: "xhigh",
+    requestedReasoningEffort: "max",
+  });
+});

--- a/src/codex/codex-policy.test.ts
+++ b/src/codex/codex-policy.test.ts
@@ -177,6 +177,26 @@ test("resolveCodexExecutionPolicy escalates only an unconsumed stable Codex Conn
       reasoningEffort: "medium",
     },
   );
+  assert.deepEqual(
+    resolveCodexExecutionPolicy(
+      createConfig({
+        codexModel: "gpt-5.6-sol",
+        codexReasoningEffortByState: { addressing_review: "max" },
+      }),
+      "addressing_review",
+      {
+        repeated_failure_signature_count: 0,
+        blocked_verification_retry_count: 0,
+        timeout_retry_count: 0,
+        last_tracked_pr_progress_snapshot: stableSnapshot,
+        codex_connector_stable_churn_dossier_consumed_signature: null,
+      },
+    ),
+    {
+      model: "gpt-5.6-sol",
+      reasoningEffort: "max",
+    },
+  );
 });
 
 test("resolveCodexExecutionPolicy escalates xhigh to max for GPT-5.6 Sol", () => {
@@ -238,5 +258,26 @@ test("resolveCodexExecutionPolicy applies inherited host-model capabilities with
     model: null,
     reasoningEffort: "xhigh",
     requestedReasoningEffort: "max",
+  });
+});
+
+test("resolveCodexExecutionPolicy inherits a fixed default model for explicit route-level inherit", () => {
+  const config = createConfig({
+    codexModel: "gpt-5.6-sol",
+    boundedRepairModelStrategy: "inherit",
+    localReviewModelStrategy: "inherit",
+    codexReasoningEffortByState: {
+      repairing_ci: "max",
+      local_review: "max",
+    },
+  });
+
+  assert.deepEqual(resolveCodexExecutionPolicy(config, "repairing_ci"), {
+    model: "gpt-5.6-sol",
+    reasoningEffort: "max",
+  });
+  assert.deepEqual(resolveCodexExecutionPolicy(config, "local_review", undefined, "local_review_generic"), {
+    model: "gpt-5.6-sol",
+    reasoningEffort: "max",
   });
 });

--- a/src/codex/codex-policy.ts
+++ b/src/codex/codex-policy.ts
@@ -4,7 +4,7 @@ import {
   isCodexConnectorStableSameFileChurn,
 } from "../codex-connector-review-churn";
 
-const REASONING_ORDER: ReasoningEffort[] = ["none", "low", "medium", "high", "xhigh"];
+const REASONING_ORDER: ReasoningEffort[] = ["none", "low", "medium", "high", "xhigh", "max"];
 
 const DEFAULT_REASONING_BY_STATE: Record<RunState, ReasoningEffort> = {
   queued: "low",
@@ -30,6 +30,11 @@ const DEFAULT_REASONING_BY_STATE: Record<RunState, ReasoningEffort> = {
 export interface CodexExecutionPolicy {
   model: string | null;
   reasoningEffort: ReasoningEffort;
+  requestedReasoningEffort?: ReasoningEffort;
+}
+
+export interface CodexExecutionPolicyContext {
+  inheritedModel?: string | null;
 }
 
 type CodexExecutionPolicyConfig = Pick<
@@ -76,7 +81,20 @@ function bumpReasoningEffort(effort: ReasoningEffort, steps = 1): ReasoningEffor
   return REASONING_ORDER[nextIndex] ?? effort;
 }
 
+function supportsMaxReasoningEffort(model: string | null): boolean {
+  const normalized = model?.trim().toLowerCase();
+  return normalized === "gpt-5.6-sol" || normalized?.startsWith("gpt-5.6-sol-") === true;
+}
+
 function clampReasoningEffortForModel(model: string | null, effort: ReasoningEffort): ReasoningEffort {
+  if (effort === "max") {
+    if (supportsMaxReasoningEffort(model)) {
+      return "max";
+    }
+
+    return model?.toLowerCase().includes("gpt-5-pro") ? "high" : "xhigh";
+  }
+
   if (!model) {
     return effort;
   }
@@ -182,13 +200,15 @@ export function resolveCodexExecutionPolicy(
     | "codex_connector_stable_churn_dossier_consumed_signature"
   > | null,
   target: CodexExecutionTarget = "supervisor",
+  context: CodexExecutionPolicyContext = {},
 ): CodexExecutionPolicy {
   const model = resolveConfiguredModel(config, state, target);
   const requestedEffort = resolveRequestedReasoningEffort(config, state, record);
-  const reasoningEffort = clampReasoningEffortForModel(model, requestedEffort);
+  const reasoningEffort = clampReasoningEffortForModel(model ?? context.inheritedModel ?? null, requestedEffort);
   return {
     model,
     reasoningEffort,
+    ...(reasoningEffort === requestedEffort ? {} : { requestedReasoningEffort: requestedEffort }),
   };
 }
 

--- a/src/codex/codex-policy.ts
+++ b/src/codex/codex-policy.ts
@@ -81,6 +81,11 @@ function bumpReasoningEffort(effort: ReasoningEffort, steps = 1): ReasoningEffor
   return REASONING_ORDER[nextIndex] ?? effort;
 }
 
+function reasoningEffortAtLeast(effort: ReasoningEffort, minimum: ReasoningEffort): ReasoningEffort {
+  const index = Math.max(REASONING_ORDER.indexOf(effort), REASONING_ORDER.indexOf(minimum));
+  return REASONING_ORDER[index] ?? effort;
+}
+
 function supportsMaxReasoningEffort(model: string | null): boolean {
   const normalized = model?.trim().toLowerCase();
   return normalized === "gpt-5.6-sol" || normalized?.startsWith("gpt-5.6-sol-") === true;
@@ -132,7 +137,7 @@ function resolveRequestedReasoningEffort(
   let effort = configured ?? DEFAULT_REASONING_BY_STATE[state];
 
   if (state === "addressing_review" && activeStableSameFileChurnDossierSignature(record)) {
-    return "xhigh";
+    return reasoningEffortAtLeast(effort, "xhigh");
   }
 
   if (
@@ -165,9 +170,11 @@ function resolveConfiguredModel(
   state: RunState,
   target: CodexExecutionTarget,
 ): string | null {
+  const defaultModel = config.codexModelStrategy === "inherit" ? null : (config.codexModel ?? null);
+
   if (target === "local_review_generic" && config.localReviewModelStrategy) {
     if (config.localReviewModelStrategy === "inherit") {
-      return null;
+      return defaultModel;
     }
 
     return config.localReviewModel ?? null;
@@ -175,17 +182,13 @@ function resolveConfiguredModel(
 
   if (usesBoundedRepairRouting(state, target) && config.boundedRepairModelStrategy) {
     if (config.boundedRepairModelStrategy === "inherit") {
-      return null;
+      return defaultModel;
     }
 
     return config.boundedRepairModel ?? null;
   }
 
-  if (config.codexModelStrategy === "inherit") {
-    return null;
-  }
-
-  return config.codexModel ?? null;
+  return defaultModel;
 }
 
 export function resolveCodexExecutionPolicy(

--- a/src/codex/codex-runner.test.ts
+++ b/src/codex/codex-runner.test.ts
@@ -218,7 +218,7 @@ exit 0
   assert.equal(args[5], workspacePath);
 });
 
-test("runCodexTurn emits max reasoning for a fixed GPT-5.6 Sol route", async () => {
+test("runCodexTurn emits max reasoning when bounded repair inherits a fixed GPT-5.6 Sol route", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-runner-test-"));
   const workspacePath = path.join(root, "workspace");
   const codexBinary = path.join(root, "fake-codex.sh");
@@ -239,11 +239,12 @@ exit 0
       codexBinary,
       codexModelStrategy: "fixed",
       codexModel: "gpt-5.6-sol",
-      codexReasoningEffortByState: { implementing: "max" },
+      boundedRepairModelStrategy: "inherit",
+      codexReasoningEffortByState: { repairing_ci: "max" },
     }),
     workspacePath,
     "max prompt",
-    "implementing",
+    "repairing_ci",
   );
   const args = (await fs.readFile(argsPath, "utf8")).trim().split("\n");
 

--- a/src/codex/codex-runner.test.ts
+++ b/src/codex/codex-runner.test.ts
@@ -218,6 +218,92 @@ exit 0
   assert.equal(args[5], workspacePath);
 });
 
+test("runCodexTurn emits max reasoning for a fixed GPT-5.6 Sol route", async () => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-runner-test-"));
+  const workspacePath = path.join(root, "workspace");
+  const codexBinary = path.join(root, "fake-codex.sh");
+  const argsPath = path.join(root, "args.log");
+  await fs.mkdir(workspacePath, { recursive: true });
+
+  await writeExecutableScript(
+    codexBinary,
+    `#!/bin/sh
+set -eu
+printf '%s\n' "$@" > "${argsPath}"
+exit 0
+`,
+  );
+
+  await runCodexTurn(
+    createConfig({
+      codexBinary,
+      codexModelStrategy: "fixed",
+      codexModel: "gpt-5.6-sol",
+      codexReasoningEffortByState: { implementing: "max" },
+    }),
+    workspacePath,
+    "max prompt",
+    "implementing",
+  );
+  const args = (await fs.readFile(argsPath, "utf8")).trim().split("\n");
+
+  assert.deepEqual(args.slice(0, 5), [
+    "exec",
+    "-m",
+    "gpt-5.6-sol",
+    "-c",
+    'model_reasoning_effort="max"',
+  ]);
+});
+
+test("runCodexTurn emits max reasoning for an inherited GPT-5.6 Sol host route", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-runner-test-"));
+  const workspacePath = path.join(root, "workspace");
+  const codexHome = path.join(root, "codex-home");
+  const codexBinary = path.join(root, "fake-codex.sh");
+  const argsPath = path.join(root, "args.log");
+  const previousCodexHome = process.env.CODEX_HOME;
+  t.after(async () => {
+    if (previousCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  await fs.mkdir(workspacePath, { recursive: true });
+  await fs.mkdir(codexHome, { recursive: true });
+  await fs.writeFile(path.join(codexHome, "config.toml"), 'model = "gpt-5.6-sol"\n', "utf8");
+  process.env.CODEX_HOME = codexHome;
+
+  await writeExecutableScript(
+    codexBinary,
+    `#!/bin/sh
+set -eu
+printf '%s\n' "$@" > "${argsPath}"
+exit 0
+`,
+  );
+
+  await runCodexTurn(
+    createConfig({
+      codexBinary,
+      codexReasoningEffortByState: { implementing: "max" },
+    }),
+    workspacePath,
+    "inherited max prompt",
+    "implementing",
+  );
+  const args = (await fs.readFile(argsPath, "utf8")).trim().split("\n");
+
+  assert.equal(args.includes("-m"), false);
+  assert.deepEqual(args.slice(0, 3), [
+    "exec",
+    "-c",
+    'model_reasoning_effort="max"',
+  ]);
+});
+
 test("runCodexTurn removes its temp dir when command execution fails", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-runner-test-"));
   const workspacePath = path.join(root, "workspace");

--- a/src/codex/codex-runner.ts
+++ b/src/codex/codex-runner.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { runCommand } from "../core/command";
 import { buildCodexConfigOverrideArgs, buildCodexExecutionSafetyArgs, resolveCodexExecutionPolicy } from "./codex-policy";
+import { resolveHostCodexDefaultModel } from "./codex-model-policy";
 import { CodexTurnResult, IssueRunRecord, RunState, SupervisorConfig } from "../core/types";
 
 function extractSessionId(stdout: string, sessionId?: string | null): string | null {
@@ -45,7 +46,10 @@ export async function runCodexTurn(
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-"));
   const messageFile = path.join(tempDir, "last-message.txt");
   try {
-    const overrideArgs = buildCodexConfigOverrideArgs(resolveCodexExecutionPolicy(config, state, record));
+    const hostDefault = await resolveHostCodexDefaultModel();
+    const overrideArgs = buildCodexConfigOverrideArgs(
+      resolveCodexExecutionPolicy(config, state, record, "supervisor", { inheritedModel: hostDefault.model }),
+    );
     const executionSafetyArgs = buildCodexExecutionSafetyArgs(config);
     const commandArgs = sessionId
       ? [

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -214,6 +214,40 @@ test("loadConfig leaves bare codexBinary values unresolved for PATH lookup", asy
   assert.equal(config.stateFile, path.join(tempDir, "state.json"));
 });
 
+test("loadConfig preserves max as a configured reasoning effort", async (t) => {
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
+  t.after(async () => {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  });
+  const configPath = path.join(tempDir, "supervisor.config.json");
+
+  await fs.writeFile(
+    configPath,
+    JSON.stringify({
+      repoPath: ".",
+      repoSlug: "owner/repo",
+      defaultBranch: "main",
+      workspaceRoot: "./workspaces",
+      stateFile: "./state.json",
+      codexBinary: "codex",
+      branchPrefix: "codex/issue-",
+      codexReasoningEffortByState: {
+        implementing: "max",
+        repairing_ci: "xhigh",
+        planning: "unsupported",
+      },
+    }),
+    "utf8",
+  );
+
+  const config = loadConfig(configPath);
+
+  assert.deepEqual(config.codexReasoningEffortByState, {
+    implementing: "max",
+    repairing_ci: "xhigh",
+  });
+});
+
 test("loadConfigSummary reports missing required fields without throwing", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
   t.after(async () => {

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -25,7 +25,7 @@ import { mapConfiguredReviewProviders, normalizeReviewBotLogins } from "./review
 import { isValidGitRefName, resolveMaybeRelative } from "./utils";
 import { DEFAULT_CANDIDATE_DISCOVERY_FETCH_WINDOW } from "./config-constants";
 
-const VALID_REASONING_EFFORTS = new Set<ReasoningEffort>(["none", "low", "medium", "high", "xhigh"]);
+const VALID_REASONING_EFFORTS = new Set<ReasoningEffort>(["none", "low", "medium", "high", "xhigh", "max"]);
 const VALID_TRUST_MODES = new Set<TrustMode>(["trusted_repo_and_authors", "untrusted_or_mixed"]);
 const VALID_EXECUTION_SAFETY_MODES = new Set<ExecutionSafetyMode>(["unsandboxed_autonomous", "operator_gated"]);
 const VALID_LOCAL_REVIEW_POLICIES = new Set<LocalReviewPolicy>(["advisory", "block_ready", "block_merge"]);

--- a/src/core/config-types.ts
+++ b/src/core/config-types.ts
@@ -4,7 +4,7 @@ import type { RunState } from "./types";
 export type CodexModelStrategy = "inherit" | "fixed" | "alias";
 export type CodexExecutionTarget = "supervisor" | "local_review_generic" | "local_review_specialist" | "local_review_verifier";
 
-export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh";
+export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh" | "max";
 export type TrustMode = "trusted_repo_and_authors" | "untrusted_or_mixed";
 export type ExecutionSafetyMode = "unsandboxed_autonomous" | "operator_gated";
 export type LocalReviewPolicy = "advisory" | "block_ready" | "block_merge";

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -778,6 +778,7 @@ test("diagnoseSupervisorHost reports inherited host Codex defaults in doctor out
       stateFile,
       codexBinary: process.execPath,
       codexModelStrategy: "inherit",
+      codexReasoningEffortByState: { reproducing: "max" },
     }),
     authStatus: async () => ({ ok: true, message: null }),
     loadState: async () => ({ activeIssueNumber: null, issues: {} }),
@@ -794,6 +795,7 @@ test("diagnoseSupervisorHost reports inherited host Codex defaults in doctor out
   assert.match(report, /doctor_codex_model_policy default=inherit->gpt-5\.4@inherited_host_default/);
   assert.match(report, /doctor_codex_route_overrides repair=default_route\(gpt-5\.4\) local_review=default_route\(gpt-5\.4\)/);
   assert.match(report, new RegExp(`doctor_codex_host_default model=gpt-5\\.4 source=${codexHome.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}/config\\.toml`));
+  assert.match(report, /doctor_codex_reasoning active=supervisor requested=max effective=xhigh/);
 });
 
 test("diagnoseSupervisorHost surfaces orphan prune candidates and representative eligibility reasons", async (t) => {

--- a/src/local-review/finalize.ts
+++ b/src/local-review/finalize.ts
@@ -232,8 +232,15 @@ function resolveLocalReviewExecutionRouting(args: {
     | "codexReasoningEscalateOnRepeatedFailure"
   >;
   target: CodexExecutionTarget;
+  inheritedModel?: string | null;
 }): LocalReviewExecutionRouting {
-  const policy = resolveCodexExecutionPolicy(args.config, "local_review", undefined, args.target);
+  const policy = resolveCodexExecutionPolicy(
+    args.config,
+    "local_review",
+    undefined,
+    args.target,
+    { inheritedModel: args.inheritedModel },
+  );
   return {
     target: args.target,
     model: policy.model,
@@ -262,6 +269,7 @@ export function finalizeLocalReview(args: {
   verifierReport: LocalReviewVerifierReport | null;
   ranAt: string;
   guardrailProvenance?: LocalReviewGuardrailProvenance;
+  inheritedModel?: string | null;
 }): FinalizedLocalReview {
   const roles = args.roleResults.map((result) => result.role);
   const allFindings = args.roleResults.flatMap((result) => result.findings);
@@ -275,6 +283,7 @@ export function finalizeLocalReview(args: {
     const routing = resolveLocalReviewExecutionRouting({
       config: args.config,
       target: localReviewExecutionTargetForRole(reviewerTypeArgs),
+      inheritedModel: args.inheritedModel,
     });
     const actionableFindingsCount = result.findings.filter((finding) =>
       findingMeetsReviewerThreshold({
@@ -378,6 +387,7 @@ export function finalizeLocalReview(args: {
           routing: resolveLocalReviewExecutionRouting({
             config: args.config,
             target: "local_review_verifier",
+            inheritedModel: args.inheritedModel,
           }),
           exitCode: args.verifierReport.exitCode,
           degraded: args.verifierReport.degraded,

--- a/src/local-review/index.ts
+++ b/src/local-review/index.ts
@@ -13,6 +13,7 @@ import {
 } from "./preparation";
 import { GitHubIssue, GitHubPullRequest, SupervisorConfig } from "../core/types";
 import { type LocalReviewResult } from "./types";
+import { resolveHostCodexDefaultModel } from "../codex/codex-model-policy";
 
 export type {
   ActionableSeverity,
@@ -123,6 +124,7 @@ export async function runLocalReview(args: {
   const ranAt = nowIso();
   const dirPath = reviewDir(args.config, args.issue.number);
   await ensureDir(dirPath);
+  const hostDefault = await resolveHostCodexDefaultModel();
   const finalized = finalizeLocalReview({
     config: args.config,
     issueNumber: args.issue.number,
@@ -133,6 +135,7 @@ export async function runLocalReview(args: {
     roleResults,
     verifierReport,
     ranAt,
+    inheritedModel: hostDefault.model,
     guardrailProvenance: prepareLocalReviewGuardrailProvenance({
       config: args.config,
       verifierReport,

--- a/src/local-review/runner.test.ts
+++ b/src/local-review/runner.test.ts
@@ -336,6 +336,50 @@ exit 0
   assert.equal(args[5], workspacePath);
 });
 
+test("runCodexReviewTurn emits max reasoning for GPT-5.6 Sol", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "local-review-runner-test-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  const workspacePath = path.join(root, "workspace");
+  const codexBinary = path.join(root, "fake-codex.sh");
+  const argsPath = path.join(root, "args.log");
+  await fs.mkdir(workspacePath, { recursive: true });
+  await fs.writeFile(
+    codexBinary,
+    `#!/bin/sh
+set -eu
+printf '%s\n' "$@" > "${argsPath}"
+exit 0
+`,
+    "utf8",
+  );
+  await fs.chmod(codexBinary, 0o755);
+
+  await runCodexReviewTurn({
+    config: createConfig({
+      codexBinary,
+      codexModelStrategy: "fixed",
+      codexModel: "gpt-5.6-sol",
+      codexReasoningEffortByState: { local_review: "max" },
+    }),
+    workspacePath,
+    role: "reviewer",
+    outputFileName: "reviewer.txt",
+    prompt: "max local review prompt",
+    executionTarget: "local_review_generic",
+  });
+  const args = (await fs.readFile(argsPath, "utf8")).trim().split("\n");
+
+  assert.deepEqual(args.slice(0, 5), [
+    "exec",
+    "-m",
+    "gpt-5.6-sol",
+    "-c",
+    'model_reasoning_effort="max"',
+  ]);
+});
+
 test("runRoleReview accepts empty fake-runner output as a configured result", async () => {
   const fakeRunner = createFakeLocalReviewRunner({
     reviewer: "",

--- a/src/local-review/runner.test.ts
+++ b/src/local-review/runner.test.ts
@@ -361,6 +361,7 @@ exit 0
       codexBinary,
       codexModelStrategy: "fixed",
       codexModel: "gpt-5.6-sol",
+      localReviewModelStrategy: "inherit",
       codexReasoningEffortByState: { local_review: "max" },
     }),
     workspacePath,

--- a/src/local-review/runner.ts
+++ b/src/local-review/runner.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { runCommand } from "../core/command";
 import { buildCodexConfigOverrideArgs, buildCodexExecutionSafetyArgs, resolveCodexExecutionPolicy } from "../codex/codex-policy";
+import { resolveHostCodexDefaultModel } from "../codex/codex-model-policy";
 import { loadRelevantExternalReviewMissPatterns, type ExternalReviewMissPattern } from "../external-review/external-review-misses";
 import { reviewDir } from "./artifacts";
 import { buildRolePrompt, buildVerifierPrompt, parseRoleFooter, parseVerifierFooter } from "./prompt";
@@ -35,8 +36,15 @@ export type LocalReviewTurnExecutor = (args: LocalReviewTurnRequest) => Promise<
 export async function runCodexReviewTurn(args: LocalReviewTurnRequest): Promise<LocalReviewTurnResult> {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-review-"));
   const messageFile = path.join(tempDir, args.outputFileName);
+  const hostDefault = await resolveHostCodexDefaultModel();
   const overrideArgs = buildCodexConfigOverrideArgs(
-    resolveCodexExecutionPolicy(args.config, "local_review", undefined, args.executionTarget),
+    resolveCodexExecutionPolicy(
+      args.config,
+      "local_review",
+      undefined,
+      args.executionTarget,
+      { inheritedModel: hostDefault.model },
+    ),
   );
   const executionSafetyArgs = buildCodexExecutionSafetyArgs(args.config);
   const result = await runCommand(

--- a/src/supervisor/supervisor-status-rendering.test.ts
+++ b/src/supervisor/supervisor-status-rendering.test.ts
@@ -464,6 +464,7 @@ test("renderStatusCodexModelPolicyLines reports inherited host defaults and over
         boundedRepairModel: "gpt-5.4-mini",
         localReviewModelStrategy: "alias",
         localReviewModel: "local-review-fast",
+        codexReasoningEffortByState: { reproducing: "max" },
       }),
       activeState: "reproducing",
       activeRecord: createRecord({
@@ -473,7 +474,7 @@ test("renderStatusCodexModelPolicyLines reports inherited host defaults and over
   );
 
   assert.deepEqual(lines, [
-    "codex_execution_policy active=supervisor:inherit->gpt-5.4@inherited_host_default reasoning=high",
+    "codex_execution_policy active=supervisor:inherit->gpt-5.4@inherited_host_default reasoning=xhigh requested_reasoning=max",
     "codex_route_overrides repair=alias:gpt-5.4-mini@bounded_repair_override local_review=alias:local-review-fast@local_review_override",
   ]);
 });


### PR DESCRIPTION
## Summary

- add `max` to the reasoning-effort config type, parser, and escalation order
- allow `max` for `gpt-5.6-sol` while safely clamping unsupported models to their highest supported effort
- resolve inherited host-model capabilities in supervisor and local-review execution paths
- report requested and effective reasoning in doctor/status diagnostics
- document the capability behavior and add fixed/inherited runner regression coverage

## Why

GPT-5.6 Sol supports a `max` reasoning effort, but codex-supervisor previously stopped at `xhigh` and had no capability boundary for emitting the new value. This change makes the new effort opt-in and model-aware without changing existing defaults.

## Validation

- `npm run verify:supervisor-pre-pr` — passed
- focused parser, policy, runner, local-review, doctor, and status tests — 181/181 passed
- `npm test` — 2850 passed, 2 failed
  - both failures reproduce unchanged on `origin/main` in `src/recovery-blocked-issue-reconciliation.test.ts`
  - required-review fixture expects `addressing_review` but receives `pr_open`
  - changes-requested fixture expects `blocked` but receives `pr_open`

Closes #2437