### PR TITLE
Refresh Codex model guidance and GPT-5.6 operational notes

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -271,9 +271,11 @@ Choose `fixed` when one supervisor profile must pin a model and ignore the host 
 ```json
 {
   "codexModelStrategy": "fixed",
-  "codexModel": "gpt-5.4"
+  "codexModel": "supported-model-id"
 }
 ```
+
+Replace `supported-model-id` with a model ID available to the Codex account or workspace that runs this supervisor.
 
 If you prefer an alias instead of a fixed model name:
 
@@ -292,7 +294,7 @@ Use this when implementation turns should inherit the main route, but `repairing
 {
   "codexModelStrategy": "inherit",
   "boundedRepairModelStrategy": "fixed",
-  "boundedRepairModel": "gpt-5.4-mini"
+  "boundedRepairModel": "supported-repair-model-id"
 }
 ```
 
@@ -666,9 +668,10 @@ That posture is deliberate. Choose `localReviewPosture: "repair_high_severity"` 
 
 Recommended default:
 
-- set your Codex default model to `GPT-5.4`
+- choose a host Codex model that the current CLI version and workspace can access
 - use `codexModelStrategy: "inherit"`
 - tune cost and depth through `codexReasoningEffortByState`
+- confirm the effective host and route models with `doctor` or `status` instead of treating one versioned model as a universal default
 
 Practical rule of thumb:
 
@@ -678,6 +681,43 @@ Practical rule of thumb:
 - reasoning escalation follows `none < low < medium < high < xhigh < max`
 - `max` is currently emitted only for `gpt-5.6-sol`; unsupported models fall back to `xhigh`, while GPT-5 Pro remains capped at `high`
 - `status` and `doctor` report the requested and effective efforts when capability clamping changes the request
