### PR TITLE
Resolve Codex reasoning capabilities from the active model catalog

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -679,7 +679,7 @@ Practical rule of thumb:
 - leave `boundedRepairModelStrategy` unset unless you intentionally want smaller models for repair turns
 - reserve `xhigh` for escalation paths rather than using it everywhere
 - reasoning escalation follows `none < low < medium < high < xhigh < max`
-- `max` is currently emitted only for `gpt-5.6-sol`; unsupported models fall back to `xhigh`, while GPT-5 Pro remains capped at `high`
+- `max` is emitted when the active Codex CLI model catalog reports support; if the catalog probe fails, a conservative built-in fallback permits it only for `gpt-5.6-sol`. Unsupported models fall back to `xhigh`, while GPT-5 Pro remains capped at `high`.
 - `status` and `doctor` report the requested and effective efforts when capability clamping changes the request
 
 ### ChatGPT desktop app and the Codex CLI
@@ -694,9 +694,9 @@ OpenAI's current preview documentation lists these model IDs:
 
 | Model | Model ID | Supervisor reasoning note |
 | --- | --- | --- |
-| GPT-5.6 Sol | `gpt-5.6-sol` | Supports the supervisor's `max` reasoning effort. |
-| GPT-5.6 Terra | `gpt-5.6-terra` | `max` is clamped to the highest supported fallback. |
-| GPT-5.6 Luna | `gpt-5.6-luna` | `max` is clamped to the highest supported fallback. |
+| GPT-5.6 Sol | `gpt-5.6-sol` | Active-catalog reasoning levels are honored; the offline fallback permits `max`. |
+| GPT-5.6 Terra | `gpt-5.6-terra` | Active-catalog reasoning levels are honored, including `max` when reported. |
+| GPT-5.6 Luna | `gpt-5.6-luna` | Active-catalog reasoning levels are honored, including `max` when reported. |
 
 Do not infer access from a model name appearing in documentation or from having a paid ChatGPT plan. During the documented preview, access is limited to selected organizations and scoped separately to approved API organizations and Codex workspaces; API approval does not imply Codex approval, and the preview is distinct from general ChatGPT availability. Keep `codexModelStrategy: "inherit"` as the resilient default so model changes do not require supervisor config churn, and pin a GPT-5.6 model only after confirming access in the exact account or workspace used by the supervisor.
 

--- a/docs/examples/atlaspm.md
+++ b/docs/examples/atlaspm.md
@@ -123,7 +123,7 @@ This is one concrete way to use `codex-supervisor` against a local checkout of `
 - Even with multiple local review roles, the reviewer turn should still read the generated context index and issue journal first, then open durable memory files only on demand.
 - `codexModelStrategy: "inherit"` means the supervisor follows the model available through the host Codex CLI/App configuration. Keep this posture unless atlaspm has a measured reason to pin a model, and confirm the effective route with `doctor` or `status`.
 - Preview access is workspace-dependent. Do not pin GPT-5.6 merely because it appears in current documentation or in another operator's account; see the central [Model and Reasoning Guidance](../configuration.md#model-and-reasoning-guidance).
-- Tune reasoning effort before adding model-routing complexity. Keep `xhigh` and `max` out of the default state policy; `max` is emitted only for supported GPT-5.6 Sol routes and is intended for deliberate deep-reasoning or escalation paths.
+- Tune reasoning effort before adding model-routing complexity. Keep `xhigh` and `max` out of the default state policy; `max` is emitted only when supported by the active Codex model catalog (or the conservative offline fallback) and is intended for deliberate deep-reasoning or escalation paths.
 - Only configured review bots are auto-addressed. Human review comments block merge and require manual follow-up.
 - `Epic:` title prefixes are skipped as direct work items because the supervisor closes epics after all child issues close.
 - Generated context index and `AGENTS.generated.md` artifacts are written under the supervisor state directory, not into the managed repo.

--- a/src/codex/codex-model-capabilities.test.ts
+++ b/src/codex/codex-model-capabilities.test.ts
@@ -3,7 +3,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { parseCodexModelCatalog, probeCodexModelCapabilities } from "./codex-model-capabilities";
+import {
+  clearCodexModelCapabilitiesCacheForTests,
+  parseCodexModelCatalog,
+  probeCodexModelCapabilities,
+  resolveCodexModelCapabilities,
+} from "./codex-model-capabilities";
 
 test("parseCodexModelCatalog resolves GPT-5.6 reasoning levels and ignores unsupported future levels", async () => {
   const fixture = await fs.readFile(path.join(process.cwd(), "src/codex/fixtures/model-catalog-gpt-5.6.json"), "utf8");
@@ -11,6 +16,48 @@ test("parseCodexModelCatalog resolves GPT-5.6 reasoning levels and ignores unsup
   assert.deepEqual([...catalog?.get("gpt-5.6-sol") ?? []], ["high", "xhigh", "max"]);
   assert.deepEqual([...catalog?.get("gpt-5.6-terra") ?? []], ["high", "xhigh", "max"]);
   assert.deepEqual([...catalog?.get("gpt-5.6-luna") ?? []], ["high", "xhigh", "max"]);
+});
+
+test("parseCodexModelCatalog normalizes catalog ultra support to max", () => {
+  const catalog = parseCodexModelCatalog(JSON.stringify({
+    models: [{ slug: "gpt-5.6-terra", supported_reasoning_levels: [{ effort: "ultra" }] }],
+  }));
+  assert.deepEqual([...catalog?.get("gpt-5.6-terra") ?? []], ["max"]);
+});
+
+test("probeCodexModelCapabilities captures catalogs larger than the default command output limit", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-capabilities-large-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const binary = path.join(root, "large-catalog");
+  await fs.writeFile(binary, `#!/usr/bin/env node
+process.stdout.write(JSON.stringify({ models: [{ slug: "gpt-5.6-terra", supported_reasoning_levels: ["max"], description: "x".repeat(70_000) }] }));
+`, { mode: 0o755 });
+
+  const result = await probeCodexModelCapabilities(binary);
+  assert.equal(result.source, "live_catalog");
+  assert.equal(result.reasoningLevelsByModel.get("gpt-5.6-terra")?.has("max"), true);
+});
+
+test("resolveCodexModelCapabilities probes and caches catalogs per target workspace", async (t) => {
+  clearCodexModelCapabilitiesCacheForTests();
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-capabilities-workspace-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const binary = path.join(root, "workspace-catalog");
+  const firstWorkspace = path.join(root, "workspace-a");
+  const secondWorkspace = path.join(root, "workspace-b");
+  await fs.mkdir(firstWorkspace);
+  await fs.mkdir(secondWorkspace);
+  await fs.writeFile(binary, `#!/bin/sh
+slug=$(basename "$PWD")
+printf '{"models":[{"slug":"%s","supported_reasoning_levels":["low"]}]}' "$slug"
+`, { mode: 0o755 });
+
+  const first = await resolveCodexModelCapabilities(binary, firstWorkspace);
+  const firstAgain = await resolveCodexModelCapabilities(binary, firstWorkspace);
+  const second = await resolveCodexModelCapabilities(binary, secondWorkspace);
+  assert.strictEqual(firstAgain, first);
+  assert.equal(first.reasoningLevelsByModel.has("workspace-a"), true);
+  assert.equal(second.reasoningLevelsByModel.has("workspace-b"), true);
 });
 
 test("probeCodexModelCapabilities falls back deterministically for malformed, non-zero, and timed-out probes", async (t) => {

--- a/src/codex/codex-model-capabilities.test.ts
+++ b/src/codex/codex-model-capabilities.test.ts
@@ -64,6 +64,23 @@ printf '{"models":[{"slug":"%s","supported_reasoning_levels":["low"]}]}' "$slug"
   assert.equal(second.reasoningLevelsByModel.has("workspace-b"), true);
 });
 
+test("resolveCodexModelCapabilities refreshes an expired live catalog", async (t) => {
+  clearCodexModelCapabilitiesCacheForTests();
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-capabilities-refresh-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const binary = path.join(root, "mutable-catalog");
+  const catalog = path.join(root, "catalog.json");
+  await fs.writeFile(binary, "#!/bin/sh\ncat \"$PWD/catalog.json\"\n", { mode: 0o755 });
+  await fs.writeFile(catalog, '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["xhigh"]}]}');
+
+  const first = await resolveCodexModelCapabilities(binary, root);
+  await fs.writeFile(catalog, '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["max"]}]}');
+  const cached = await resolveCodexModelCapabilities(binary, root);
+  const refreshed = await resolveCodexModelCapabilities(binary, root, 0);
+  assert.strictEqual(cached, first);
+  assert.equal(refreshed.reasoningLevelsByModel.get("gpt-5.6-terra")?.has("max"), true);
+});
+
 test("resolveCodexModelCapabilities retries after a transient fallback result", async (t) => {
   clearCodexModelCapabilitiesCacheForTests();
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-capabilities-retry-"));

--- a/src/codex/codex-model-capabilities.test.ts
+++ b/src/codex/codex-model-capabilities.test.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { parseCodexModelCatalog, probeCodexModelCapabilities } from "./codex-model-capabilities";
+
+test("parseCodexModelCatalog resolves GPT-5.6 reasoning levels and ignores unsupported future levels", async () => {
+  const fixture = await fs.readFile(path.join(process.cwd(), "src/codex/fixtures/model-catalog-gpt-5.6.json"), "utf8");
+  const catalog = parseCodexModelCatalog(fixture);
+  assert.deepEqual([...catalog?.get("gpt-5.6-sol") ?? []], ["high", "xhigh", "max"]);
+  assert.deepEqual([...catalog?.get("gpt-5.6-terra") ?? []], ["high", "xhigh", "max"]);
+  assert.deepEqual([...catalog?.get("gpt-5.6-luna") ?? []], ["high", "xhigh", "max"]);
+});
+
+test("probeCodexModelCapabilities falls back deterministically for malformed, non-zero, and timed-out probes", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-capabilities-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const cases = [
+    { name: "malformed", body: "printf 'not-json'", reason: "malformed_catalog", timeout: 1_000 },
+    { name: "nonzero", body: "exit 7", reason: "catalog_probe_exit_7", timeout: 1_000 },
+    { name: "timeout", body: "sleep 1", reason: "catalog_probe_timeout", timeout: 10 },
+  ];
+  for (const fixture of cases) {
+    const binary = path.join(root, fixture.name);
+    await fs.writeFile(binary, `#!/bin/sh\n${fixture.body}\n`, { mode: 0o755 });
+    const result = await probeCodexModelCapabilities(binary, fixture.timeout);
+    assert.equal(result.source, "fallback");
+    assert.equal(result.fallbackReason, fixture.reason);
+    assert.equal(result.reasoningLevelsByModel.get("gpt-5.6-sol")?.has("max"), true);
+    assert.equal(result.reasoningLevelsByModel.has("gpt-5.6-terra"), false);
+  }
+});
+
+test("parseCodexModelCatalog fails closed for malformed or unknown schemas", () => {
+  assert.equal(parseCodexModelCatalog("not json"), null);
+  assert.equal(parseCodexModelCatalog('{"models":[{"slug":"gpt-5.6-terra"}]}'), null);
+  assert.equal(parseCodexModelCatalog('{"data":[]}'), null);
+});

--- a/src/codex/codex-model-capabilities.test.ts
+++ b/src/codex/codex-model-capabilities.test.ts
@@ -34,6 +34,20 @@ test("parseCodexModelCatalog preserves the distinction between unsupported ultra
   assert.deepEqual([...catalog?.get("gpt-5.6-sol") ?? []], ["max"]);
 });
 