+
+### ChatGPT desktop app and the Codex CLI
+
+The macOS desktop bundle may be installed as `ChatGPT.app` rather than the older `Codex.app`. This is an app packaging and branding change, not a migration away from the Codex execution contract: `codex-supervisor` still launches the `codex` CLI, and OpenAI documents the ChatGPT desktop app in Codex mode alongside the Codex CLI, IDE extension, and web surfaces.
+
+Prefer `"codexBinary": "codex"` when the CLI is available on `PATH`. If an absolute executable path is required, point it at the bundle actually installed on that host and run `doctor`; do not copy a stale `/Applications/Codex.app/...` path from another machine. The supervisor's binary resolution supports both current ChatGPT and legacy Codex desktop bundles.
+
+### GPT-5.6 preview and access boundaries
+
+OpenAI's current preview documentation lists these model IDs:
+
+| Model | Model ID | Supervisor reasoning note |
+| --- | --- | --- |
+| GPT-5.6 Sol | `gpt-5.6-sol` | Supports the supervisor's `max` reasoning effort. |
+| GPT-5.6 Terra | `gpt-5.6-terra` | `max` is clamped to the highest supported fallback. |
+| GPT-5.6 Luna | `gpt-5.6-luna` | `max` is clamped to the highest supported fallback. |
+
+Do not infer access from a model name appearing in documentation or from having a paid ChatGPT plan. During the documented preview, access is limited to selected organizations and scoped separately to approved API organizations and Codex workspaces; API approval does not imply Codex approval, and the preview is distinct from general ChatGPT availability. Keep `codexModelStrategy: "inherit"` as the resilient default so model changes do not require supervisor config churn, and pin a GPT-5.6 model only after confirming access in the exact account or workspace used by the supervisor.
+
+Availability is time-sensitive. Check the current OpenAI sources rather than copying this preview status into automation:
+
+- [Previewing GPT-5.6 Sol: a next-generation model](https://openai.com/index/previewing-gpt-5-6-sol/)
+- [A preview of GPT-5.6 Sol, Terra, and Luna](https://help.openai.com/en/articles/20001325-a-preview-of-gpt-5-6-sol-terra-and-luna)
+- [Using Codex with your ChatGPT plan](https://help.openai.com/en/articles/11369540-using-codex-with-chatgpt)
+
+### Additional safety checks and timeout evidence
+
+OpenAI documents that some biological or cybersecurity requests can take longer, pause for an additional automated safety check, or return no content. A slow request is not by itself evidence that the supervisor timeout is wrong.
+
+When diagnosing a suspected safety-check timeout:
+
+1. Record the exact CLI event or error, the elapsed time, the model, and whether the run used Codex or the API.
+2. Preserve the date, time zone, request ID when available, and a brief redacted task description. Do not collect secrets or proprietary prompt content in public artifacts.
+3. Keep the existing `codexExecTimeoutMinutes` value for the first reproduction.
+4. Increase `codexExecTimeoutMinutes` only when repeated, allowed workloads show that the current limit ends otherwise successful requests. Document the observed duration and chosen margin.
+
+See [OpenAI's additional safety checks guidance](https://help.openai.com/en/articles/20001326-additional-safety-checks-for-biological-and-cybersecurity-requests-in-api-and-codex) for the current behavior and support evidence. This operational guidance does not change the shipped runtime default.
 
 ## Operator Dashboard
 

--- a/docs/examples/atlaspm.md
+++ b/docs/examples/atlaspm.md
@@ -103,7 +103,7 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
 - `atlaspm` uses canonical `Part of: #...`, `Depends on: ...`, and `## Execution order`, so the built-in sequencing logic is enough.
 - If you use GSD for upstream planning, enable `gsdEnabled` and point `gsdPlanningFiles` at `PROJECT.md`, `REQUIREMENTS.md`, `ROADMAP.md`, and `STATE.md`.
 - Copilot review is expected to start automatically after the PR is marked ready.
-- Leave `boundedRepairModelStrategy` unset unless you explicitly want `repairing_ci` and `addressing_review` turns to use a smaller bounded-repair model such as `gpt-5.4-mini`.
+- Leave `boundedRepairModelStrategy` unset unless you explicitly want `repairing_ci` and `addressing_review` turns to use a supported smaller model or alias.
 - Leave `localReviewModelStrategy` unset unless you explicitly want generic local-review turns to use a separate review model.
 - Keep `workspacePreparationCommand` and `localCiCommand` explicit when the repo owns host-local setup and verification entrypoints; otherwise leave them unset instead of expecting the supervisor to infer a contract.
 - The shipped starter profiles keep local review disabled by default. This atlaspm example intentionally shows the recommended once-enabled posture.
@@ -121,9 +121,9 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
 - Switch to `localReviewHighSeverityAction: "retry"` when your team explicitly wants the supervisor to start another repair pass automatically after verifier-confirmed high-severity findings.
 - Findings below the configured confidence threshold stay in the raw role reports but are not counted as actionable.
 - Even with multiple local review roles, the reviewer turn should still read the generated context index and issue journal first, then open durable memory files only on demand.
-- `codexModelStrategy: "inherit"` means the supervisor follows the Codex CLI/App default model automatically. In practice, set the Codex default model to `GPT-5.4` and let the supervisor inherit it.
-- For most atlaspm-style implementation loops, there is little reason to rotate through older Codex 5.1 to 5.3 variants. Tune reasoning effort first.
-- Keep `xhigh` out of the default state policy. It is better reserved for exceptional repeated-failure escalation only.
+- `codexModelStrategy: "inherit"` means the supervisor follows the model available through the host Codex CLI/App configuration. Keep this posture unless atlaspm has a measured reason to pin a model, and confirm the effective route with `doctor` or `status`.
+- Preview access is workspace-dependent. Do not pin GPT-5.6 merely because it appears in current documentation or in another operator's account; see the central [Model and Reasoning Guidance](../configuration.md#model-and-reasoning-guidance).
+- Tune reasoning effort before adding model-routing complexity. Keep `xhigh` and `max` out of the default state policy; `max` is emitted only for supported GPT-5.6 Sol routes and is intended for deliberate deep-reasoning or escalation paths.
 - Only configured review bots are auto-addressed. Human review comments block merge and require manual follow-up.
 - `Epic:` title prefixes are skipped as direct work items because the supervisor closes epics after all child issues close.
 - Generated context index and `AGENTS.generated.md` artifacts are written under the supervisor state directory, not into the managed repo.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -101,6 +101,12 @@ At minimum, set these first-run fields before the first run:
 
 The setup/readiness report stays `ready: false` until these required first-run blockers, including the explicit trust posture decisions, are resolved.
 
+### Codex client and model defaults
+
+Prefer `"codexBinary": "codex"` when the Codex CLI is available on `PATH`. On macOS, the desktop bundle may now be named `ChatGPT.app` instead of `Codex.app`; the ChatGPT desktop app still provides the Codex coding surface, and `codex-supervisor` still invokes the Codex CLI. This branding change does not require an API, runner, or config-schema migration. If you must use an absolute binary path, use the bundle installed on that host and verify it with `doctor`.
+
+Keep `codexModelStrategy: "inherit"` unless the workflow requires a deliberate pin. The inherited model depends on the installed CLI, its configuration, and workspace access, so do not assume that a versioned model is a universal default. GPT-5.6 preview access is account- and workspace-dependent and is separate from general ChatGPT availability. See [Model and Reasoning Guidance](./configuration.md#model-and-reasoning-guidance) for current model IDs, `max` reasoning behavior, and evidence-driven timeout troubleshooting.
+
 The shipped CodeRabbit profile intentionally uses a non-loadable `repoSlug` placeholder so operators must replace it before the first run.
 
 For TypeScript and Node repositories, [supervisor.config.typescript-node.json](../supervisor.config.typescript-node.json) publishes an npm-oriented starter profile. It uses `npm ci` for worktree preparation and `npm run verify:pre-pr` for the repo-owned local CI gate; see the [TypeScript and Node starter profile](./examples/typescript-node.md) for the expected scripts and a first issue example.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -2433,14 +2433,24 @@ test("getting started links to focused configuration and local review references
   assert.match(configuration, /^## Model Routing Quick Recipes$/m);
   assert.match(configuration, /authoritative fields for Codex model selection/i);
   assert.match(configuration, /"codexModelStrategy": "inherit"/);
+  assert.match(configuration, /"codexModel": "supported-model-id"/);
   assert.match(configuration, /"boundedRepairModelStrategy": "fixed"/);
-  assert.match(configuration, /"boundedRepairModel": "gpt-5\.4-mini"/);
+  assert.match(configuration, /"boundedRepairModel": "supported-repair-model-id"/);
   assert.match(configuration, /"localReviewModelStrategy": "alias"/);
   assert.match(configuration, /"localReviewModel": "local-review-fast"/);
   assert.match(configuration, /fixed` and `alias`.*fail closed unless the matching model field is set explicitly/i);
   assert.match(configuration, /requires `codexModel`/i);
   assert.match(configuration, /requires `boundedRepairModel`/i);
   assert.match(configuration, /requires `localReviewModel`/i);
+  assert.doesNotMatch(configuration, /set (?:your|the) Codex default model to `GPT-5\.4`/i);
+  assert.match(configuration, /`gpt-5\.6-sol`/);
+  assert.match(configuration, /`gpt-5\.6-terra`/);
+  assert.match(configuration, /`gpt-5\.6-luna`/);
+  assert.match(configuration, /ChatGPT\.app/);
+  assert.match(configuration, /`codexExecTimeoutMinutes`/);
+  assert.match(configuration, /additional safety checks guidance/i);
+  assert.match(gettingStarted, /codexModelStrategy: "inherit"/);
+  assert.match(gettingStarted, /GPT-5\.6 preview access is account- and workspace-dependent/i);
 
   assert.match(configuration, /\| Profile \| Start from \| Choose when \| Supervisor watches \| First-run caveat \|/);
   assert.match(configuration, /\| Copilot \| \[supervisor\.config\.copilot\.json\]\(\.\.\/supervisor\.config\.copilot\.json\) \|/);


### PR DESCRIPTION
## Summary

- replace version-specific GPT-5.4 default guidance with durable `codexModelStrategy: "inherit"` recommendations
- document the ChatGPT desktop bundle rename while preserving the Codex CLI and runner contract
- add GPT-5.6 Sol, Terra, and Luna model IDs with preview and access-boundary guidance
- document the implemented GPT-5.6 Sol `max` reasoning behavior and safe fallback for unsupported models
- add evidence-driven troubleshooting for additional safety checks and `codexExecTimeoutMinutes`
- update atlaspm guidance and extend documentation contract tests

## Why

The maintained guides still presented GPT-5.4 as a practical universal default. That advice is brittle as Codex defaults and workspace entitlements change, and it could lead operators to pin a limited-preview model or raise all timeouts preemptively. The refreshed guidance keeps model selection resilient and separates the ChatGPT desktop brand from the Codex execution surface.

## Official references

- https://openai.com/index/previewing-gpt-5-6-sol/
- https://help.openai.com/en/articles/20001325-a-preview-of-gpt-5-6-sol-terra-and-luna
- https://help.openai.com/en/articles/20001326-additional-safety-checks-for-biological-and-cybersecurity-requests-in-api-and-codex
- https://help.openai.com/en/articles/11369540-using-codex-with-chatgpt

## Validation

- documentation assertions for model IDs, `inherit`, ChatGPT.app, `max`, timeout guidance, and local links — passed
- `npm run verify:supervisor-pre-pr` — passed
- `npm test` — 2851 passed, 2 failed
  - both failures are the existing `src/recovery-blocked-issue-reconciliation.test.ts` baseline reproduced on `main`
  - required-review fixture expects `addressing_review` but receives `pr_open`
  - changes-requested fixture expects `blocked` but receives `pr_open`

Closes #2438