+test("parseCodexModelCatalog skips malformed unrelated entries without discarding valid capabilities", () => {
+  const catalog = parseCodexModelCatalog(JSON.stringify({
+    models: [
+      { slug: "legacy-model" },
+      null,
+      { slug: "gpt-5.6-terra", supported_reasoning_levels: ["high", "max"] },
+      { slug: "malformed-levels", supported_reasoning_levels: [{}] },
+    ],
+  }));
+  assert.deepEqual([...catalog?.get("gpt-5.6-terra") ?? []], ["high", "max"]);
+  assert.equal(catalog?.has("legacy-model"), false);
+  assert.equal(catalog?.has("malformed-levels"), false);
+});
+
 test("probeCodexModelCapabilities captures catalogs larger than the default command output limit", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-capabilities-large-"));
   t.after(() => fs.rm(root, { recursive: true, force: true }));
@@ -86,7 +100,7 @@ test("resolveCodexModelCapabilities refreshes an expired live catalog", async (t
   assert.equal(refreshed.reasoningLevelsByModel.get("gpt-5.6-terra")?.has("max"), true);
 });
 
-test("resolveCodexModelCapabilities retries after a transient fallback result", async (t) => {
+test("resolveCodexModelCapabilities caches fallback results within the TTL and permits a forced refresh", async (t) => {
   clearCodexModelCapabilitiesCacheForTests();
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-capabilities-retry-"));
   t.after(() => fs.rm(root, { recursive: true, force: true }));
@@ -101,11 +115,13 @@ printf '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["max"]}
 `, { mode: 0o755 });
 
   const first = await resolveCodexModelCapabilities(binary, root);
-  const second = await resolveCodexModelCapabilities(binary, root);
+  const cached = await resolveCodexModelCapabilities(binary, root);
+  const refreshed = await resolveCodexModelCapabilities(binary, root, 0);
   assert.equal(first.source, "fallback");
   assert.equal(first.fallbackReason, "catalog_probe_exit_7");
-  assert.equal(second.source, "live_catalog");
-  assert.equal(second.reasoningLevelsByModel.get("gpt-5.6-terra")?.has("max"), true);
+  assert.strictEqual(cached, first);
+  assert.equal(refreshed.source, "live_catalog");
+  assert.equal(refreshed.reasoningLevelsByModel.get("gpt-5.6-terra")?.has("max"), true);
 });
 
 test("probeCodexModelCapabilities falls back deterministically for malformed, non-zero, and timed-out probes", async (t) => {

--- a/src/codex/codex-model-capabilities.test.ts
+++ b/src/codex/codex-model-capabilities.test.ts
@@ -60,6 +60,28 @@ printf '{"models":[{"slug":"%s","supported_reasoning_levels":["low"]}]}' "$slug"
   assert.equal(second.reasoningLevelsByModel.has("workspace-b"), true);
 });
 
+test("resolveCodexModelCapabilities retries after a transient fallback result", async (t) => {
+  clearCodexModelCapabilitiesCacheForTests();
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-capabilities-retry-"));
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const binary = path.join(root, "recovering-catalog");
+  await fs.writeFile(binary, `#!/bin/sh
+marker="$PWD/.catalog-ready"
+if [ ! -f "$marker" ]; then
+  touch "$marker"
+  exit 7
+fi
+printf '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["max"]}]}'
+`, { mode: 0o755 });
+
+  const first = await resolveCodexModelCapabilities(binary, root);
+  const second = await resolveCodexModelCapabilities(binary, root);
+  assert.equal(first.source, "fallback");
+  assert.equal(first.fallbackReason, "catalog_probe_exit_7");
+  assert.equal(second.source, "live_catalog");
+  assert.equal(second.reasoningLevelsByModel.get("gpt-5.6-terra")?.has("max"), true);
+});
+
 test("probeCodexModelCapabilities falls back deterministically for malformed, non-zero, and timed-out probes", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-capabilities-"));
   t.after(() => fs.rm(root, { recursive: true, force: true }));

--- a/src/codex/codex-model-capabilities.test.ts
+++ b/src/codex/codex-model-capabilities.test.ts
@@ -18,11 +18,15 @@ test("parseCodexModelCatalog resolves GPT-5.6 reasoning levels and ignores unsup
   assert.deepEqual([...catalog?.get("gpt-5.6-luna") ?? []], ["high", "xhigh", "max"]);
 });
 
-test("parseCodexModelCatalog normalizes catalog ultra support to max", () => {
+test("parseCodexModelCatalog preserves the distinction between unsupported ultra and max", () => {
   const catalog = parseCodexModelCatalog(JSON.stringify({
-    models: [{ slug: "gpt-5.6-terra", supported_reasoning_levels: [{ effort: "ultra" }] }],
+    models: [
+      { slug: "gpt-5.6-terra", supported_reasoning_levels: [{ effort: "ultra" }] },
+      { slug: "gpt-5.6-sol", supported_reasoning_levels: [{ effort: "ultra" }, { effort: "max" }] },
+    ],
   }));
-  assert.deepEqual([...catalog?.get("gpt-5.6-terra") ?? []], ["max"]);
+  assert.deepEqual([...catalog?.get("gpt-5.6-terra") ?? []], []);
+  assert.deepEqual([...catalog?.get("gpt-5.6-sol") ?? []], ["max"]);
 });
 
 test("probeCodexModelCapabilities captures catalogs larger than the default command output limit", async (t) => {

--- a/src/codex/codex-model-capabilities.test.ts
+++ b/src/codex/codex-model-capabilities.test.ts
@@ -5,10 +5,15 @@ import path from "node:path";
 import test from "node:test";
 import {
   clearCodexModelCapabilitiesCacheForTests,
+  DEFAULT_CODEX_MODEL_CATALOG_PROBE_TIMEOUT_MS,
   parseCodexModelCatalog,
   probeCodexModelCapabilities,
   resolveCodexModelCapabilities,
 } from "./codex-model-capabilities";
+
+test("model catalog probes allow a bounded remote refresh window", () => {
+  assert.equal(DEFAULT_CODEX_MODEL_CATALOG_PROBE_TIMEOUT_MS, 15_000);
+});
 
 test("parseCodexModelCatalog resolves GPT-5.6 reasoning levels and ignores unsupported future levels", async () => {
   const fixture = await fs.readFile(path.join(process.cwd(), "src/codex/fixtures/model-catalog-gpt-5.6.json"), "utf8");

--- a/src/codex/codex-model-capabilities.ts
+++ b/src/codex/codex-model-capabilities.ts
@@ -15,6 +15,7 @@ const FALLBACK = new Map<string, ReadonlySet<ReasoningEffort>>([
   ["gpt-5.6-sol", new Set<ReasoningEffort>(["low", "medium", "high", "xhigh", "max"])],
 ]);
 const LIVE_CATALOG_CACHE_TTL_MS = 60_000;
+export const DEFAULT_CODEX_MODEL_CATALOG_PROBE_TIMEOUT_MS = 15_000;
 
 interface CapabilityCacheEntry {
   expiresAt: number;
@@ -68,7 +69,7 @@ export function parseCodexModelCatalog(raw: string): ReadonlyMap<string, Readonl
 
 export async function probeCodexModelCapabilities(
   codexBinary: string,
-  timeoutMs = 5_000,
+  timeoutMs = DEFAULT_CODEX_MODEL_CATALOG_PROBE_TIMEOUT_MS,
   cwd?: string,
 ): Promise<CodexModelCapabilities> {
   try {
@@ -98,7 +99,7 @@ export function resolveCodexModelCapabilities(
   const now = Date.now();
   const existing = cache.get(cacheKey);
   if (existing && cacheTtlMs > 0 && existing.expiresAt > now) return existing.pending;
-  const pending = probeCodexModelCapabilities(codexBinary, 5_000, cwd);
+  const pending = probeCodexModelCapabilities(codexBinary, DEFAULT_CODEX_MODEL_CATALOG_PROBE_TIMEOUT_MS, cwd);
   cache.set(cacheKey, { pending, expiresAt: now + Math.max(0, cacheTtlMs) });
   void pending.then((result) => {
     if (result.source === "fallback" && cache.get(cacheKey)?.pending === pending) {

--- a/src/codex/codex-model-capabilities.ts
+++ b/src/codex/codex-model-capabilities.ts
@@ -54,14 +54,14 @@ export function parseCodexModelCatalog(raw: string): ReadonlyMap<string, Readonl
 
   const models = new Map<string, ReadonlySet<ReasoningEffort>>();
   for (const entry of entries) {
-    if (!entry || typeof entry !== "object") return null;
+    if (!entry || typeof entry !== "object") continue;
     const { slug, supported_reasoning_levels: levels } = entry as {
       slug?: unknown;
       supported_reasoning_levels?: unknown;
     };
-    if (typeof slug !== "string" || slug.trim() === "" || !Array.isArray(levels)) return null;
+    if (typeof slug !== "string" || slug.trim() === "" || !Array.isArray(levels)) continue;
     const parsedLevels = levels.map(parseReasoningLevel);
-    if (parsedLevels.some((level) => level === null)) return null;
+    if (parsedLevels.some((level) => level === null)) continue;
     models.set(slug.trim().toLowerCase(), new Set(parsedLevels.filter((level) => level !== undefined) as ReasoningEffort[]));
   }
   return models.size > 0 ? models : null;
@@ -101,11 +101,6 @@ export function resolveCodexModelCapabilities(
   if (existing && cacheTtlMs > 0 && existing.expiresAt > now) return existing.pending;
   const pending = probeCodexModelCapabilities(codexBinary, DEFAULT_CODEX_MODEL_CATALOG_PROBE_TIMEOUT_MS, cwd);
   cache.set(cacheKey, { pending, expiresAt: now + Math.max(0, cacheTtlMs) });
-  void pending.then((result) => {
-    if (result.source === "fallback" && cache.get(cacheKey)?.pending === pending) {
-      cache.delete(cacheKey);
-    }
-  });
   return pending;
 }
 

--- a/src/codex/codex-model-capabilities.ts
+++ b/src/codex/codex-model-capabilities.ts
@@ -92,6 +92,11 @@ export function resolveCodexModelCapabilities(
   if (existing) return existing;
   const pending = probeCodexModelCapabilities(codexBinary, 5_000, cwd);
   cache.set(cacheKey, pending);
+  void pending.then((result) => {
+    if (result.source === "fallback" && cache.get(cacheKey) === pending) {
+      cache.delete(cacheKey);
+    }
+  });
   return pending;
 }
 

--- a/src/codex/codex-model-capabilities.ts
+++ b/src/codex/codex-model-capabilities.ts
@@ -14,7 +14,14 @@ const REASONING_LEVELS = new Set<ReasoningEffort>(["none", "low", "medium", "hig
 const FALLBACK = new Map<string, ReadonlySet<ReasoningEffort>>([
   ["gpt-5.6-sol", new Set<ReasoningEffort>(["low", "medium", "high", "xhigh", "max"])],
 ]);
-const cache = new Map<string, Promise<CodexModelCapabilities>>();
+const LIVE_CATALOG_CACHE_TTL_MS = 60_000;
+
+interface CapabilityCacheEntry {
+  expiresAt: number;
+  pending: Promise<CodexModelCapabilities>;
+}
+
+const cache = new Map<string, CapabilityCacheEntry>();
 
 function fallback(reason: string): CodexModelCapabilities {
   return { reasoningLevelsByModel: FALLBACK, source: "fallback", fallbackReason: reason };
@@ -85,14 +92,16 @@ export async function probeCodexModelCapabilities(
 export function resolveCodexModelCapabilities(
   codexBinary: string,
   cwd = process.cwd(),
+  cacheTtlMs = LIVE_CATALOG_CACHE_TTL_MS,
 ): Promise<CodexModelCapabilities> {
   const cacheKey = JSON.stringify([codexBinary, path.resolve(cwd)]);
+  const now = Date.now();
   const existing = cache.get(cacheKey);
-  if (existing) return existing;
+  if (existing && cacheTtlMs > 0 && existing.expiresAt > now) return existing.pending;
   const pending = probeCodexModelCapabilities(codexBinary, 5_000, cwd);
-  cache.set(cacheKey, pending);
+  cache.set(cacheKey, { pending, expiresAt: now + Math.max(0, cacheTtlMs) });
   void pending.then((result) => {
-    if (result.source === "fallback" && cache.get(cacheKey) === pending) {
+    if (result.source === "fallback" && cache.get(cacheKey)?.pending === pending) {
       cache.delete(cacheKey);
     }
   });

--- a/src/codex/codex-model-capabilities.ts
+++ b/src/codex/codex-model-capabilities.ts
@@ -1,0 +1,89 @@
+import { CommandExecutionError, runCommand } from "../core/command";
+import { ReasoningEffort } from "../core/types";
+
+export type CodexCapabilitySource = "live_catalog" | "fallback";
+
+export interface CodexModelCapabilities {
+  reasoningLevelsByModel: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>;
+  source: CodexCapabilitySource;
+  fallbackReason: string | null;
+}
+
+const REASONING_LEVELS = new Set<ReasoningEffort>(["none", "low", "medium", "high", "xhigh", "max"]);
+const FALLBACK = new Map<string, ReadonlySet<ReasoningEffort>>([
+  ["gpt-5.6-sol", new Set<ReasoningEffort>(["low", "medium", "high", "xhigh", "max"])],
+]);
+const cache = new Map<string, Promise<CodexModelCapabilities>>();
+
+function fallback(reason: string): CodexModelCapabilities {
+  return { reasoningLevelsByModel: FALLBACK, source: "fallback", fallbackReason: reason };
+}
+
+function parseReasoningLevel(value: unknown): ReasoningEffort | null | undefined {
+  const candidate = typeof value === "string"
+    ? value
+    : value && typeof value === "object" && "effort" in value
+      ? (value as { effort?: unknown }).effort
+      : null;
+  if (typeof candidate !== "string") return null;
+  return REASONING_LEVELS.has(candidate as ReasoningEffort) ? candidate as ReasoningEffort : undefined;
+}
+
+export function parseCodexModelCatalog(raw: string): ReadonlyMap<string, ReadonlySet<ReasoningEffort>> | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  const entries = Array.isArray(parsed)
+    ? parsed
+    : parsed && typeof parsed === "object" && Array.isArray((parsed as { models?: unknown }).models)
+      ? (parsed as { models: unknown[] }).models
+      : null;
+  if (!entries) return null;
+
+  const models = new Map<string, ReadonlySet<ReasoningEffort>>();
+  for (const entry of entries) {
+    if (!entry || typeof entry !== "object") return null;
+    const { slug, supported_reasoning_levels: levels } = entry as {
+      slug?: unknown;
+      supported_reasoning_levels?: unknown;
+    };
+    if (typeof slug !== "string" || slug.trim() === "" || !Array.isArray(levels)) return null;
+    const parsedLevels = levels.map(parseReasoningLevel);
+    if (parsedLevels.some((level) => level === null)) return null;
+    models.set(slug.trim().toLowerCase(), new Set(parsedLevels.filter((level) => level !== undefined) as ReasoningEffort[]));
+  }
+  return models.size > 0 ? models : null;
+}
+
+export async function probeCodexModelCapabilities(
+  codexBinary: string,
+  timeoutMs = 5_000,
+): Promise<CodexModelCapabilities> {
+  try {
+    const result = await runCommand(codexBinary, ["debug", "models"], { timeoutMs });
+    const models = parseCodexModelCatalog(result.stdout);
+    return models
+      ? { reasoningLevelsByModel: models, source: "live_catalog", fallbackReason: null }
+      : fallback("malformed_catalog");
+  } catch (error) {
+    if (error instanceof CommandExecutionError) {
+      return fallback(error.timedOut ? "catalog_probe_timeout" : `catalog_probe_exit_${error.exitCode}`);
+    }
+    return fallback("catalog_probe_unavailable");
+  }
+}
+
+export function resolveCodexModelCapabilities(codexBinary: string): Promise<CodexModelCapabilities> {
+  const existing = cache.get(codexBinary);
+  if (existing) return existing;
+  const pending = probeCodexModelCapabilities(codexBinary);
+  cache.set(codexBinary, pending);
+  return pending;
+}
+
+export function clearCodexModelCapabilitiesCacheForTests(): void {
+  cache.clear();
+}

--- a/src/codex/codex-model-capabilities.ts
+++ b/src/codex/codex-model-capabilities.ts
@@ -27,7 +27,6 @@ function parseReasoningLevel(value: unknown): ReasoningEffort | null | undefined
       ? (value as { effort?: unknown }).effort
       : null;
   if (typeof candidate !== "string") return null;
-  if (candidate === "ultra") return "max";
   return REASONING_LEVELS.has(candidate as ReasoningEffort) ? candidate as ReasoningEffort : undefined;
 }
 

--- a/src/codex/codex-model-capabilities.ts
+++ b/src/codex/codex-model-capabilities.ts
@@ -1,3 +1,4 @@
+import path from "node:path";
 import { CommandExecutionError, runCommand } from "../core/command";
 import { ReasoningEffort } from "../core/types";
 
@@ -26,6 +27,7 @@ function parseReasoningLevel(value: unknown): ReasoningEffort | null | undefined
       ? (value as { effort?: unknown }).effort
       : null;
   if (typeof candidate !== "string") return null;
+  if (candidate === "ultra") return "max";
   return REASONING_LEVELS.has(candidate as ReasoningEffort) ? candidate as ReasoningEffort : undefined;
 }
 
@@ -61,9 +63,14 @@ export function parseCodexModelCatalog(raw: string): ReadonlyMap<string, Readonl
 export async function probeCodexModelCapabilities(
   codexBinary: string,
   timeoutMs = 5_000,
+  cwd?: string,
 ): Promise<CodexModelCapabilities> {
   try {
-    const result = await runCommand(codexBinary, ["debug", "models"], { timeoutMs });
+    const result = await runCommand(codexBinary, ["debug", "models"], {
+      cwd,
+      timeoutMs,
+      stdoutCaptureLimitBytes: null,
+    });
     const models = parseCodexModelCatalog(result.stdout);
     return models
       ? { reasoningLevelsByModel: models, source: "live_catalog", fallbackReason: null }
@@ -76,11 +83,15 @@ export async function probeCodexModelCapabilities(
   }
 }
 
-export function resolveCodexModelCapabilities(codexBinary: string): Promise<CodexModelCapabilities> {
-  const existing = cache.get(codexBinary);
+export function resolveCodexModelCapabilities(
+  codexBinary: string,
+  cwd = process.cwd(),
+): Promise<CodexModelCapabilities> {
+  const cacheKey = JSON.stringify([codexBinary, path.resolve(cwd)]);
+  const existing = cache.get(cacheKey);
   if (existing) return existing;
-  const pending = probeCodexModelCapabilities(codexBinary);
-  cache.set(codexBinary, pending);
+  const pending = probeCodexModelCapabilities(codexBinary, 5_000, cwd);
+  cache.set(cacheKey, pending);
   return pending;
 }
 

--- a/src/codex/codex-model-policy.test.ts
+++ b/src/codex/codex-model-policy.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { resolveHostCodexDefaultModel } from "./codex-model-policy";
+
+test("resolveHostCodexDefaultModel ignores untrusted workspace config", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-policy-untrusted-"));
+  const codexHome = path.join(root, "codex-home");
+  const workspace = path.join(root, "workspace");
+  const previousCodexHome = process.env.CODEX_HOME;
+  t.after(async () => {
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  process.env.CODEX_HOME = codexHome;
+  await fs.mkdir(path.join(workspace, ".codex"), { recursive: true });
+  await fs.mkdir(codexHome, { recursive: true });
+  await fs.writeFile(path.join(workspace, ".codex", "config.toml"), 'model = "gpt-5.6-sol"\n');
+  await fs.writeFile(path.join(codexHome, "config.toml"), 'model = "gpt-5.4"\n');
+
+  assert.deepEqual(await resolveHostCodexDefaultModel(workspace), {
+    model: "gpt-5.4",
+    source: path.join(codexHome, "config.toml"),
+  });
+});
+
+test("resolveHostCodexDefaultModel loads workspace config only for an explicitly trusted project", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-policy-trusted-"));
+  const codexHome = path.join(root, "codex-home");
+  const workspace = path.join(root, "workspace");
+  const previousCodexHome = process.env.CODEX_HOME;
+  t.after(async () => {
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  process.env.CODEX_HOME = codexHome;
+  await fs.mkdir(path.join(workspace, ".codex"), { recursive: true });
+  await fs.mkdir(codexHome, { recursive: true });
+  await fs.writeFile(path.join(workspace, ".codex", "config.toml"), 'model = "gpt-5.6-terra"\n');
+  await fs.writeFile(
+    path.join(codexHome, "config.toml"),
+    `model = "gpt-5.4"\n\n[projects.${JSON.stringify(workspace)}]\ntrust_level = "trusted"\n`,
+  );
+
+  assert.deepEqual(await resolveHostCodexDefaultModel(workspace), {
+    model: "gpt-5.6-terra",
+    source: path.join(workspace, ".codex", "config.toml"),
+  });
+});

--- a/src/codex/codex-model-policy.test.ts
+++ b/src/codex/codex-model-policy.test.ts
@@ -51,3 +51,28 @@ test("resolveHostCodexDefaultModel loads workspace config only for an explicitly
     source: path.join(workspace, ".codex", "config.toml"),
   });
 });
+
+test("resolveHostCodexDefaultModel decodes TOML escapes in trusted project keys", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-policy-escaped-trust-"));
+  const codexHome = path.join(root, "codex-home");
+  const workspace = path.join(root, String.raw`workspace\with\backslashes`);
+  const previousCodexHome = process.env.CODEX_HOME;
+  t.after(async () => {
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  process.env.CODEX_HOME = codexHome;
+  await fs.mkdir(path.join(workspace, ".codex"), { recursive: true });
+  await fs.mkdir(codexHome, { recursive: true });
+  await fs.writeFile(path.join(workspace, ".codex", "config.toml"), 'model = "gpt-5.6-terra"\n');
+  await fs.writeFile(
+    path.join(codexHome, "config.toml"),
+    `model = "gpt-5.4"\n\n[projects.${JSON.stringify(workspace)}]\ntrust_level = "trusted"\n`,
+  );
+
+  assert.deepEqual(await resolveHostCodexDefaultModel(workspace), {
+    model: "gpt-5.6-terra",
+    source: path.join(workspace, ".codex", "config.toml"),
+  });
+});

--- a/src/codex/codex-model-policy.ts
+++ b/src/codex/codex-model-policy.ts
@@ -111,21 +111,25 @@ function parseTopLevelTomlString(contents: string, key: string): string | null {
   return null;
 }
 
-export async function resolveHostCodexDefaultModel(): Promise<HostCodexDefaultModelResolution> {
-  const configPath = path.join(resolveCodexConfigDir(), "config.toml");
-  let raw: string;
-  try {
-    raw = await fs.readFile(configPath, "utf8");
-  } catch {
-    return {
-      model: null,
-      source: null,
-    };
+export async function resolveHostCodexDefaultModel(cwd?: string): Promise<HostCodexDefaultModelResolution> {
+  const configPaths = [
+    ...(cwd ? [path.join(path.resolve(cwd), ".codex", "config.toml")] : []),
+    path.join(resolveCodexConfigDir(), "config.toml"),
+  ];
+  for (const configPath of configPaths) {
+    try {
+      const model = parseTopLevelTomlString(await fs.readFile(configPath, "utf8"), "model");
+      if (model !== null) {
+        return { model, source: configPath };
+      }
+    } catch {
+      continue;
+    }
   }
 
   return {
-    model: parseTopLevelTomlString(raw, "model"),
-    source: configPath,
+    model: null,
+    source: null,
   };
 }
 
@@ -191,12 +195,13 @@ export async function buildCodexModelPolicySnapshot(args: {
   activeState: RunState;
   activeRecord?: Pick<
     IssueRunRecord,
-    "repeated_failure_signature_count" | "blocked_verification_retry_count" | "timeout_retry_count"
+    "workspace" | "repeated_failure_signature_count" | "blocked_verification_retry_count" | "timeout_retry_count"
   > | null;
 }): Promise<CodexModelPolicySnapshot> {
+  const workspace = args.activeRecord?.workspace;
   const [hostDefault, capabilities] = await Promise.all([
-    resolveHostCodexDefaultModel(),
-    resolveCodexModelCapabilities(args.config.codexBinary),
+    resolveHostCodexDefaultModel(workspace),
+    resolveCodexModelCapabilities(args.config.codexBinary, workspace),
   ]);
   const defaultRoute: CodexModelRouteResolution = {
     strategy: args.config.codexModelStrategy,

--- a/src/codex/codex-model-policy.ts
+++ b/src/codex/codex-model-policy.ts
@@ -53,6 +53,64 @@ function countTrailingBackslashes(value: string, endExclusive: number): number {
   return count;
 }
 
+function decodeTomlBasicString(value: string): string | null {
+  let decoded = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (character !== "\\") {
+      decoded += character;
+      continue;
+    }
+
+    const escape = value[index + 1];
+    if (escape === undefined) {
+      return null;
+    }
+    index += 1;
+    switch (escape) {
+      case "b":
+        decoded += "\b";
+        break;
+      case "t":
+        decoded += "\t";
+        break;
+      case "n":
+        decoded += "\n";
+        break;
+      case "f":
+        decoded += "\f";
+        break;
+      case "r":
+        decoded += "\r";
+        break;
+      case `"`:
+        decoded += `"`;
+        break;
+      case "\\":
+        decoded += "\\";
+        break;
+      case "u":
+      case "U": {
+        const length = escape === "u" ? 4 : 8;
+        const hex = value.slice(index + 1, index + 1 + length);
+        if (hex.length !== length || !/^[0-9a-fA-F]+$/u.test(hex)) {
+          return null;
+        }
+        const codePoint = Number.parseInt(hex, 16);
+        if (codePoint > 0x10ffff || (codePoint >= 0xd800 && codePoint <= 0xdfff)) {
+          return null;
+        }
+        decoded += String.fromCodePoint(codePoint);
+        index += length;
+        break;
+      }
+      default:
+        return null;
+    }
+  }
+  return decoded;
+}
+
 function parseTomlQuotedString(value: string): string | null {
   const trimmed = value.trim();
   const quote = trimmed[0];
@@ -72,7 +130,8 @@ function parseTomlQuotedString(value: string): string | null {
     if (trailing !== "" && !trailing.startsWith("#")) {
       return null;
     }
-    return trimmed.slice(1, index);
+    const parsed = trimmed.slice(1, index);
+    return quote === `"` ? decodeTomlBasicString(parsed) : parsed;
   }
 
   return null;

--- a/src/codex/codex-model-policy.ts
+++ b/src/codex/codex-model-policy.ts
@@ -111,14 +111,48 @@ function parseTopLevelTomlString(contents: string, key: string): string | null {
   return null;
 }
 
+function isCodexProjectTrusted(contents: string, cwd: string): boolean {
+  const resolvedCwd = path.resolve(cwd);
+  let currentProject: string | null = null;
+  for (const rawLine of contents.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    const projectHeader = /^\[projects\.(.+)\](?:\s+#.*)?$/u.exec(line);
+    if (projectHeader) {
+      const parsedProject = parseTomlQuotedString(projectHeader[1] ?? "");
+      currentProject = parsedProject === null ? null : path.resolve(parsedProject);
+      continue;
+    }
+    if (line.startsWith("[")) {
+      currentProject = null;
+      continue;
+    }
+    if (currentProject !== resolvedCwd) continue;
+
+    const separatorIndex = line.indexOf("=");
+    if (separatorIndex === -1 || line.slice(0, separatorIndex).trim() !== "trust_level") continue;
+    return parseTomlQuotedString(line.slice(separatorIndex + 1)) === "trusted";
+  }
+  return false;
+}
+
 export async function resolveHostCodexDefaultModel(cwd?: string): Promise<HostCodexDefaultModelResolution> {
-  const configPaths = [
-    ...(cwd ? [path.join(path.resolve(cwd), ".codex", "config.toml")] : []),
-    path.join(resolveCodexConfigDir(), "config.toml"),
-  ];
+  const userConfigPath = path.join(resolveCodexConfigDir(), "config.toml");
+  let userConfigContents: string | null = null;
+  try {
+    userConfigContents = await fs.readFile(userConfigPath, "utf8");
+  } catch {
+    // A missing user config also means there is no persisted project trust.
+  }
+
+  const configPaths = cwd && userConfigContents && isCodexProjectTrusted(userConfigContents, cwd)
+    ? [path.join(path.resolve(cwd), ".codex", "config.toml"), userConfigPath]
+    : [userConfigPath];
   for (const configPath of configPaths) {
     try {
-      const model = parseTopLevelTomlString(await fs.readFile(configPath, "utf8"), "model");
+      const contents = configPath === userConfigPath && userConfigContents !== null
+        ? userConfigContents
+        : await fs.readFile(configPath, "utf8");
+      const model = parseTopLevelTomlString(contents, "model");
       if (model !== null) {
         return { model, source: configPath };
       }

--- a/src/codex/codex-model-policy.ts
+++ b/src/codex/codex-model-policy.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { resolveCodexExecutionPolicy } from "./codex-policy";
+import { CodexModelCapabilities, resolveCodexModelCapabilities } from "./codex-model-capabilities";
 import { CodexExecutionTarget, CodexModelStrategy, IssueRunRecord, ReasoningEffort, RunState, SupervisorConfig } from "../core/types";
 
 export interface HostCodexDefaultModelResolution {
@@ -23,6 +24,7 @@ interface CodexModelRouteResolution {
 }
 
 export interface CodexModelPolicySnapshot {
+  capabilities: Pick<CodexModelCapabilities, "source" | "fallbackReason">;
   hostDefault: HostCodexDefaultModelResolution;
   defaultRoute: CodexModelRouteResolution;
   boundedRepairRoute: CodexModelRouteResolution;
@@ -184,6 +186,7 @@ export async function buildCodexModelPolicySnapshot(args: {
     | "localReviewModel"
     | "codexReasoningEffortByState"
     | "codexReasoningEscalateOnRepeatedFailure"
+    | "codexBinary"
   >;
   activeState: RunState;
   activeRecord?: Pick<
@@ -191,7 +194,10 @@ export async function buildCodexModelPolicySnapshot(args: {
     "repeated_failure_signature_count" | "blocked_verification_retry_count" | "timeout_retry_count"
   > | null;
 }): Promise<CodexModelPolicySnapshot> {
-  const hostDefault = await resolveHostCodexDefaultModel();
+  const [hostDefault, capabilities] = await Promise.all([
+    resolveHostCodexDefaultModel(),
+    resolveCodexModelCapabilities(args.config.codexBinary),
+  ]);
   const defaultRoute: CodexModelRouteResolution = {
     strategy: args.config.codexModelStrategy,
     configuredModel: args.config.codexModel ?? null,
@@ -232,7 +238,10 @@ export async function buildCodexModelPolicySnapshot(args: {
     args.activeState,
     args.activeRecord,
     activeTarget,
-    { inheritedModel: hostDefault.model },
+    {
+      inheritedModel: hostDefault.model,
+      reasoningLevelsByModel: capabilities.reasoningLevelsByModel,
+    },
   );
   const activeRoute = {
     ...activeBaseRoute,
@@ -243,6 +252,7 @@ export async function buildCodexModelPolicySnapshot(args: {
   };
 
   return {
+    capabilities: { source: capabilities.source, fallbackReason: capabilities.fallbackReason },
     hostDefault,
     defaultRoute,
     boundedRepairRoute,
@@ -256,7 +266,7 @@ export function renderDoctorCodexModelPolicyLines(snapshot: CodexModelPolicySnap
     `doctor_codex_model_policy default=${summarizeRoute(snapshot.defaultRoute)}`,
     `doctor_codex_route_overrides repair=${summarizeRoute(snapshot.boundedRepairRoute)} local_review=${summarizeRoute(snapshot.localReviewRoute)}`,
     `doctor_codex_host_default model=${snapshot.hostDefault.model ?? "unresolved"} source=${snapshot.hostDefault.source ?? "unresolved"}`,
-    `doctor_codex_reasoning active=${snapshot.activeRoute.target} requested=${snapshot.activeRoute.requestedReasoningEffort} effective=${snapshot.activeRoute.reasoningEffort}`,
+    `doctor_codex_reasoning active=${snapshot.activeRoute.target} requested=${snapshot.activeRoute.requestedReasoningEffort} effective=${snapshot.activeRoute.reasoningEffort} capability_source=${snapshot.capabilities.source} fallback_reason=${snapshot.capabilities.fallbackReason ?? "none"}`,
   ];
 }
 
@@ -265,7 +275,7 @@ export function renderStatusCodexModelPolicyLines(snapshot: CodexModelPolicySnap
     ? ""
     : ` requested_reasoning=${snapshot.activeRoute.requestedReasoningEffort}`;
   return [
-    `codex_execution_policy active=${snapshot.activeRoute.target}:${summarizeRoute(snapshot.activeRoute)} reasoning=${snapshot.activeRoute.reasoningEffort}${requestedSuffix}`,
+    `codex_execution_policy active=${snapshot.activeRoute.target}:${summarizeRoute(snapshot.activeRoute)} reasoning=${snapshot.activeRoute.reasoningEffort}${requestedSuffix} capability_source=${snapshot.capabilities.source} fallback_reason=${snapshot.capabilities.fallbackReason ?? "none"}`,
     `codex_route_overrides repair=${summarizeRoute(snapshot.boundedRepairRoute)} local_review=${summarizeRoute(snapshot.localReviewRoute)}`,
   ];
 }

--- a/src/codex/codex-model-policy.ts
+++ b/src/codex/codex-model-policy.ts
@@ -32,8 +32,8 @@ export interface CodexModelPolicySnapshot {
   activeRoute: CodexModelRouteResolution & {
     state: RunState;
     target: CodexExecutionTarget;
-    requestedReasoningEffort: ReasoningEffort;
-    reasoningEffort: ReasoningEffort;
+    requestedReasoningEffort: ReasoningEffort | null;
+    reasoningEffort: ReasoningEffort | null;
   };
 }
 
@@ -271,7 +271,7 @@ export function renderDoctorCodexModelPolicyLines(snapshot: CodexModelPolicySnap
     `doctor_codex_model_policy default=${summarizeRoute(snapshot.defaultRoute)}`,
     `doctor_codex_route_overrides repair=${summarizeRoute(snapshot.boundedRepairRoute)} local_review=${summarizeRoute(snapshot.localReviewRoute)}`,
     `doctor_codex_host_default model=${snapshot.hostDefault.model ?? "unresolved"} source=${snapshot.hostDefault.source ?? "unresolved"}`,
-    `doctor_codex_reasoning active=${snapshot.activeRoute.target} requested=${snapshot.activeRoute.requestedReasoningEffort} effective=${snapshot.activeRoute.reasoningEffort} capability_source=${snapshot.capabilities.source} fallback_reason=${snapshot.capabilities.fallbackReason ?? "none"}`,
+    `doctor_codex_reasoning active=${snapshot.activeRoute.target} requested=${snapshot.activeRoute.requestedReasoningEffort ?? "default"} effective=${snapshot.activeRoute.reasoningEffort ?? "default"} capability_source=${snapshot.capabilities.source} fallback_reason=${snapshot.capabilities.fallbackReason ?? "none"}`,
   ];
 }
 
@@ -280,7 +280,7 @@ export function renderStatusCodexModelPolicyLines(snapshot: CodexModelPolicySnap
     ? ""
     : ` requested_reasoning=${snapshot.activeRoute.requestedReasoningEffort}`;
   return [
-    `codex_execution_policy active=${snapshot.activeRoute.target}:${summarizeRoute(snapshot.activeRoute)} reasoning=${snapshot.activeRoute.reasoningEffort}${requestedSuffix} capability_source=${snapshot.capabilities.source} fallback_reason=${snapshot.capabilities.fallbackReason ?? "none"}`,
+    `codex_execution_policy active=${snapshot.activeRoute.target}:${summarizeRoute(snapshot.activeRoute)} reasoning=${snapshot.activeRoute.reasoningEffort ?? "default"}${requestedSuffix} capability_source=${snapshot.capabilities.source} fallback_reason=${snapshot.capabilities.fallbackReason ?? "none"}`,
     `codex_route_overrides repair=${summarizeRoute(snapshot.boundedRepairRoute)} local_review=${summarizeRoute(snapshot.localReviewRoute)}`,
   ];
 }

--- a/src/codex/codex-model-policy.ts
+++ b/src/codex/codex-model-policy.ts
@@ -3,6 +3,7 @@ import os from "node:os";
 import path from "node:path";
 import { resolveCodexExecutionPolicy } from "./codex-policy";
 import { CodexModelCapabilities, resolveCodexModelCapabilities } from "./codex-model-capabilities";
+import { resolveTrackedIssueHostPaths } from "../core/journal";
 import { CodexExecutionTarget, CodexModelStrategy, IssueRunRecord, ReasoningEffort, RunState, SupervisorConfig } from "../core/types";
 
 export interface HostCodexDefaultModelResolution {
@@ -284,14 +285,23 @@ export async function buildCodexModelPolicySnapshot(args: {
     | "codexReasoningEffortByState"
     | "codexReasoningEscalateOnRepeatedFailure"
     | "codexBinary"
+    | "workspaceRoot"
+    | "issueJournalRelativePath"
   >;
   activeState: RunState;
   activeRecord?: Pick<
     IssueRunRecord,
-    "workspace" | "repeated_failure_signature_count" | "blocked_verification_retry_count" | "timeout_retry_count"
+    | "issue_number"
+    | "workspace"
+    | "journal_path"
+    | "repeated_failure_signature_count"
+    | "blocked_verification_retry_count"
+    | "timeout_retry_count"
   > | null;
 }): Promise<CodexModelPolicySnapshot> {
-  const workspace = args.activeRecord?.workspace;
+  const workspace = args.activeRecord
+    ? resolveTrackedIssueHostPaths(args.config, args.activeRecord).workspace
+    : undefined;
   const [hostDefault, capabilities] = await Promise.all([
     resolveHostCodexDefaultModel(workspace),
     resolveCodexModelCapabilities(args.config.codexBinary, workspace),

--- a/src/codex/codex-policy.test.ts
+++ b/src/codex/codex-policy.test.ts
@@ -251,6 +251,31 @@ test("resolveCodexExecutionPolicy allows catalog-backed Terra and Luna routes to
   }
 });
 
+test("resolveCodexExecutionPolicy clamps every unsupported effort to the live catalog", () => {
+  const capabilities = new Map([
+    ["gpt-5.6-terra", new Set(["low", "medium", "high", "xhigh"] as const)],
+  ]);
+  const noneConfig = createConfig({
+    codexModel: "gpt-5.6-terra",
+    codexReasoningEffortByState: { implementing: "none" },
+  });
+  assert.deepEqual(resolveCodexExecutionPolicy(noneConfig, "implementing", undefined, "supervisor", {
+    reasoningLevelsByModel: capabilities,
+  }), {
+    model: "gpt-5.6-terra",
+    reasoningEffort: "low",
+    requestedReasoningEffort: "none",
+  });
+
+  const maxConfig = createConfig({
+    codexModel: "gpt-5.6-terra",
+    codexReasoningEffortByState: { implementing: "max" },
+  });
+  assert.equal(resolveCodexExecutionPolicy(maxConfig, "implementing", undefined, "supervisor", {
+    reasoningLevelsByModel: capabilities,
+  }).reasoningEffort, "xhigh");
+});
+
 test("resolveCodexExecutionPolicy applies inherited host-model capabilities without forcing a model override", () => {
   const config = createConfig({
     codexModelStrategy: "inherit",

--- a/src/codex/codex-policy.test.ts
+++ b/src/codex/codex-policy.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
-import { resolveCodexExecutionPolicy } from "./codex-policy";
+import { buildCodexConfigOverrideArgs, resolveCodexExecutionPolicy } from "./codex-policy";
 import { type SupervisorConfig } from "../core/types";
 
 function createConfig(overrides: Partial<SupervisorConfig> = {}): SupervisorConfig {
@@ -274,6 +274,41 @@ test("resolveCodexExecutionPolicy clamps every unsupported effort to the live ca
   assert.equal(resolveCodexExecutionPolicy(maxConfig, "implementing", undefined, "supervisor", {
     reasoningLevelsByModel: capabilities,
   }).reasoningEffort, "xhigh");
+});
+
+test("resolveCodexExecutionPolicy lets live catalogs override legacy Pro clamps", () => {
+  const policy = resolveCodexExecutionPolicy(
+    createConfig({
+      codexModel: "gpt-5-pro",
+      codexReasoningEffortByState: { implementing: "xhigh" },
+    }),
+    "implementing",
+    undefined,
+    "supervisor",
+    { reasoningLevelsByModel: new Map([["gpt-5-pro", new Set(["high", "xhigh"] as const)]]) },
+  );
+
+  assert.deepEqual(policy, { model: "gpt-5-pro", reasoningEffort: "xhigh" });
+});
+
+test("resolveCodexExecutionPolicy suppresses reasoning overrides for empty live capability sets", () => {
+  const policy = resolveCodexExecutionPolicy(
+    createConfig({
+      codexModel: "catalog-model",
+      codexReasoningEffortByState: { implementing: "high" },
+    }),
+    "implementing",
+    undefined,
+    "supervisor",
+    { reasoningLevelsByModel: new Map([["catalog-model", new Set()]]) },
+  );
+
+  assert.deepEqual(policy, {
+    model: "catalog-model",
+    reasoningEffort: null,
+    requestedReasoningEffort: "high",
+  });
+  assert.deepEqual(buildCodexConfigOverrideArgs(policy), ["-m", "catalog-model"]);
 });
 
 test("resolveCodexExecutionPolicy applies inherited host-model capabilities without forcing a model override", () => {

--- a/src/codex/codex-policy.test.ts
+++ b/src/codex/codex-policy.test.ts
@@ -264,6 +264,27 @@ test("resolveCodexExecutionPolicy uses Codex-style alias and dated-suffix catalo
   }
 });
 
+test("resolveCodexExecutionPolicy maps the unsuffixed GPT-5.6 alias to Sol catalog capabilities", () => {
+  const capabilities = new Map([
+    ["gpt-5.6-sol", new Set(["high", "xhigh", "max"] as const)],
+  ]);
+  for (const model of ["gpt-5.6", "openai/gpt-5.6"]) {
+    const config = createConfig({ codexModel: model, codexReasoningEffortByState: { implementing: "max" } });
+    assert.equal(resolveCodexExecutionPolicy(config, "implementing", undefined, "supervisor", {
+      reasoningLevelsByModel: capabilities,
+    }).reasoningEffort, "max");
+  }
+
+  const directAliasCapabilities = new Map(capabilities).set("gpt-5.6", new Set(["high"] as const));
+  const directAliasConfig = createConfig({
+    codexModel: "gpt-5.6",
+    codexReasoningEffortByState: { implementing: "max" },
+  });
+  assert.equal(resolveCodexExecutionPolicy(directAliasConfig, "implementing", undefined, "supervisor", {
+    reasoningLevelsByModel: directAliasCapabilities,
+  }).reasoningEffort, "high");
+});
+
 test("resolveCodexExecutionPolicy clamps every unsupported effort to the live catalog", () => {
   const capabilities = new Map([
     ["gpt-5.6-terra", new Set(["low", "medium", "high", "xhigh"] as const)],

--- a/src/codex/codex-policy.test.ts
+++ b/src/codex/codex-policy.test.ts
@@ -251,6 +251,19 @@ test("resolveCodexExecutionPolicy allows catalog-backed Terra and Luna routes to
   }
 });
 
+test("resolveCodexExecutionPolicy uses Codex-style alias and dated-suffix catalog matching", () => {
+  const capabilities = new Map([
+    ["gpt-5.6", new Set(["high"] as const)],
+    ["gpt-5.6-terra", new Set(["high", "xhigh", "max"] as const)],
+  ]);
+  for (const model of ["openai/gpt-5.6-terra", "gpt-5.6-terra-2026-07-10"]) {
+    const config = createConfig({ codexModel: model, codexReasoningEffortByState: { implementing: "max" } });
+    assert.equal(resolveCodexExecutionPolicy(config, "implementing", undefined, "supervisor", {
+      reasoningLevelsByModel: capabilities,
+    }).reasoningEffort, "max");
+  }
+});
+
 test("resolveCodexExecutionPolicy clamps every unsupported effort to the live catalog", () => {
   const capabilities = new Map([
     ["gpt-5.6-terra", new Set(["low", "medium", "high", "xhigh"] as const)],

--- a/src/codex/codex-policy.test.ts
+++ b/src/codex/codex-policy.test.ts
@@ -238,6 +238,19 @@ test("resolveCodexExecutionPolicy clamps max to each model family's highest supp
   );
 });
 
+test("resolveCodexExecutionPolicy allows catalog-backed Terra and Luna routes to emit max", () => {
+  const capabilities = new Map([
+    ["gpt-5.6-terra", new Set(["high", "xhigh", "max"] as const)],
+    ["gpt-5.6-luna", new Set(["high", "xhigh", "max"] as const)],
+  ]);
+  for (const model of capabilities.keys()) {
+    const config = createConfig({ codexModel: model, codexReasoningEffortByState: { implementing: "max" } });
+    assert.equal(resolveCodexExecutionPolicy(config, "implementing", undefined, "supervisor", {
+      reasoningLevelsByModel: capabilities,
+    }).reasoningEffort, "max");
+  }
+});
+
 test("resolveCodexExecutionPolicy applies inherited host-model capabilities without forcing a model override", () => {
   const config = createConfig({
     codexModelStrategy: "inherit",

--- a/src/codex/codex-policy.ts
+++ b/src/codex/codex-policy.ts
@@ -94,13 +94,41 @@ function supportsMaxReasoningEffort(
   return normalized === "gpt-5.6-sol" || normalized?.startsWith("gpt-5.6-sol-") === true;
 }
 
+function resolveCatalogReasoningLevels(
+  model: string,
+  reasoningLevelsByModel: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>,
+): ReadonlySet<ReasoningEffort> | undefined {
+  const exact = reasoningLevelsByModel.get(model);
+  if (exact) return exact;
+
+  const namespaceSeparator = model.indexOf("/");
+  const lookupModel = namespaceSeparator > 0 && namespaceSeparator === model.lastIndexOf("/")
+    ? model.slice(namespaceSeparator + 1)
+    : model;
+  const namespacedExact = reasoningLevelsByModel.get(lookupModel);
+  if (namespacedExact) return namespacedExact;
+
+  let longestPrefix: string | null = null;
+  for (const catalogModel of reasoningLevelsByModel.keys()) {
+    if (
+      lookupModel.startsWith(`${catalogModel}-`)
+      && (longestPrefix === null || catalogModel.length > longestPrefix.length)
+    ) {
+      longestPrefix = catalogModel;
+    }
+  }
+  return longestPrefix === null ? undefined : reasoningLevelsByModel.get(longestPrefix);
+}
+
 function clampReasoningEffortForModel(
   model: string | null,
   effort: ReasoningEffort,
   reasoningLevelsByModel?: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>,
 ): ReasoningEffort | null {
   const normalized = model?.trim().toLowerCase();
-  const supported = normalized ? reasoningLevelsByModel?.get(normalized) : undefined;
+  const supported = normalized && reasoningLevelsByModel
+    ? resolveCatalogReasoningLevels(normalized, reasoningLevelsByModel)
+    : undefined;
   if (supported) {
     if (supported.size === 0) return null;
     if (supported.has(effort)) return effort;

--- a/src/codex/codex-policy.ts
+++ b/src/codex/codex-policy.ts
@@ -103,33 +103,43 @@ function clampReasoningEffortForModel(
   effort: ReasoningEffort,
   reasoningLevelsByModel?: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>,
 ): ReasoningEffort {
+  let clamped = effort;
   if (effort === "max") {
     if (supportsMaxReasoningEffort(model, reasoningLevelsByModel)) {
-      return "max";
+      clamped = "max";
+    } else {
+      clamped = model?.toLowerCase().includes("gpt-5-pro") ? "high" : "xhigh";
     }
-
-    return model?.toLowerCase().includes("gpt-5-pro") ? "high" : "xhigh";
+  } else if (model) {
+    const normalized = model.toLowerCase();
+    if (normalized.includes("gpt-5-pro")) {
+      clamped = effort === "xhigh" ? "high" : effort;
+    } else if (
+      normalized.includes("gpt-5.3-codex") ||
+      normalized.includes("gpt-5.2-codex") ||
+      normalized.includes("gpt-5.1-codex") ||
+      normalized.includes("codex")
+    ) {
+      clamped = effort === "none" ? "low" : effort;
+    }
   }
 
-  if (!model) {
-    return effort;
+  const normalized = model?.trim().toLowerCase();
+  const supported = normalized ? reasoningLevelsByModel?.get(normalized) : undefined;
+  if (!supported || supported.size === 0 || supported.has(clamped)) {
+    return clamped;
   }
 
-  const normalized = model.toLowerCase();
-  if (normalized.includes("gpt-5-pro")) {
-    return effort === "xhigh" ? "high" : effort;
+  const requestedIndex = REASONING_ORDER.indexOf(clamped);
+  for (let index = requestedIndex - 1; index >= 0; index -= 1) {
+    const candidate = REASONING_ORDER[index];
+    if (candidate && supported.has(candidate)) return candidate;
   }
-
-  if (
-    normalized.includes("gpt-5.3-codex") ||
-    normalized.includes("gpt-5.2-codex") ||
-    normalized.includes("gpt-5.1-codex") ||
-    normalized.includes("codex")
-  ) {
-    return effort === "none" ? "low" : effort;
+  for (let index = requestedIndex + 1; index < REASONING_ORDER.length; index += 1) {
+    const candidate = REASONING_ORDER[index];
+    if (candidate && supported.has(candidate)) return candidate;
   }
-
-  return effort;
+  return clamped;
 }
 
 function resolveRequestedReasoningEffort(

--- a/src/codex/codex-policy.ts
+++ b/src/codex/codex-policy.ts
@@ -29,7 +29,7 @@ const DEFAULT_REASONING_BY_STATE: Record<RunState, ReasoningEffort> = {
 
 export interface CodexExecutionPolicy {
   model: string | null;
-  reasoningEffort: ReasoningEffort;
+  reasoningEffort: ReasoningEffort | null;
   requestedReasoningEffort?: ReasoningEffort;
 }
 
@@ -89,12 +89,8 @@ function reasoningEffortAtLeast(effort: ReasoningEffort, minimum: ReasoningEffor
 
 function supportsMaxReasoningEffort(
   model: string | null,
-  reasoningLevelsByModel?: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>,
 ): boolean {
   const normalized = model?.trim().toLowerCase();
-  if (normalized && reasoningLevelsByModel?.has(normalized)) {
-    return reasoningLevelsByModel.get(normalized)?.has("max") === true;
-  }
   return normalized === "gpt-5.6-sol" || normalized?.startsWith("gpt-5.6-sol-") === true;
 }
 
@@ -102,10 +98,28 @@ function clampReasoningEffortForModel(
   model: string | null,
   effort: ReasoningEffort,
   reasoningLevelsByModel?: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>,
-): ReasoningEffort {
+): ReasoningEffort | null {
+  const normalized = model?.trim().toLowerCase();
+  const supported = normalized ? reasoningLevelsByModel?.get(normalized) : undefined;
+  if (supported) {
+    if (supported.size === 0) return null;
+    if (supported.has(effort)) return effort;
+
+    const requestedIndex = REASONING_ORDER.indexOf(effort);
+    for (let index = requestedIndex - 1; index >= 0; index -= 1) {
+      const candidate = REASONING_ORDER[index];
+      if (candidate && supported.has(candidate)) return candidate;
+    }
+    for (let index = requestedIndex + 1; index < REASONING_ORDER.length; index += 1) {
+      const candidate = REASONING_ORDER[index];
+      if (candidate && supported.has(candidate)) return candidate;
+    }
+    return null;
+  }
+
   let clamped = effort;
   if (effort === "max") {
-    if (supportsMaxReasoningEffort(model, reasoningLevelsByModel)) {
+    if (supportsMaxReasoningEffort(model)) {
       clamped = "max";
     } else {
       clamped = model?.toLowerCase().includes("gpt-5-pro") ? "high" : "xhigh";
@@ -124,21 +138,6 @@ function clampReasoningEffortForModel(
     }
   }
 
-  const normalized = model?.trim().toLowerCase();
-  const supported = normalized ? reasoningLevelsByModel?.get(normalized) : undefined;
-  if (!supported || supported.size === 0 || supported.has(clamped)) {
-    return clamped;
-  }
-
-  const requestedIndex = REASONING_ORDER.indexOf(clamped);
-  for (let index = requestedIndex - 1; index >= 0; index -= 1) {
-    const candidate = REASONING_ORDER[index];
-    if (candidate && supported.has(candidate)) return candidate;
-  }
-  for (let index = requestedIndex + 1; index < REASONING_ORDER.length; index += 1) {
-    const candidate = REASONING_ORDER[index];
-    if (candidate && supported.has(candidate)) return candidate;
-  }
   return clamped;
 }
 
@@ -246,7 +245,9 @@ export function buildCodexConfigOverrideArgs(policy: CodexExecutionPolicy): stri
     args.push("-m", policy.model);
   }
 
-  args.push("-c", `model_reasoning_effort="${policy.reasoningEffort}"`);
+  if (policy.reasoningEffort !== null) {
+    args.push("-c", `model_reasoning_effort="${policy.reasoningEffort}"`);
+  }
   return args;
 }
 

--- a/src/codex/codex-policy.ts
+++ b/src/codex/codex-policy.ts
@@ -35,6 +35,7 @@ export interface CodexExecutionPolicy {
 
 export interface CodexExecutionPolicyContext {
   inheritedModel?: string | null;
+  reasoningLevelsByModel?: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>;
 }
 
 type CodexExecutionPolicyConfig = Pick<
@@ -86,14 +87,24 @@ function reasoningEffortAtLeast(effort: ReasoningEffort, minimum: ReasoningEffor
   return REASONING_ORDER[index] ?? effort;
 }
 
-function supportsMaxReasoningEffort(model: string | null): boolean {
+function supportsMaxReasoningEffort(
+  model: string | null,
+  reasoningLevelsByModel?: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>,
+): boolean {
   const normalized = model?.trim().toLowerCase();
+  if (normalized && reasoningLevelsByModel?.has(normalized)) {
+    return reasoningLevelsByModel.get(normalized)?.has("max") === true;
+  }
   return normalized === "gpt-5.6-sol" || normalized?.startsWith("gpt-5.6-sol-") === true;
 }
 
-function clampReasoningEffortForModel(model: string | null, effort: ReasoningEffort): ReasoningEffort {
+function clampReasoningEffortForModel(
+  model: string | null,
+  effort: ReasoningEffort,
+  reasoningLevelsByModel?: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>,
+): ReasoningEffort {
   if (effort === "max") {
-    if (supportsMaxReasoningEffort(model)) {
+    if (supportsMaxReasoningEffort(model, reasoningLevelsByModel)) {
       return "max";
     }
 
@@ -207,7 +218,11 @@ export function resolveCodexExecutionPolicy(
 ): CodexExecutionPolicy {
   const model = resolveConfiguredModel(config, state, target);
   const requestedEffort = resolveRequestedReasoningEffort(config, state, record);
-  const reasoningEffort = clampReasoningEffortForModel(model ?? context.inheritedModel ?? null, requestedEffort);
+  const reasoningEffort = clampReasoningEffortForModel(
+    model ?? context.inheritedModel ?? null,
+    requestedEffort,
+    context.reasoningLevelsByModel,
+  );
   return {
     model,
     reasoningEffort,

--- a/src/codex/codex-policy.ts
+++ b/src/codex/codex-policy.ts
@@ -5,6 +5,9 @@ import {
 } from "../codex-connector-review-churn";
 
 const REASONING_ORDER: ReasoningEffort[] = ["none", "low", "medium", "high", "xhigh", "max"];
+const CODEX_MODEL_CATALOG_ALIASES: Readonly<Record<string, string>> = {
+  "gpt-5.6": "gpt-5.6-sol",
+};
 
 const DEFAULT_REASONING_BY_STATE: Record<RunState, ReasoningEffort> = {
   queued: "low",
@@ -107,6 +110,10 @@ function resolveCatalogReasoningLevels(
     : model;
   const namespacedExact = reasoningLevelsByModel.get(lookupModel);
   if (namespacedExact) return namespacedExact;
+
+  const aliasedModel = CODEX_MODEL_CATALOG_ALIASES[lookupModel];
+  const aliasedExact = aliasedModel ? reasoningLevelsByModel.get(aliasedModel) : undefined;
+  if (aliasedExact) return aliasedExact;
 
   let longestPrefix: string | null = null;
   for (const catalogModel of reasoningLevelsByModel.keys()) {

--- a/src/codex/codex-runner.test.ts
+++ b/src/codex/codex-runner.test.ts
@@ -308,11 +308,24 @@ exit 0
 test("runCodexTurn resolves inherited models from the target workspace before clamping", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-runner-workspace-model-"));
   const workspacePath = path.join(root, "workspace");
+  const codexHome = path.join(root, "codex-home");
   const codexBinary = path.join(root, "fake-codex.sh");
   const argsPath = path.join(root, "args.log");
-  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const previousCodexHome = process.env.CODEX_HOME;
+  t.after(async () => {
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  process.env.CODEX_HOME = codexHome;
   await fs.mkdir(path.join(workspacePath, ".codex"), { recursive: true });
+  await fs.mkdir(codexHome, { recursive: true });
   await fs.writeFile(path.join(workspacePath, ".codex", "config.toml"), 'model = "gpt-5.6-terra"\n', "utf8");
+  await fs.writeFile(
+    path.join(codexHome, "config.toml"),
+    `[projects.${JSON.stringify(workspacePath)}]\ntrust_level = "trusted"\n`,
+    "utf8",
+  );
 
   await writeExecutableScript(
     codexBinary,

--- a/src/codex/codex-runner.test.ts
+++ b/src/codex/codex-runner.test.ts
@@ -305,6 +305,48 @@ exit 0
   ]);
 });
 
+test("runCodexTurn resolves inherited models from the target workspace before clamping", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-runner-workspace-model-"));
+  const workspacePath = path.join(root, "workspace");
+  const codexBinary = path.join(root, "fake-codex.sh");
+  const argsPath = path.join(root, "args.log");
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  await fs.mkdir(path.join(workspacePath, ".codex"), { recursive: true });
+  await fs.writeFile(path.join(workspacePath, ".codex", "config.toml"), 'model = "gpt-5.6-terra"\n', "utf8");
+
+  await writeExecutableScript(
+    codexBinary,
+    `#!/bin/sh
+set -eu
+if [ "$1" = "debug" ] && [ "$2" = "models" ]; then
+  printf '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["high","xhigh","max"]}]}'
+  exit 0
+fi
+printf '%s\n' "$@" > "${argsPath}"
+exit 0
+`,
+  );
+
+  await runCodexTurn(
+    createConfig({
+      codexBinary,
+      codexModelStrategy: "inherit",
+      codexReasoningEffortByState: { implementing: "max" },
+    }),
+    workspacePath,
+    "workspace inherited max prompt",
+    "implementing",
+  );
+  const args = (await fs.readFile(argsPath, "utf8")).trim().split("\n");
+
+  assert.equal(args.includes("-m"), false);
+  assert.deepEqual(args.slice(0, 3), [
+    "exec",
+    "-c",
+    'model_reasoning_effort="max"',
+  ]);
+});
+
 test("runCodexTurn removes its temp dir when command execution fails", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-runner-test-"));
   const workspacePath = path.join(root, "workspace");

--- a/src/codex/codex-runner.ts
+++ b/src/codex/codex-runner.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { runCommand } from "../core/command";
 import { buildCodexConfigOverrideArgs, buildCodexExecutionSafetyArgs, resolveCodexExecutionPolicy } from "./codex-policy";
 import { resolveHostCodexDefaultModel } from "./codex-model-policy";
+import { resolveCodexModelCapabilities } from "./codex-model-capabilities";
 import { CodexTurnResult, IssueRunRecord, RunState, SupervisorConfig } from "../core/types";
 
 function extractSessionId(stdout: string, sessionId?: string | null): string | null {
@@ -46,9 +47,15 @@ export async function runCodexTurn(
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-"));
   const messageFile = path.join(tempDir, "last-message.txt");
   try {
-    const hostDefault = await resolveHostCodexDefaultModel();
+    const [hostDefault, capabilities] = await Promise.all([
+      resolveHostCodexDefaultModel(),
+      resolveCodexModelCapabilities(config.codexBinary),
+    ]);
     const overrideArgs = buildCodexConfigOverrideArgs(
-      resolveCodexExecutionPolicy(config, state, record, "supervisor", { inheritedModel: hostDefault.model }),
+      resolveCodexExecutionPolicy(config, state, record, "supervisor", {
+        inheritedModel: hostDefault.model,
+        reasoningLevelsByModel: capabilities.reasoningLevelsByModel,
+      }),
     );
     const executionSafetyArgs = buildCodexExecutionSafetyArgs(config);
     const commandArgs = sessionId

--- a/src/codex/codex-runner.ts
+++ b/src/codex/codex-runner.ts
@@ -49,7 +49,7 @@ export async function runCodexTurn(
   try {
     const [hostDefault, capabilities] = await Promise.all([
       resolveHostCodexDefaultModel(),
-      resolveCodexModelCapabilities(config.codexBinary),
+      resolveCodexModelCapabilities(config.codexBinary, workspacePath),
     ]);
     const overrideArgs = buildCodexConfigOverrideArgs(
       resolveCodexExecutionPolicy(config, state, record, "supervisor", {

--- a/src/codex/codex-runner.ts
+++ b/src/codex/codex-runner.ts
@@ -48,7 +48,7 @@ export async function runCodexTurn(
   const messageFile = path.join(tempDir, "last-message.txt");
   try {
     const [hostDefault, capabilities] = await Promise.all([
-      resolveHostCodexDefaultModel(),
+      resolveHostCodexDefaultModel(workspacePath),
       resolveCodexModelCapabilities(config.codexBinary, workspacePath),
     ]);
     const overrideArgs = buildCodexConfigOverrideArgs(

--- a/src/codex/fixtures/model-catalog-gpt-5.6.json
+++ b/src/codex/fixtures/model-catalog-gpt-5.6.json
@@ -1,0 +1,7 @@
+{
+  "models": [
+    { "slug": "gpt-5.6-sol", "supported_reasoning_levels": [{ "effort": "high" }, { "effort": "xhigh" }, { "effort": "max" }, { "effort": "ultra" }] },
+    { "slug": "gpt-5.6-terra", "supported_reasoning_levels": [{ "effort": "high" }, { "effort": "xhigh" }, { "effort": "max" }, { "effort": "ultra" }] },
+    { "slug": "gpt-5.6-luna", "supported_reasoning_levels": [{ "effort": "high" }, { "effort": "xhigh" }, { "effort": "max" }] }
+  ]
+}

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -816,7 +816,11 @@ test("diagnoseSupervisorHost reports the active workspace Codex model and catalo
   });
 
   await fs.mkdir(codexHome, { recursive: true });
-  await fs.writeFile(path.join(codexHome, "config.toml"), 'model = "gpt-5.6-sol"\n', "utf8");
+  await fs.writeFile(
+    path.join(codexHome, "config.toml"),
+    `model = "gpt-5.6-sol"\n\n[projects.${JSON.stringify(workspace)}]\ntrust_level = "trusted"\n`,
+    "utf8",
+  );
   await fs.mkdir(path.join(workspace, ".codex"), { recursive: true });
   await fs.writeFile(path.join(workspace, ".codex", "config.toml"), 'model = "gpt-5.6-terra"\n', "utf8");
   await fs.writeFile(codexBinary, `#!/bin/sh

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -798,6 +798,60 @@ test("diagnoseSupervisorHost reports inherited host Codex defaults in doctor out
   assert.match(report, /doctor_codex_reasoning active=supervisor requested=max effective=xhigh/);
 });
 
+test("diagnoseSupervisorHost reports the active workspace Codex model and catalog", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-workspace-model-"));
+  const codexHome = path.join(root, "codex-home");
+  const repoPath = path.join(root, "repo");
+  const workspaceRoot = path.join(root, "workspaces");
+  const workspace = path.join(workspaceRoot, "issue-102");
+  const codexBinary = path.join(root, "fake-codex.sh");
+  const previousCodexHome = process.env.CODEX_HOME;
+  t.after(async () => {
+    if (previousCodexHome === undefined) {
+      delete process.env.CODEX_HOME;
+    } else {
+      process.env.CODEX_HOME = previousCodexHome;
+    }
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  await fs.mkdir(codexHome, { recursive: true });
+  await fs.writeFile(path.join(codexHome, "config.toml"), 'model = "gpt-5.6-sol"\n', "utf8");
+  await fs.mkdir(path.join(workspace, ".codex"), { recursive: true });
+  await fs.writeFile(path.join(workspace, ".codex", "config.toml"), 'model = "gpt-5.6-terra"\n', "utf8");
+  await fs.writeFile(codexBinary, `#!/bin/sh
+if [ ! -f .codex/config.toml ]; then
+  exit 9
+fi
+printf '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["max"]}]}'
+`, { mode: 0o755 });
+  await fs.mkdir(repoPath, { recursive: true });
+  execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
+  process.env.CODEX_HOME = codexHome;
+
+  const activeRecord = createRecord({ state: "implementing", workspace });
+  const diagnostics = await diagnoseSupervisorHost({
+    config: createConfig({
+      repoPath,
+      workspaceRoot,
+      stateFile: path.join(root, "state.json"),
+      codexBinary,
+      codexModelStrategy: "inherit",
+      codexReasoningEffortByState: { implementing: "max" },
+    }),
+    authStatus: async () => ({ ok: true, message: null }),
+    loadState: async () => ({ activeIssueNumber: activeRecord.issue_number, issues: { [activeRecord.issue_number]: activeRecord } }),
+    github: {
+      getCandidateDiscoveryDiagnostics: async () => ({ fetchWindow: 100, observedMatchingOpenIssues: 0, truncated: false }),
+    },
+  });
+
+  const report = renderDoctorReport(diagnostics);
+  assert.match(report, /doctor_codex_model_policy default=inherit->gpt-5\.6-terra@inherited_host_default/);
+  assert.match(report, /doctor_codex_host_default model=gpt-5\.6-terra/);
+  assert.match(report, /doctor_codex_reasoning active=supervisor requested=max effective=max capability_source=live_catalog/);
+});
+
 test("diagnoseSupervisorHost surfaces orphan prune candidates and representative eligibility reasons", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-doctor-"));
   t.after(async () => {

--- a/src/doctor.ts
+++ b/src/doctor.ts
@@ -859,13 +859,6 @@ export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): 
   const candidateDiscoveryWarning = formatCandidateDiscoveryWarningDetail(
     await github.getCandidateDiscoveryDiagnostics().catch(() => null),
   );
-  const codexModelPolicyLines = renderDoctorCodexModelPolicyLines(
-    await buildCodexModelPolicySnapshot({
-      config: args.config,
-      activeState: "reproducing",
-      activeRecord: null,
-    }),
-  );
   let state: SupervisorStateFile | null = null;
   let finalRawDiagnostics = rawDiagnostics;
   try {
@@ -875,6 +868,17 @@ export async function diagnoseSupervisorHost(args: DiagnoseSupervisorHostArgs): 
       withReconciliationBacklogStateReadFailure(rawDiagnostics.checks, args.config, error),
     );
   }
+
+  const activeRecord = state?.activeIssueNumber === null || state?.activeIssueNumber === undefined
+    ? null
+    : state.issues[String(state.activeIssueNumber)] ?? null;
+  const codexModelPolicyLines = renderDoctorCodexModelPolicyLines(
+    await buildCodexModelPolicySnapshot({
+      config: args.config,
+      activeState: activeRecord?.state ?? "reproducing",
+      activeRecord,
+    }),
+  );
 
   const decisionSurface = buildDoctorOperatorDecisionSurface(finalRawDiagnostics);
 

--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -125,6 +125,7 @@ const EXPECTED_TOP_LEVEL_ENTRIES = {
 const EXPECTED_FAMILY_FILES = {
   codex: [
     "codex-connector-review-loop-prompt.ts",
+    "codex-model-capabilities.ts",
     "codex-model-policy.ts",
     "codex-output-parser.ts",
     "codex-policy.ts",

--- a/src/local-review/artifacts.test.ts
+++ b/src/local-review/artifacts.test.ts
@@ -12,6 +12,12 @@ import { writeLocalReviewArtifacts } from "./artifacts";
 import { finalizeLocalReview } from "./finalize";
 import { createConfig } from "./test-helpers";
 
+const GENERIC_ROUTING = {
+  target: "local_review_generic" as const,
+  model: null,
+  reasoningEffort: null,
+};
+
 test("writeLocalReviewArtifacts renders durable guardrail provenance compactly", async () => {
   const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "local-review-workspace-"));
   const config = createConfig({
@@ -23,6 +29,7 @@ test("writeLocalReviewArtifacts renders durable guardrail provenance compactly",
       summary: "No actionable findings.",
       recommendation: "ready" as const,
       degraded: false,
+      routing: GENERIC_ROUTING,
       exitCode: 0,
       rawOutput: "review raw output",
       findings: [],
@@ -101,6 +108,11 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
       summary: "Flagged one high-severity issue.",
       recommendation: "changes_requested" as const,
       degraded: false,
+      routing: {
+        target: "local_review_generic" as const,
+        model: "local-review-fast",
+        reasoningEffort: "low" as const,
+      },
       exitCode: 0,
       rawOutput: "review raw output",
       findings: [
@@ -123,6 +135,11 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
       summary: "Checked the specialist path.",
       recommendation: "ready" as const,
       degraded: false,
+      routing: {
+        target: "local_review_specialist" as const,
+        model: "gpt-5-codex",
+        reasoningEffort: "low" as const,
+      },
       exitCode: 0,
       rawOutput: "specialist raw output",
       findings: [],
@@ -150,6 +167,11 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
       summary: "Confirmed the generic finding.",
       recommendation: "changes_requested",
       degraded: false,
+      routing: {
+        target: "local_review_verifier",
+        model: "gpt-5-codex",
+        reasoningEffort: "low",
+      },
       exitCode: 0,
       rawOutput: "verifier raw output",
       findings: [
@@ -179,6 +201,11 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
       summary: "Confirmed the generic finding.",
       recommendation: "changes_requested",
       degraded: false,
+      routing: {
+        target: "local_review_verifier",
+        model: "gpt-5-codex",
+        reasoningEffort: "low",
+      },
       exitCode: 0,
       rawOutput: "verifier raw output",
       findings: [
@@ -244,6 +271,7 @@ test("writeLocalReviewArtifacts rewrites repo-local absolute paths and redacts h
       summary: "Flagged one location-sensitive issue.",
       recommendation: "changes_requested" as const,
       degraded: false,
+      routing: GENERIC_ROUTING,
       exitCode: 0,
       rawOutput: `Absolute repo path: ${repoFilePath}\nHost-local note: ${leakedHostPath}`,
       findings: [],

--- a/src/local-review/artifacts.ts
+++ b/src/local-review/artifacts.ts
@@ -80,12 +80,12 @@ function summarizeGuardrailProvenance(provenance: FinalizedLocalReview["artifact
 function summarizeModelRouting(finalized: FinalizedLocalReview): string[] {
   const lines = finalized.artifact.roleReports.map(
     (report) =>
-      `- ${report.role}: target=${report.routing.target} model=${report.routing.model ?? "inherit"} reasoning=${report.routing.reasoningEffort}`,
+      `- ${report.role}: target=${report.routing.target} model=${report.routing.model ?? "inherit"} reasoning=${report.routing.reasoningEffort ?? "default"}`,
   );
 
   if (finalized.artifact.verifierReport) {
     lines.push(
-      `- verifier: target=${finalized.artifact.verifierReport.routing.target} model=${finalized.artifact.verifierReport.routing.model ?? "inherit"} reasoning=${finalized.artifact.verifierReport.routing.reasoningEffort}`,
+      `- verifier: target=${finalized.artifact.verifierReport.routing.target} model=${finalized.artifact.verifierReport.routing.model ?? "inherit"} reasoning=${finalized.artifact.verifierReport.routing.reasoningEffort ?? "default"}`,
     );
   }
 

--- a/src/local-review/execution.test.ts
+++ b/src/local-review/execution.test.ts
@@ -110,6 +110,11 @@ function createRoleResult(overrides: Partial<LocalReviewRoleResult> = {}): Local
     rawOutput: "raw",
     exitCode: 0,
     degraded: false,
+    routing: {
+      target: "local_review_generic",
+      model: null,
+      reasoningEffort: null,
+    },
     ...overrides,
   };
 }
@@ -303,6 +308,11 @@ test("runLocalReviewExecution invokes verifier only when actionable high-severit
         rawOutput: "raw",
         exitCode: 0,
         degraded: false,
+        routing: {
+          target: "local_review_verifier",
+          model: null,
+          reasoningEffort: null,
+        },
       };
     },
   });
@@ -351,6 +361,11 @@ test("runLocalReviewExecution invokes verifier only when actionable high-severit
       rawOutput: "raw",
       exitCode: 0,
       degraded: false,
+      routing: {
+        target: "local_review_verifier",
+        model: null,
+        reasoningEffort: null,
+      },
     }),
   });
 

--- a/src/local-review/finalize.test.ts
+++ b/src/local-review/finalize.test.ts
@@ -3,6 +3,36 @@ import test from "node:test";
 import { finalizeLocalReview } from "./finalize";
 import { createConfig, createDetectedRoles } from "./test-helpers";
 
+test("finalizeLocalReview records catalog-aware reasoning for generated artifacts", () => {
+  const result = finalizeLocalReview({
+    config: createConfig({
+      localReviewModelStrategy: "fixed",
+      localReviewModel: "gpt-5.6-terra",
+      codexReasoningEffortByState: { local_review: "max" },
+    }),
+    issueNumber: 38,
+    prNumber: 12,
+    branch: "codex/issue-38",
+    headSha: "catalog123456",
+    roleResults: [{
+      role: "reviewer",
+      summary: "No findings.",
+      recommendation: "ready",
+      degraded: false,
+      exitCode: 0,
+      rawOutput: "review raw output",
+      findings: [],
+    }],
+    verifierReport: null,
+    ranAt: "2026-07-11T00:00:00Z",
+    reasoningLevelsByModel: new Map([
+      ["gpt-5.6-terra", new Set(["high", "xhigh", "max"] as const)],
+    ]),
+  });
+
+  assert.equal(result.artifact.roleReports[0]?.routing.reasoningEffort, "max");
+});
+
 test("finalizeLocalReview keeps raw high-severity findings separate from dismissed verifier results", () => {
   const result = finalizeLocalReview({
     config: createConfig({ localReviewConfidenceThreshold: 0.7 }),

--- a/src/local-review/finalize.test.ts
+++ b/src/local-review/finalize.test.ts
@@ -3,7 +3,23 @@ import test from "node:test";
 import { finalizeLocalReview } from "./finalize";
 import { createConfig, createDetectedRoles } from "./test-helpers";
 
-test("finalizeLocalReview records catalog-aware reasoning for generated artifacts", () => {
+const GENERIC_ROUTING = {
+  target: "local_review_generic" as const,
+  model: null,
+  reasoningEffort: null,
+};
+const SPECIALIST_ROUTING = {
+  target: "local_review_specialist" as const,
+  model: null,
+  reasoningEffort: null,
+};
+const VERIFIER_ROUTING = {
+  target: "local_review_verifier" as const,
+  model: null,
+  reasoningEffort: null,
+};
+
+test("finalizeLocalReview preserves the routing captured by the review turn", () => {
   const result = finalizeLocalReview({
     config: createConfig({
       localReviewModelStrategy: "fixed",
@@ -19,18 +35,20 @@ test("finalizeLocalReview records catalog-aware reasoning for generated artifact
       summary: "No findings.",
       recommendation: "ready",
       degraded: false,
+      routing: {
+        target: "local_review_generic",
+        model: "gpt-5.6-terra",
+        reasoningEffort: "xhigh",
+      },
       exitCode: 0,
       rawOutput: "review raw output",
       findings: [],
     }],
     verifierReport: null,
     ranAt: "2026-07-11T00:00:00Z",
-    reasoningLevelsByModel: new Map([
-      ["gpt-5.6-terra", new Set(["high", "xhigh", "max"] as const)],
-    ]),
   });
 
-  assert.equal(result.artifact.roleReports[0]?.routing.reasoningEffort, "max");
+  assert.equal(result.artifact.roleReports[0]?.routing.reasoningEffort, "xhigh");
 });
 
 test("finalizeLocalReview keeps raw high-severity findings separate from dismissed verifier results", () => {
@@ -46,6 +64,7 @@ test("finalizeLocalReview keeps raw high-severity findings separate from dismiss
         summary: "Flagged one high issue and one medium issue.",
         recommendation: "changes_requested",
         degraded: false,
+        routing: GENERIC_ROUTING,
         exitCode: 0,
         rawOutput: "review raw output",
         findings: [
@@ -81,6 +100,7 @@ test("finalizeLocalReview keeps raw high-severity findings separate from dismiss
       summary: "Dismissed the high-severity finding after re-check.",
       recommendation: "ready",
       degraded: false,
+      routing: VERIFIER_ROUTING,
       exitCode: 0,
       rawOutput: "verifier raw output",
       findings: [
@@ -116,6 +136,7 @@ test("finalizeLocalReview propagates verifier degradation to top-level result", 
         summary: "Flagged one high issue.",
         recommendation: "changes_requested",
         degraded: false,
+        routing: GENERIC_ROUTING,
         exitCode: 0,
         rawOutput: "review raw output",
         findings: [
@@ -139,6 +160,7 @@ test("finalizeLocalReview propagates verifier degradation to top-level result", 
       summary: "Verifier failed to complete.",
       recommendation: "unknown",
       degraded: true,
+      routing: VERIFIER_ROUTING,
       exitCode: 1,
       rawOutput: "verifier raw output",
       findings: [],
@@ -166,6 +188,7 @@ test("finalizeLocalReview includes auto-detect reasons in the artifact", () => {
         summary: "No issues found.",
         recommendation: "ready",
         degraded: false,
+        routing: GENERIC_ROUTING,
         exitCode: 0,
         rawOutput: "review raw output",
         findings: [],
@@ -175,6 +198,7 @@ test("finalizeLocalReview includes auto-detect reasons in the artifact", () => {
         summary: "Checked schema and migrations.",
         recommendation: "ready",
         degraded: false,
+        routing: SPECIALIST_ROUTING,
         exitCode: 0,
         rawOutput: "prisma raw output",
         findings: [],
@@ -213,6 +237,7 @@ test("finalizeLocalReview uses stricter confidence thresholds for specialist rev
         summary: "Flagged a generic concern below the generic threshold.",
         recommendation: "changes_requested",
         degraded: false,
+        routing: GENERIC_ROUTING,
         exitCode: 0,
         rawOutput: "generic raw output",
         findings: [
@@ -235,6 +260,7 @@ test("finalizeLocalReview uses stricter confidence thresholds for specialist rev
         summary: "Flagged a specialist concern at the specialist threshold.",
         recommendation: "changes_requested",
         degraded: false,
+        routing: SPECIALIST_ROUTING,
         exitCode: 0,
         rawOutput: "specialist raw output",
         findings: [
@@ -258,6 +284,7 @@ test("finalizeLocalReview uses stricter confidence thresholds for specialist rev
       summary: "Confirmed the specialist issue.",
       recommendation: "changes_requested",
       degraded: false,
+      routing: VERIFIER_ROUTING,
       exitCode: 0,
       rawOutput: "verifier raw output",
       findings: [
@@ -293,6 +320,7 @@ test("finalizeLocalReview compresses overlapping findings into a root-cause summ
         summary: "Flagged missing nil handling in the same path.",
         recommendation: "changes_requested",
         degraded: false,
+        routing: GENERIC_ROUTING,
         exitCode: 0,
         rawOutput: "review raw output",
         findings: [
@@ -315,6 +343,7 @@ test("finalizeLocalReview compresses overlapping findings into a root-cause summ
         summary: "Found the same bug from the repair prompt side.",
         recommendation: "changes_requested",
         degraded: false,
+        routing: GENERIC_ROUTING,
         exitCode: 0,
         rawOutput: "explorer raw output",
         findings: [
@@ -357,6 +386,7 @@ test("finalizeLocalReview merges root-cause groups connected by a bridging findi
         summary: "Found repeated auth-refresh failures.",
         recommendation: "changes_requested",
         degraded: false,
+        routing: GENERIC_ROUTING,
         exitCode: 0,
         rawOutput: "review raw output",
         findings: [
@@ -421,6 +451,7 @@ test("finalizeLocalReview does not compress findings without file locations", ()
         summary: "Found two similar unscoped concerns.",
         recommendation: "changes_requested",
         degraded: false,
+        routing: GENERIC_ROUTING,
         exitCode: 0,
         rawOutput: "review raw output",
         findings: [

--- a/src/local-review/finalize.ts
+++ b/src/local-review/finalize.ts
@@ -1,6 +1,6 @@
 import { type LocalReviewRoleSelection } from "../review-role-detector";
 import { resolveCodexExecutionPolicy } from "../codex/codex-policy";
-import { type CodexExecutionTarget } from "../core/types";
+import { type CodexExecutionTarget, type ReasoningEffort } from "../core/types";
 import { type SupervisorConfig } from "../core/types";
 import { truncate } from "../core/utils";
 import { findingMeetsReviewerThreshold, reviewerTypeForRole, thresholdsForReviewerType } from "./thresholds";
@@ -233,13 +233,17 @@ function resolveLocalReviewExecutionRouting(args: {
   >;
   target: CodexExecutionTarget;
   inheritedModel?: string | null;
+  reasoningLevelsByModel?: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>;
 }): LocalReviewExecutionRouting {
   const policy = resolveCodexExecutionPolicy(
     args.config,
     "local_review",
     undefined,
     args.target,
-    { inheritedModel: args.inheritedModel },
+    {
+      inheritedModel: args.inheritedModel,
+      reasoningLevelsByModel: args.reasoningLevelsByModel,
+    },
   );
   return {
     target: args.target,
@@ -270,6 +274,7 @@ export function finalizeLocalReview(args: {
   ranAt: string;
   guardrailProvenance?: LocalReviewGuardrailProvenance;
   inheritedModel?: string | null;
+  reasoningLevelsByModel?: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>;
 }): FinalizedLocalReview {
   const roles = args.roleResults.map((result) => result.role);
   const allFindings = args.roleResults.flatMap((result) => result.findings);
@@ -284,6 +289,7 @@ export function finalizeLocalReview(args: {
       config: args.config,
       target: localReviewExecutionTargetForRole(reviewerTypeArgs),
       inheritedModel: args.inheritedModel,
+      reasoningLevelsByModel: args.reasoningLevelsByModel,
     });
     const actionableFindingsCount = result.findings.filter((finding) =>
       findingMeetsReviewerThreshold({
@@ -388,6 +394,7 @@ export function finalizeLocalReview(args: {
             config: args.config,
             target: "local_review_verifier",
             inheritedModel: args.inheritedModel,
+            reasoningLevelsByModel: args.reasoningLevelsByModel,
           }),
           exitCode: args.verifierReport.exitCode,
           degraded: args.verifierReport.degraded,

--- a/src/local-review/finalize.ts
+++ b/src/local-review/finalize.ts
@@ -1,6 +1,4 @@
 import { type LocalReviewRoleSelection } from "../review-role-detector";
-import { resolveCodexExecutionPolicy } from "../codex/codex-policy";
-import { type CodexExecutionTarget, type ReasoningEffort } from "../core/types";
 import { type SupervisorConfig } from "../core/types";
 import { truncate } from "../core/utils";
 import { findingMeetsReviewerThreshold, reviewerTypeForRole, thresholdsForReviewerType } from "./thresholds";
@@ -10,7 +8,6 @@ import {
   type LocalReviewGuardrailProvenance,
   type LocalReviewArtifact,
   type LocalReviewFinding,
-  type LocalReviewExecutionRouting,
   type LocalReviewResult,
   type LocalReviewRootCauseSummary,
   type LocalReviewRoleResult,
@@ -212,57 +209,11 @@ function maxSeverity(findings: LocalReviewFinding[]): LocalReviewSeverity {
   return "none";
 }
 
-function localReviewExecutionTargetForRole(args: {
-  role: string;
-  detectedRoles?: LocalReviewRoleSelection[];
-}): CodexExecutionTarget {
-  return reviewerTypeForRole(args) === "generic"
-    ? "local_review_generic"
-    : "local_review_specialist";
-}
-
-function resolveLocalReviewExecutionRouting(args: {
-  config: Pick<
-    SupervisorConfig,
-    | "codexModelStrategy"
-    | "codexModel"
-    | "localReviewModelStrategy"
-    | "localReviewModel"
-    | "codexReasoningEffortByState"
-    | "codexReasoningEscalateOnRepeatedFailure"
-  >;
-  target: CodexExecutionTarget;
-  inheritedModel?: string | null;
-  reasoningLevelsByModel?: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>;
-}): LocalReviewExecutionRouting {
-  const policy = resolveCodexExecutionPolicy(
-    args.config,
-    "local_review",
-    undefined,
-    args.target,
-    {
-      inheritedModel: args.inheritedModel,
-      reasoningLevelsByModel: args.reasoningLevelsByModel,
-    },
-  );
-  return {
-    target: args.target,
-    model: policy.model,
-    reasoningEffort: policy.reasoningEffort,
-  };
-}
-
 export function finalizeLocalReview(args: {
   config: Pick<
     SupervisorConfig,
     | "localReviewConfidenceThreshold"
     | "localReviewReviewerThresholds"
-    | "codexModelStrategy"
-    | "codexModel"
-    | "localReviewModelStrategy"
-    | "localReviewModel"
-    | "codexReasoningEffortByState"
-    | "codexReasoningEscalateOnRepeatedFailure"
   >;
   issueNumber: number;
   prNumber: number;
@@ -273,8 +224,6 @@ export function finalizeLocalReview(args: {
   verifierReport: LocalReviewVerifierReport | null;
   ranAt: string;
   guardrailProvenance?: LocalReviewGuardrailProvenance;
-  inheritedModel?: string | null;
-  reasoningLevelsByModel?: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>;
 }): FinalizedLocalReview {
   const roles = args.roleResults.map((result) => result.role);
   const allFindings = args.roleResults.flatMap((result) => result.findings);
@@ -285,12 +234,6 @@ export function finalizeLocalReview(args: {
     };
     const reviewerType = reviewerTypeForRole(reviewerTypeArgs);
     const thresholds = thresholdsForReviewerType(args.config, reviewerType);
-    const routing = resolveLocalReviewExecutionRouting({
-      config: args.config,
-      target: localReviewExecutionTargetForRole(reviewerTypeArgs),
-      inheritedModel: args.inheritedModel,
-      reasoningLevelsByModel: args.reasoningLevelsByModel,
-    });
     const actionableFindingsCount = result.findings.filter((finding) =>
       findingMeetsReviewerThreshold({
         finding,
@@ -301,7 +244,7 @@ export function finalizeLocalReview(args: {
 
     return {
       role: result.role,
-      routing,
+      routing: result.routing,
       reviewerType,
       confidenceThreshold: thresholds.confidenceThreshold,
       minimumSeverity: thresholds.minimumSeverity,
@@ -390,12 +333,7 @@ export function finalizeLocalReview(args: {
     verifierReport: args.verifierReport
       ? {
           role: args.verifierReport.role,
-          routing: resolveLocalReviewExecutionRouting({
-            config: args.config,
-            target: "local_review_verifier",
-            inheritedModel: args.inheritedModel,
-            reasoningLevelsByModel: args.reasoningLevelsByModel,
-          }),
+          routing: args.verifierReport.routing,
           exitCode: args.verifierReport.exitCode,
           degraded: args.verifierReport.degraded,
           summary: args.verifierReport.summary,

--- a/src/local-review/index.ts
+++ b/src/local-review/index.ts
@@ -14,6 +14,7 @@ import {
 import { GitHubIssue, GitHubPullRequest, SupervisorConfig } from "../core/types";
 import { type LocalReviewResult } from "./types";
 import { resolveHostCodexDefaultModel } from "../codex/codex-model-policy";
+import { resolveCodexModelCapabilities } from "../codex/codex-model-capabilities";
 
 export type {
   ActionableSeverity,
@@ -124,7 +125,10 @@ export async function runLocalReview(args: {
   const ranAt = nowIso();
   const dirPath = reviewDir(args.config, args.issue.number);
   await ensureDir(dirPath);
-  const hostDefault = await resolveHostCodexDefaultModel();
+  const [hostDefault, capabilities] = await Promise.all([
+    resolveHostCodexDefaultModel(args.workspacePath),
+    resolveCodexModelCapabilities(args.config.codexBinary, args.workspacePath),
+  ]);
   const finalized = finalizeLocalReview({
     config: args.config,
     issueNumber: args.issue.number,
@@ -136,6 +140,7 @@ export async function runLocalReview(args: {
     verifierReport,
     ranAt,
     inheritedModel: hostDefault.model,
+    reasoningLevelsByModel: capabilities.reasoningLevelsByModel,
     guardrailProvenance: prepareLocalReviewGuardrailProvenance({
       config: args.config,
       verifierReport,

--- a/src/local-review/index.ts
+++ b/src/local-review/index.ts
@@ -13,8 +13,6 @@ import {
 } from "./preparation";
 import { GitHubIssue, GitHubPullRequest, SupervisorConfig } from "../core/types";
 import { type LocalReviewResult } from "./types";
-import { resolveHostCodexDefaultModel } from "../codex/codex-model-policy";
-import { resolveCodexModelCapabilities } from "../codex/codex-model-capabilities";
 
 export type {
   ActionableSeverity,
@@ -125,10 +123,6 @@ export async function runLocalReview(args: {
   const ranAt = nowIso();
   const dirPath = reviewDir(args.config, args.issue.number);
   await ensureDir(dirPath);
-  const [hostDefault, capabilities] = await Promise.all([
-    resolveHostCodexDefaultModel(args.workspacePath),
-    resolveCodexModelCapabilities(args.config.codexBinary, args.workspacePath),
-  ]);
   const finalized = finalizeLocalReview({
     config: args.config,
     issueNumber: args.issue.number,
@@ -139,8 +133,6 @@ export async function runLocalReview(args: {
     roleResults,
     verifierReport,
     ranAt,
-    inheritedModel: hostDefault.model,
-    reasoningLevelsByModel: capabilities.reasoningLevelsByModel,
     guardrailProvenance: prepareLocalReviewGuardrailProvenance({
       config: args.config,
       verifierReport,

--- a/src/local-review/result.test.ts
+++ b/src/local-review/result.test.ts
@@ -9,6 +9,17 @@ import {
 import { finalizeLocalReview } from "./finalize";
 import { createConfig, createMissPattern } from "./test-helpers";
 
+const GENERIC_ROUTING = {
+  target: "local_review_generic" as const,
+  model: null,
+  reasoningEffort: null,
+};
+const VERIFIER_ROUTING = {
+  target: "local_review_verifier" as const,
+  model: null,
+  reasoningEffort: null,
+};
+
 test("prepareLocalReviewGuardrailProvenance groups runtime sources and keeps artifact-relative paths", () => {
   const config = createConfig({
     localReviewArtifactDir: "/tmp/reviews",
@@ -21,6 +32,7 @@ test("prepareLocalReviewGuardrailProvenance groups runtime sources and keeps art
       summary: "verified",
       recommendation: "ready",
       degraded: false,
+      routing: VERIFIER_ROUTING,
       exitCode: 0,
       rawOutput: "verifier raw output",
       verifierGuardrails: [{ id: "rule-1", title: "Rule", summary: "Summary", file: "src/file.ts", line: 12, rationale: "Because" }],
@@ -95,6 +107,7 @@ test("formatLocalReviewResult preserves finalized summary fields and blocker sum
         summary: "Flagged one medium issue.",
         recommendation: "changes_requested",
         degraded: false,
+        routing: GENERIC_ROUTING,
         exitCode: 0,
         rawOutput: "review raw output",
         findings: [
@@ -178,6 +191,7 @@ test("buildLocalReviewBlockerSummary summarizes the leading root cause compactly
         summary: "Found two retry-path defects.",
         recommendation: "changes_requested",
         degraded: false,
+        routing: GENERIC_ROUTING,
         exitCode: 0,
         rawOutput: "review raw output",
         findings: [

--- a/src/local-review/runner.test.ts
+++ b/src/local-review/runner.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 import { runCodexReviewTurn, runRoleReview, runVerifierReview, type LocalReviewTurnRequest } from "./runner";
+import { type LocalReviewExecutionRouting } from "./types";
 import {
   createConfig,
   createFakeLocalReviewRunner,
@@ -11,6 +12,18 @@ import {
   createMissPattern,
   createPullRequest,
 } from "./test-helpers";
+
+function routingForRequest(
+  request: LocalReviewTurnRequest,
+  model: string | null = null,
+  reasoningEffort: LocalReviewExecutionRouting["reasoningEffort"] = null,
+): LocalReviewExecutionRouting {
+  return {
+    target: request.executionTarget,
+    model,
+    reasoningEffort,
+  };
+}
 
 test("runRoleReview routes reviewer turns through the injected execution contract", async () => {
   const requests: LocalReviewTurnRequest[] = [];
@@ -30,6 +43,7 @@ test("runRoleReview routes reviewer turns through the injected execution contrac
       requests.push(request);
       return {
         exitCode: 0,
+        routing: routingForRequest(request, "reviewer-turn-model", "xhigh"),
         rawOutput: [
           "Review summary: Runner-backed reviewer result",
           "Recommendation: changes_requested",
@@ -103,6 +117,11 @@ test("runRoleReview routes reviewer turns through the injected execution contrac
     ].join("\n"),
     exitCode: 0,
     degraded: false,
+    routing: {
+      target: "local_review_generic",
+      model: "reviewer-turn-model",
+      reasoningEffort: "xhigh",
+    },
   });
 });
 
@@ -130,6 +149,7 @@ test("runRoleReview routes docs researcher turns through the generic local-revie
       requests.push(request);
       return {
         exitCode: 0,
+        routing: routingForRequest(request),
         rawOutput: [
           "Review summary: Docs researcher ran",
           "Recommendation: ready",
@@ -170,6 +190,7 @@ test("runRoleReview keeps specialist local-review turns on the specialist execut
       requests.push(request);
       return {
         exitCode: 0,
+        routing: routingForRequest(request),
         rawOutput: [
           "Review summary: Specialist reviewer ran",
           "Recommendation: ready",
@@ -216,6 +237,7 @@ test("runVerifierReview routes verifier turns through the injected execution con
         requests.push(request);
         return {
           exitCode: 0,
+          routing: routingForRequest(request, "verifier-turn-model", "max"),
           rawOutput: [
             "Verification summary: Runner-backed verifier result",
             "Recommendation: changes_requested",
@@ -233,8 +255,6 @@ test("runVerifierReview routes verifier turns through the injected execution con
           ].join("\n"),
         };
       },
-    } as Parameters<typeof runVerifierReview>[0] & {
-      executeTurn: (request: LocalReviewTurnRequest) => Promise<{ exitCode: number; rawOutput: string }>;
     });
 
     assert.equal(requests.length, 1);
@@ -272,6 +292,11 @@ test("runVerifierReview routes verifier turns through the injected execution con
       ].join("\n"),
       exitCode: 0,
       degraded: false,
+      routing: {
+        target: "local_review_verifier",
+        model: "verifier-turn-model",
+        reasoningEffort: "max",
+      },
       verifierGuardrails: [],
     });
   } finally {
@@ -325,6 +350,11 @@ exit 0
 
   assert.equal(result.exitCode, 0);
   assert.match(result.rawOutput, /Operator gated local review ran/);
+  assert.deepEqual(result.routing, {
+    target: "local_review_generic",
+    model: null,
+    reasoningEffort: "low",
+  });
   assert.equal(args.includes("--dangerously-bypass-approvals-and-sandbox"), false);
   assert.deepEqual(args.slice(0, 5), [
     "exec",
@@ -356,7 +386,7 @@ exit 0
   );
   await fs.chmod(codexBinary, 0o755);
 
-  await runCodexReviewTurn({
+  const result = await runCodexReviewTurn({
     config: createConfig({
       codexBinary,
       codexModelStrategy: "fixed",
@@ -372,12 +402,68 @@ exit 0
   });
   const args = (await fs.readFile(argsPath, "utf8")).trim().split("\n");
 
+  assert.deepEqual(result.routing, {
+    target: "local_review_generic",
+    model: "gpt-5.6-sol",
+    reasoningEffort: "max",
+  });
+
   assert.deepEqual(args.slice(0, 5), [
     "exec",
     "-m",
     "gpt-5.6-sol",
     "-c",
     'model_reasoning_effort="max"',
+  ]);
+});
+
+test("runCodexReviewTurn returns the same routing used for a transient catalog fallback", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "local-review-runner-fallback-"));
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  const workspacePath = path.join(root, "workspace");
+  const codexBinary = path.join(root, "fake-codex.sh");
+  const argsPath = path.join(root, "args.log");
+  await fs.mkdir(workspacePath, { recursive: true });
+  await fs.writeFile(
+    codexBinary,
+    `#!/bin/sh
+set -eu
+printf '%s\n' "$@" > "${argsPath}"
+exit 0
+`,
+    "utf8",
+  );
+  await fs.chmod(codexBinary, 0o755);
+
+  const result = await runCodexReviewTurn({
+    config: createConfig({
+      codexBinary,
+      codexModelStrategy: "fixed",
+      codexModel: "gpt-5.6-terra",
+      localReviewModelStrategy: "inherit",
+      codexReasoningEffortByState: { local_review: "max" },
+    }),
+    workspacePath,
+    role: "reviewer",
+    outputFileName: "reviewer.txt",
+    prompt: "fallback local review prompt",
+    executionTarget: "local_review_generic",
+  });
+  const args = (await fs.readFile(argsPath, "utf8")).trim().split("\n");
+
+  assert.deepEqual(result.routing, {
+    target: "local_review_generic",
+    model: "gpt-5.6-terra",
+    reasoningEffort: "xhigh",
+  });
+  assert.deepEqual(args.slice(0, 5), [
+    "exec",
+    "-m",
+    "gpt-5.6-terra",
+    "-c",
+    'model_reasoning_effort="xhigh"',
   ]);
 });
 

--- a/src/local-review/runner.ts
+++ b/src/local-review/runner.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { runCommand } from "../core/command";
 import { buildCodexConfigOverrideArgs, buildCodexExecutionSafetyArgs, resolveCodexExecutionPolicy } from "../codex/codex-policy";
 import { resolveHostCodexDefaultModel } from "../codex/codex-model-policy";
+import { resolveCodexModelCapabilities } from "../codex/codex-model-capabilities";
 import { loadRelevantExternalReviewMissPatterns, type ExternalReviewMissPattern } from "../external-review/external-review-misses";
 import { reviewDir } from "./artifacts";
 import { buildRolePrompt, buildVerifierPrompt, parseRoleFooter, parseVerifierFooter } from "./prompt";
@@ -36,14 +37,20 @@ export type LocalReviewTurnExecutor = (args: LocalReviewTurnRequest) => Promise<
 export async function runCodexReviewTurn(args: LocalReviewTurnRequest): Promise<LocalReviewTurnResult> {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-review-"));
   const messageFile = path.join(tempDir, args.outputFileName);
-  const hostDefault = await resolveHostCodexDefaultModel();
+  const [hostDefault, capabilities] = await Promise.all([
+    resolveHostCodexDefaultModel(),
+    resolveCodexModelCapabilities(args.config.codexBinary),
+  ]);
   const overrideArgs = buildCodexConfigOverrideArgs(
     resolveCodexExecutionPolicy(
       args.config,
       "local_review",
       undefined,
       args.executionTarget,
-      { inheritedModel: hostDefault.model },
+      {
+        inheritedModel: hostDefault.model,
+        reasoningLevelsByModel: capabilities.reasoningLevelsByModel,
+      },
     ),
   );
   const executionSafetyArgs = buildCodexExecutionSafetyArgs(args.config);

--- a/src/local-review/runner.ts
+++ b/src/local-review/runner.ts
@@ -9,7 +9,12 @@ import { loadRelevantExternalReviewMissPatterns, type ExternalReviewMissPattern 
 import { reviewDir } from "./artifacts";
 import { buildRolePrompt, buildVerifierPrompt, parseRoleFooter, parseVerifierFooter } from "./prompt";
 import { reviewerTypeForRole } from "./thresholds";
-import { type LocalReviewFinding, type LocalReviewRoleResult, type LocalReviewVerifierReport } from "./types";
+import {
+  type LocalReviewExecutionRouting,
+  type LocalReviewFinding,
+  type LocalReviewRoleResult,
+  type LocalReviewVerifierReport,
+} from "./types";
 import { type LocalReviewRoleSelection } from "../review-role-detector";
 import { type GitHubIssue, type GitHubPullRequest, type SupervisorConfig } from "../core/types";
 import { loadRelevantVerifierGuardrails } from "../verifier-guardrails";
@@ -30,6 +35,7 @@ export interface LocalReviewTurnRequest {
 export interface LocalReviewTurnResult {
   exitCode: number;
   rawOutput: string;
+  routing: LocalReviewExecutionRouting;
 }
 
 export type LocalReviewTurnExecutor = (args: LocalReviewTurnRequest) => Promise<LocalReviewTurnResult>;
@@ -41,18 +47,22 @@ export async function runCodexReviewTurn(args: LocalReviewTurnRequest): Promise<
     resolveHostCodexDefaultModel(args.workspacePath),
     resolveCodexModelCapabilities(args.config.codexBinary, args.workspacePath),
   ]);
-  const overrideArgs = buildCodexConfigOverrideArgs(
-    resolveCodexExecutionPolicy(
-      args.config,
-      "local_review",
-      undefined,
-      args.executionTarget,
-      {
-        inheritedModel: hostDefault.model,
-        reasoningLevelsByModel: capabilities.reasoningLevelsByModel,
-      },
-    ),
+  const policy = resolveCodexExecutionPolicy(
+    args.config,
+    "local_review",
+    undefined,
+    args.executionTarget,
+    {
+      inheritedModel: hostDefault.model,
+      reasoningLevelsByModel: capabilities.reasoningLevelsByModel,
+    },
   );
+  const routing: LocalReviewExecutionRouting = {
+    target: args.executionTarget,
+    model: policy.model,
+    reasoningEffort: policy.reasoningEffort,
+  };
+  const overrideArgs = buildCodexConfigOverrideArgs(policy);
   const executionSafetyArgs = buildCodexExecutionSafetyArgs(args.config);
   const result = await runCommand(
     args.config.codexBinary,
@@ -90,6 +100,7 @@ export async function runCodexReviewTurn(args: LocalReviewTurnRequest): Promise<
   return {
     exitCode: result.exitCode,
     rawOutput,
+    routing,
   };
 }
 
@@ -137,6 +148,7 @@ export async function runRoleReview(args: {
     rawOutput: result.rawOutput,
     exitCode: result.exitCode,
     degraded: result.exitCode !== 0,
+    routing: result.routing,
     ...parsed,
   };
 }
@@ -198,6 +210,7 @@ export async function runVerifierReview(args: {
     rawOutput: result.rawOutput,
     exitCode: result.exitCode,
     degraded: result.exitCode !== 0,
+    routing: result.routing,
     verifierGuardrails,
     ...parsed,
   };

--- a/src/local-review/runner.ts
+++ b/src/local-review/runner.ts
@@ -39,7 +39,7 @@ export async function runCodexReviewTurn(args: LocalReviewTurnRequest): Promise<
   const messageFile = path.join(tempDir, args.outputFileName);
   const [hostDefault, capabilities] = await Promise.all([
     resolveHostCodexDefaultModel(),
-    resolveCodexModelCapabilities(args.config.codexBinary),
+    resolveCodexModelCapabilities(args.config.codexBinary, args.workspacePath),
   ]);
   const overrideArgs = buildCodexConfigOverrideArgs(
     resolveCodexExecutionPolicy(

--- a/src/local-review/runner.ts
+++ b/src/local-review/runner.ts
@@ -38,7 +38,7 @@ export async function runCodexReviewTurn(args: LocalReviewTurnRequest): Promise<
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-review-"));
   const messageFile = path.join(tempDir, args.outputFileName);
   const [hostDefault, capabilities] = await Promise.all([
-    resolveHostCodexDefaultModel(),
+    resolveHostCodexDefaultModel(args.workspacePath),
     resolveCodexModelCapabilities(args.config.codexBinary, args.workspacePath),
   ]);
   const overrideArgs = buildCodexConfigOverrideArgs(

--- a/src/local-review/test-helpers.ts
+++ b/src/local-review/test-helpers.ts
@@ -186,11 +186,19 @@ export function createFakeLocalReviewRunner(outputs: Record<
   executeTurn: LocalReviewTurnExecutor;
 } {
   const requests: LocalReviewTurnRequest[] = [];
-  const normalizeResult = (value: LocalReviewTurnResult | string): LocalReviewTurnResult =>
+  const normalizeResult = (
+    value: LocalReviewTurnResult | string,
+    request: LocalReviewTurnRequest,
+  ): LocalReviewTurnResult =>
     typeof value === "string"
       ? {
           exitCode: 0,
           rawOutput: value,
+          routing: {
+            target: request.executionTarget,
+            model: null,
+            reasoningEffort: null,
+          },
         }
       : value;
 
@@ -207,6 +215,7 @@ export function createFakeLocalReviewRunner(outputs: Record<
         typeof output === "function"
           ? await output(request)
           : output,
+        request,
       );
     },
   };

--- a/src/local-review/types.ts
+++ b/src/local-review/types.ts
@@ -134,6 +134,7 @@ export interface LocalReviewRoleResult {
   rawOutput: string;
   exitCode: number;
   degraded: boolean;
+  routing: LocalReviewExecutionRouting;
 }
 
 export interface LocalReviewVerifierReport {
@@ -144,6 +145,7 @@ export interface LocalReviewVerifierReport {
   rawOutput: string;
   exitCode: number;
   degraded: boolean;
+  routing: LocalReviewExecutionRouting;
   verifierGuardrails?: VerifierGuardrailRule[];
 }
 

--- a/src/local-review/types.ts
+++ b/src/local-review/types.ts
@@ -165,7 +165,7 @@ export interface LocalReviewGuardrailProvenance {
 export interface LocalReviewExecutionRouting {
   target: CodexExecutionTarget;
   model: string | null;
-  reasoningEffort: ReasoningEffort;
+  reasoningEffort: ReasoningEffort | null;
 }
 
 export interface LocalReviewArtifact {

--- a/src/supervisor/supervisor-status-rendering.test.ts
+++ b/src/supervisor/supervisor-status-rendering.test.ts
@@ -482,10 +482,23 @@ test("renderStatusCodexModelPolicyLines reports inherited host defaults and over
 test("buildCodexModelPolicySnapshot probes and resolves inherited models from the active workspace", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "status-codex-policy-workspace-"));
   const workspace = path.join(root, "workspace");
+  const codexHome = path.join(root, "codex-home");
   const codexBinary = path.join(root, "fake-codex.sh");
-  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  const previousCodexHome = process.env.CODEX_HOME;
+  t.after(async () => {
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  process.env.CODEX_HOME = codexHome;
   await fs.mkdir(path.join(workspace, ".codex"), { recursive: true });
+  await fs.mkdir(codexHome, { recursive: true });
   await fs.writeFile(path.join(workspace, ".codex", "config.toml"), 'model = "gpt-5.6-terra"\n', "utf8");
+  await fs.writeFile(
+    path.join(codexHome, "config.toml"),
+    `[projects.${JSON.stringify(workspace)}]\ntrust_level = "trusted"\n`,
+    "utf8",
+  );
   await fs.writeFile(codexBinary, `#!/bin/sh
 if [ ! -f .codex/config.toml ]; then
   exit 9

--- a/src/supervisor/supervisor-status-rendering.test.ts
+++ b/src/supervisor/supervisor-status-rendering.test.ts
@@ -474,7 +474,7 @@ test("renderStatusCodexModelPolicyLines reports inherited host defaults and over
   );
 
   assert.deepEqual(lines, [
-    "codex_execution_policy active=supervisor:inherit->gpt-5.4@inherited_host_default reasoning=xhigh requested_reasoning=max",
+    "codex_execution_policy active=supervisor:inherit->gpt-5.4@inherited_host_default reasoning=xhigh requested_reasoning=max capability_source=fallback fallback_reason=catalog_probe_unavailable",
     "codex_route_overrides repair=alias:gpt-5.4-mini@bounded_repair_override local_review=alias:local-review-fast@local_review_override",
   ]);
 });
@@ -512,7 +512,7 @@ test("buildCodexModelPolicySnapshot keeps the default route independent from act
   });
   assert.equal(
     renderStatusCodexModelPolicyLines(snapshot)[0],
-    "codex_execution_policy active=supervisor:alias:gpt-5.4-mini@bounded_repair_override reasoning=medium",
+    "codex_execution_policy active=supervisor:alias:gpt-5.4-mini@bounded_repair_override reasoning=medium capability_source=fallback fallback_reason=catalog_probe_unavailable",
   );
 });
 
@@ -544,7 +544,7 @@ test("buildCodexModelPolicySnapshot uses the local-review route for active local
   );
 
   assert.deepEqual(lines, [
-    "codex_execution_policy active=local_review_generic:alias:local-review-fast@local_review_override reasoning=low",
+    "codex_execution_policy active=local_review_generic:alias:local-review-fast@local_review_override reasoning=low capability_source=fallback fallback_reason=catalog_probe_unavailable",
     "codex_route_overrides repair=default_route(gpt-5.4) local_review=alias:local-review-fast@local_review_override",
   ]);
 });

--- a/src/supervisor/supervisor-status-rendering.test.ts
+++ b/src/supervisor/supervisor-status-rendering.test.ts
@@ -479,6 +479,36 @@ test("renderStatusCodexModelPolicyLines reports inherited host defaults and over
   ]);
 });
 
+test("buildCodexModelPolicySnapshot probes and resolves inherited models from the active workspace", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "status-codex-policy-workspace-"));
+  const workspace = path.join(root, "workspace");
+  const codexBinary = path.join(root, "fake-codex.sh");
+  t.after(() => fs.rm(root, { recursive: true, force: true }));
+  await fs.mkdir(path.join(workspace, ".codex"), { recursive: true });
+  await fs.writeFile(path.join(workspace, ".codex", "config.toml"), 'model = "gpt-5.6-terra"\n', "utf8");
+  await fs.writeFile(codexBinary, `#!/bin/sh
+if [ ! -f .codex/config.toml ]; then
+  exit 9
+fi
+printf '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["max"]}]}'
+`, { mode: 0o755 });
+
+  const snapshot = await buildCodexModelPolicySnapshot({
+    config: createConfig({
+      codexBinary,
+      codexModelStrategy: "inherit",
+      codexReasoningEffortByState: { implementing: "max" },
+    }),
+    activeState: "implementing",
+    activeRecord: createRecord({ workspace, state: "implementing" }),
+  });
+
+  assert.equal(snapshot.hostDefault.model, "gpt-5.6-terra");
+  assert.equal(snapshot.hostDefault.source, path.join(workspace, ".codex", "config.toml"));
+  assert.equal(snapshot.capabilities.source, "live_catalog");
+  assert.equal(snapshot.activeRoute.reasoningEffort, "max");
+});
+
 test("buildCodexModelPolicySnapshot keeps the default route independent from active repair overrides", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "status-codex-policy-default-route-"));
   const previousCodexHome = process.env.CODEX_HOME;

--- a/src/supervisor/supervisor-status-rendering.test.ts
+++ b/src/supervisor/supervisor-status-rendering.test.ts
@@ -522,6 +522,62 @@ printf '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["max"]}
   assert.equal(snapshot.activeRoute.reasoningEffort, "max");
 });
 
+test("buildCodexModelPolicySnapshot resolves migrated records through the canonical workspace", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "status-codex-policy-canonical-workspace-"));
+  const workspaceRoot = path.join(root, "workspaces");
+  const canonicalWorkspace = path.join(workspaceRoot, "issue-366");
+  const persistedWorkspace = path.join(root, "other-host", "issue-366");
+  const codexHome = path.join(root, "codex-home");
+  const codexBinary = path.join(root, "fake-codex.sh");
+  const previousCodexHome = process.env.CODEX_HOME;
+  t.after(async () => {
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    await fs.rm(root, { recursive: true, force: true });
+  });
+
+  process.env.CODEX_HOME = codexHome;
+  await fs.mkdir(path.join(canonicalWorkspace, ".codex"), { recursive: true });
+  await fs.writeFile(path.join(canonicalWorkspace, ".git"), "gitdir: /tmp/fake\n", "utf8");
+  await fs.mkdir(codexHome, { recursive: true });
+  await fs.writeFile(
+    path.join(canonicalWorkspace, ".codex", "config.toml"),
+    'model = "gpt-5.6-terra"\n',
+    "utf8",
+  );
+  await fs.writeFile(
+    path.join(codexHome, "config.toml"),
+    `model = "gpt-5.6-sol"\n\n[projects.${JSON.stringify(canonicalWorkspace)}]\ntrust_level = "trusted"\n`,
+    "utf8",
+  );
+  await fs.writeFile(codexBinary, `#!/bin/sh
+if [ ! -f .codex/config.toml ]; then
+  exit 9
+fi
+printf '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["max"]}]}'
+`, { mode: 0o755 });
+
+  const snapshot = await buildCodexModelPolicySnapshot({
+    config: createConfig({
+      workspaceRoot,
+      codexBinary,
+      codexModelStrategy: "inherit",
+      codexReasoningEffortByState: { implementing: "max" },
+    }),
+    activeState: "implementing",
+    activeRecord: createRecord({
+      workspace: persistedWorkspace,
+      journal_path: path.join(persistedWorkspace, ".codex-supervisor", "issue-journal.md"),
+      state: "implementing",
+    }),
+  });
+
+  assert.equal(snapshot.hostDefault.model, "gpt-5.6-terra");
+  assert.equal(snapshot.hostDefault.source, path.join(canonicalWorkspace, ".codex", "config.toml"));
+  assert.equal(snapshot.capabilities.source, "live_catalog");
+  assert.equal(snapshot.activeRoute.reasoningEffort, "max");
+});
+
 test("buildCodexModelPolicySnapshot keeps the default route independent from active repair overrides", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "status-codex-policy-default-route-"));
   const previousCodexHome = process.env.CODEX_HOME;


### PR DESCRIPTION
## Summary
- resolve supported reasoning levels from `codex debug models`
- cache catalog probes and fail closed to the conservative Sol-only fallback
- surface capability provenance in doctor/status and refresh GPT-5.6 docs

## Verification
- `npx tsx --test src/codex/codex-model-capabilities.test.ts src/codex/codex-policy.test.ts src/codex/codex-runner.test.ts src/local-review/runner.test.ts src/doctor.test.ts src/supervisor/supervisor-status-rendering.test.ts`
- `npm run build`
- `npm run verify:paths`
- `npm run verify:subprocess-safety`

Full `npm test` currently reports unrelated existing replay/recovery failures. `issue-lint` requires a non-placeholder supervisor config.

Closes #2443