### PR TITLE
Add bounded GPT-5.6 ultra reasoning

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -678,9 +678,11 @@ Practical rule of thumb:
 - use `inherit` unless you have a strong reason not to
 - leave `boundedRepairModelStrategy` unset unless you intentionally want smaller models for repair turns
 - reserve `xhigh` for escalation paths rather than using it everywhere
-- reasoning escalation follows `none < low < medium < high < xhigh < max`
+- automatic reasoning escalation follows `none < low < medium < high < xhigh < max`; it never selects `ultra`
 - `max` is emitted when the active Codex CLI model catalog reports support; if the catalog probe fails, a conservative built-in fallback permits it only for `gpt-5.6-sol`. Unsupported models fall back to `xhigh`, while GPT-5 Pro remains capped at `high`.
-- `status` and `doctor` report the requested and effective efforts when capability clamping changes the request
+- `ultra` is explicit-only through `codexReasoningEffortByState`. It is forwarded only for the `supervisor` execution target when the effective model's live catalog reports `ultra`; unsupported supervisor routes and every local-review route clamp to a supported non-delegating effort and report the fallback reason.
+- `ultra` is Codex-native automatic task delegation, not codex-supervisor's local-review role orchestration. Expect potentially higher latency, concurrent work, and cost, and enable it only after evaluating those tradeoffs for the managed repository.
+- `status`, `doctor`, supervisor execution-routing summaries, and local-review artifacts report requested/effective effort plus `reasoning_fallback_reason=unsupported_reasoning_effort|nested_delegation_blocked|none`
 
 ### ChatGPT desktop app and the Codex CLI
 
@@ -694,9 +696,9 @@ OpenAI's current preview documentation lists these model IDs:
 
 | Model | Model ID | Supervisor reasoning note |
 | --- | --- | --- |
-| GPT-5.6 Sol | `gpt-5.6-sol` | Active-catalog reasoning levels are honored; the offline fallback permits `max`. |
-| GPT-5.6 Terra | `gpt-5.6-terra` | Active-catalog reasoning levels are honored, including `max` when reported. |
-| GPT-5.6 Luna | `gpt-5.6-luna` | Active-catalog reasoning levels are honored, including `max` when reported. |
+| GPT-5.6 Sol | `gpt-5.6-sol` | Active-catalog reasoning levels are honored; catalog-backed `ultra` remains bounded to supervisor turns, and the offline fallback permits only `max`. |
+| GPT-5.6 Terra | `gpt-5.6-terra` | Active-catalog reasoning levels are honored; catalog-backed `ultra` remains bounded to supervisor turns. |
+| GPT-5.6 Luna | `gpt-5.6-luna` | Active-catalog reasoning levels are honored; without reported `ultra` support, explicit requests fall back safely. |
 
 Do not infer access from a model name appearing in documentation or from having a paid ChatGPT plan. During the documented preview, access is limited to selected organizations and scoped separately to approved API organizations and Codex workspaces; API approval does not imply Codex approval, and the preview is distinct from general ChatGPT availability. Keep `codexModelStrategy: "inherit"` as the resilient default so model changes do not require supervisor config churn, and pin a GPT-5.6 model only after confirming access in the exact account or workspace used by the supervisor.
 

--- a/docs/local-review.md
+++ b/docs/local-review.md
@@ -22,6 +22,8 @@ Core behavior:
 - generated Markdown and JSON artifacts are marked as trusted durable artifacts so downstream promotion and path-hygiene checks can distinguish them from ordinary publishable content
 - the same memory budget policy still applies: read the compact context index and issue journal first, then open durable memory only on demand
 
+The swarm above is codex-supervisor role orchestration: generic reviewers, specialists, and the verifier each run in their own Codex turn. It is separate from Codex-native automatic task delegation. If `codexReasoningEffortByState` explicitly requests `ultra`, every local-review execution target clamps it to the highest supported non-delegating effort and records `nested_delegation_blocked`; local-review turns never forward `ultra`. This prevents nested delegation from multiplying the swarm's concurrency, latency, and cost.
+
 Policy guidance:
 
 - `off` disables local review and keeps the default conservative posture

--- a/src/codex/codex-model-capabilities.test.ts
+++ b/src/codex/codex-model-capabilities.test.ts
@@ -18,20 +18,20 @@ test("model catalog probes allow a bounded remote refresh window", () => {
 test("parseCodexModelCatalog resolves GPT-5.6 reasoning levels and ignores unsupported future levels", async () => {
   const fixture = await fs.readFile(path.join(process.cwd(), "src/codex/fixtures/model-catalog-gpt-5.6.json"), "utf8");
   const catalog = parseCodexModelCatalog(fixture);
-  assert.deepEqual([...catalog?.get("gpt-5.6-sol") ?? []], ["high", "xhigh", "max"]);
-  assert.deepEqual([...catalog?.get("gpt-5.6-terra") ?? []], ["high", "xhigh", "max"]);
+  assert.deepEqual([...catalog?.get("gpt-5.6-sol") ?? []], ["high", "xhigh", "max", "ultra"]);
+  assert.deepEqual([...catalog?.get("gpt-5.6-terra") ?? []], ["high", "xhigh", "max", "ultra"]);
   assert.deepEqual([...catalog?.get("gpt-5.6-luna") ?? []], ["high", "xhigh", "max"]);
 });
 
-test("parseCodexModelCatalog preserves the distinction between unsupported ultra and max", () => {
+test("parseCodexModelCatalog preserves ultra and ignores unknown future reasoning levels", () => {
   const catalog = parseCodexModelCatalog(JSON.stringify({
     models: [
-      { slug: "gpt-5.6-terra", supported_reasoning_levels: [{ effort: "ultra" }] },
+      { slug: "gpt-5.6-terra", supported_reasoning_levels: [{ effort: "ultra" }, { effort: "hyper" }] },
       { slug: "gpt-5.6-sol", supported_reasoning_levels: [{ effort: "ultra" }, { effort: "max" }] },
     ],
   }));
-  assert.deepEqual([...catalog?.get("gpt-5.6-terra") ?? []], []);
-  assert.deepEqual([...catalog?.get("gpt-5.6-sol") ?? []], ["max"]);
+  assert.deepEqual([...catalog?.get("gpt-5.6-terra") ?? []], ["ultra"]);
+  assert.deepEqual([...catalog?.get("gpt-5.6-sol") ?? []], ["ultra", "max"]);
 });
 
 test("parseCodexModelCatalog skips malformed unrelated entries without discarding valid capabilities", () => {

--- a/src/codex/codex-model-capabilities.ts
+++ b/src/codex/codex-model-capabilities.ts
@@ -10,7 +10,7 @@ export interface CodexModelCapabilities {
   fallbackReason: string | null;
 }
 
-const REASONING_LEVELS = new Set<ReasoningEffort>(["none", "low", "medium", "high", "xhigh", "max"]);
+const REASONING_LEVELS = new Set<ReasoningEffort>(["none", "low", "medium", "high", "xhigh", "max", "ultra"]);
 const FALLBACK = new Map<string, ReadonlySet<ReasoningEffort>>([
   ["gpt-5.6-sol", new Set<ReasoningEffort>(["low", "medium", "high", "xhigh", "max"])],
 ]);

--- a/src/codex/codex-model-policy.test.ts
+++ b/src/codex/codex-model-policy.test.ts
@@ -3,7 +3,12 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
-import { resolveHostCodexDefaultModel } from "./codex-model-policy";
+import {
+  buildCodexModelPolicySnapshot,
+  renderDoctorCodexModelPolicyLines,
+  resolveHostCodexDefaultModel,
+} from "./codex-model-policy";
+import { createConfig } from "../turn-execution-test-helpers";
 
 test("resolveHostCodexDefaultModel ignores untrusted workspace config", async (t) => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-policy-untrusted-"));
@@ -75,4 +80,108 @@ test("resolveHostCodexDefaultModel decodes TOML escapes in trusted project keys"
     model: "gpt-5.6-terra",
     source: path.join(workspace, ".codex", "config.toml"),
   });
+});
+
+test("buildCodexModelPolicySnapshot preserves ultra provenance across supported, unsupported, and nested routes", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-model-policy-ultra-"));
+  const previousCodexHome = process.env.CODEX_HOME;
+  t.after(async () => {
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  process.env.CODEX_HOME = path.join(root, "codex-home");
+  await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+
+  async function writeCatalogBinary(name: string, models: unknown[]): Promise<string> {
+    const binary = path.join(root, name);
+    await fs.writeFile(
+      binary,
+      `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(JSON.stringify({ models }))});\n`,
+      { mode: 0o755 },
+    );
+    return binary;
+  }
+
+  const solBinary = await writeCatalogBinary("sol-catalog", [
+    { slug: "gpt-5.6-sol", supported_reasoning_levels: ["max", "ultra"] },
+  ]);
+  const lunaBinary = await writeCatalogBinary("luna-catalog", [
+    { slug: "gpt-5.6-luna", supported_reasoning_levels: ["xhigh", "max"] },
+  ]);
+
+  const supported = await buildCodexModelPolicySnapshot({
+    config: createConfig({
+      codexBinary: solBinary,
+      codexModelStrategy: "fixed",
+      codexModel: "gpt-5.6-sol",
+      codexReasoningEffortByState: { implementing: "ultra" },
+    }),
+    activeState: "implementing",
+    activeRecord: null,
+  });
+  assert.deepEqual(
+    {
+      target: supported.activeRoute.target,
+      requested: supported.activeRoute.requestedReasoningEffort,
+      effective: supported.activeRoute.reasoningEffort,
+      reason: supported.activeRoute.reasoningEffortFallbackReason,
+    },
+    { target: "supervisor", requested: "ultra", effective: "ultra", reason: null },
+  );
+
+  const unsupported = await buildCodexModelPolicySnapshot({
+    config: createConfig({
+      codexBinary: lunaBinary,
+      codexModelStrategy: "fixed",
+      codexModel: "gpt-5.6-luna",
+      codexReasoningEffortByState: { implementing: "ultra" },
+    }),
+    activeState: "implementing",
+    activeRecord: null,
+  });
+  assert.deepEqual(
+    {
+      target: unsupported.activeRoute.target,
+      requested: unsupported.activeRoute.requestedReasoningEffort,
+      effective: unsupported.activeRoute.reasoningEffort,
+      reason: unsupported.activeRoute.reasoningEffortFallbackReason,
+    },
+    {
+      target: "supervisor",
+      requested: "ultra",
+      effective: "max",
+      reason: "unsupported_reasoning_effort",
+    },
+  );
+  assert.match(
+    renderDoctorCodexModelPolicyLines(unsupported).join("\n"),
+    /requested=ultra effective=max reasoning_fallback_reason=unsupported_reasoning_effort capability_source=live_catalog fallback_reason=none/,
+  );
+
+  const nested = await buildCodexModelPolicySnapshot({
+    config: createConfig({
+      codexBinary: solBinary,
+      codexModelStrategy: "fixed",
+      codexModel: "gpt-5.6-sol",
+      localReviewModelStrategy: "inherit",
+      codexReasoningEffortByState: { local_review: "ultra" },
+    }),
+    activeState: "local_review",
+    activeRecord: null,
+  });
+  assert.deepEqual(
+    {
+      target: nested.activeRoute.target,
+      requested: nested.activeRoute.requestedReasoningEffort,
+      effective: nested.activeRoute.reasoningEffort,
+      reason: nested.activeRoute.reasoningEffortFallbackReason,
+    },
+    {
+      target: "local_review_generic",
+      requested: "ultra",
+      effective: "max",
+      reason: "nested_delegation_blocked",
+    },
+  );
 });

--- a/src/codex/codex-model-policy.ts
+++ b/src/codex/codex-model-policy.ts
@@ -4,7 +4,15 @@ import path from "node:path";
 import { resolveCodexExecutionPolicy } from "./codex-policy";
 import { CodexModelCapabilities, resolveCodexModelCapabilities } from "./codex-model-capabilities";
 import { resolveTrackedIssueHostPaths } from "../core/journal";
-import { CodexExecutionTarget, CodexModelStrategy, IssueRunRecord, ReasoningEffort, RunState, SupervisorConfig } from "../core/types";
+import {
+  CodexExecutionTarget,
+  CodexModelStrategy,
+  IssueRunRecord,
+  ReasoningEffort,
+  ReasoningEffortFallbackReason,
+  RunState,
+  SupervisorConfig,
+} from "../core/types";
 
 export interface HostCodexDefaultModelResolution {
   model: string | null;
@@ -35,6 +43,7 @@ export interface CodexModelPolicySnapshot {
     target: CodexExecutionTarget;
     requestedReasoningEffort: ReasoningEffort | null;
     reasoningEffort: ReasoningEffort | null;
+    reasoningEffortFallbackReason: ReasoningEffortFallbackReason | null;
   };
 }
 
@@ -357,6 +366,7 @@ export async function buildCodexModelPolicySnapshot(args: {
     target: activeTarget,
     requestedReasoningEffort: activePolicy.requestedReasoningEffort ?? activePolicy.reasoningEffort,
     reasoningEffort: activePolicy.reasoningEffort,
+    reasoningEffortFallbackReason: activePolicy.reasoningEffortFallbackReason ?? null,
   };
 
   return {
@@ -374,16 +384,13 @@ export function renderDoctorCodexModelPolicyLines(snapshot: CodexModelPolicySnap
     `doctor_codex_model_policy default=${summarizeRoute(snapshot.defaultRoute)}`,
     `doctor_codex_route_overrides repair=${summarizeRoute(snapshot.boundedRepairRoute)} local_review=${summarizeRoute(snapshot.localReviewRoute)}`,
     `doctor_codex_host_default model=${snapshot.hostDefault.model ?? "unresolved"} source=${snapshot.hostDefault.source ?? "unresolved"}`,
-    `doctor_codex_reasoning active=${snapshot.activeRoute.target} requested=${snapshot.activeRoute.requestedReasoningEffort ?? "default"} effective=${snapshot.activeRoute.reasoningEffort ?? "default"} capability_source=${snapshot.capabilities.source} fallback_reason=${snapshot.capabilities.fallbackReason ?? "none"}`,
+    `doctor_codex_reasoning active=${snapshot.activeRoute.target} requested=${snapshot.activeRoute.requestedReasoningEffort ?? "default"} effective=${snapshot.activeRoute.reasoningEffort ?? "default"} reasoning_fallback_reason=${snapshot.activeRoute.reasoningEffortFallbackReason ?? "none"} capability_source=${snapshot.capabilities.source} fallback_reason=${snapshot.capabilities.fallbackReason ?? "none"}`,
   ];
 }
 
 export function renderStatusCodexModelPolicyLines(snapshot: CodexModelPolicySnapshot): string[] {
-  const requestedSuffix = snapshot.activeRoute.requestedReasoningEffort === snapshot.activeRoute.reasoningEffort
-    ? ""
-    : ` requested_reasoning=${snapshot.activeRoute.requestedReasoningEffort}`;
   return [
-    `codex_execution_policy active=${snapshot.activeRoute.target}:${summarizeRoute(snapshot.activeRoute)} reasoning=${snapshot.activeRoute.reasoningEffort ?? "default"}${requestedSuffix} capability_source=${snapshot.capabilities.source} fallback_reason=${snapshot.capabilities.fallbackReason ?? "none"}`,
+    `codex_execution_policy active=${snapshot.activeRoute.target}:${summarizeRoute(snapshot.activeRoute)} reasoning=${snapshot.activeRoute.reasoningEffort ?? "default"} requested_reasoning=${snapshot.activeRoute.requestedReasoningEffort ?? "default"} effective_reasoning=${snapshot.activeRoute.reasoningEffort ?? "default"} reasoning_fallback_reason=${snapshot.activeRoute.reasoningEffortFallbackReason ?? "none"} capability_source=${snapshot.capabilities.source} fallback_reason=${snapshot.capabilities.fallbackReason ?? "none"}`,
     `codex_route_overrides repair=${summarizeRoute(snapshot.boundedRepairRoute)} local_review=${summarizeRoute(snapshot.localReviewRoute)}`,
   ];
 }

--- a/src/codex/codex-policy.test.ts
+++ b/src/codex/codex-policy.test.ts
@@ -197,6 +197,7 @@ test("resolveCodexExecutionPolicy escalates only an unconsumed stable Codex Conn
       reasoningEffort: "max",
     },
   );
+
 });
 
 test("resolveCodexExecutionPolicy escalates xhigh to max for GPT-5.6 Sol", () => {
@@ -210,6 +211,10 @@ test("resolveCodexExecutionPolicy escalates xhigh to max for GPT-5.6 Sol", () =>
       repeated_failure_signature_count: 1,
       blocked_verification_retry_count: 0,
       timeout_retry_count: 0,
+    }, "supervisor", {
+      reasoningLevelsByModel: new Map([
+        ["gpt-5.6-sol", new Set(["high", "xhigh", "max", "ultra"] as const)],
+      ]),
     }),
     {
       model: "gpt-5.6-sol",
@@ -227,6 +232,7 @@ test("resolveCodexExecutionPolicy clamps max to each model family's highest supp
     model: "gpt-5-codex",
     reasoningEffort: "xhigh",
     requestedReasoningEffort: "max",
+    reasoningEffortFallbackReason: "unsupported_reasoning_effort",
   });
   assert.deepEqual(
     resolveCodexExecutionPolicy(createConfig({ ...maxConfig, codexModel: "gpt-5-pro" }), "implementing"),
@@ -234,6 +240,7 @@ test("resolveCodexExecutionPolicy clamps max to each model family's highest supp
       model: "gpt-5-pro",
       reasoningEffort: "high",
       requestedReasoningEffort: "max",
+      reasoningEffortFallbackReason: "unsupported_reasoning_effort",
     },
   );
 });
@@ -299,6 +306,7 @@ test("resolveCodexExecutionPolicy clamps every unsupported effort to the live ca
     model: "gpt-5.6-terra",
     reasoningEffort: "low",
     requestedReasoningEffort: "none",
+    reasoningEffortFallbackReason: "unsupported_reasoning_effort",
   });
 
   const maxConfig = createConfig({
@@ -341,6 +349,7 @@ test("resolveCodexExecutionPolicy suppresses reasoning overrides for empty live 
     model: "catalog-model",
     reasoningEffort: null,
     requestedReasoningEffort: "high",
+    reasoningEffortFallbackReason: "unsupported_reasoning_effort",
   });
   assert.deepEqual(buildCodexConfigOverrideArgs(policy), ["-m", "catalog-model"]);
 });
@@ -365,7 +374,164 @@ test("resolveCodexExecutionPolicy applies inherited host-model capabilities with
     model: null,
     reasoningEffort: "xhigh",
     requestedReasoningEffort: "max",
+    reasoningEffortFallbackReason: "unsupported_reasoning_effort",
   });
+});
+
+test("resolveCodexExecutionPolicy forwards explicit ultra only for catalog-supported supervisor routes", () => {
+  const capabilities = new Map([
+    ["gpt-5.6-sol", new Set(["high", "xhigh", "max", "ultra"] as const)],
+    ["gpt-5.6-terra", new Set(["high", "xhigh", "max", "ultra"] as const)],
+    ["gpt-5.6-luna", new Set(["high", "xhigh", "max"] as const)],
+  ]);
+
+  for (const model of ["gpt-5.6-sol", "gpt-5.6-terra"]) {
+    const policy = resolveCodexExecutionPolicy(
+      createConfig({ codexModel: model, codexReasoningEffortByState: { implementing: "ultra" } }),
+      "implementing",
+      undefined,
+      "supervisor",
+      { reasoningLevelsByModel: capabilities },
+    );
+    assert.deepEqual(policy, { model, reasoningEffort: "ultra" });
+    assert.deepEqual(buildCodexConfigOverrideArgs(policy), [
+      "-m",
+      model,
+      "-c",
+      'model_reasoning_effort="ultra"',
+    ]);
+  }
+
+  assert.deepEqual(
+    resolveCodexExecutionPolicy(
+      createConfig({
+        codexModel: "gpt-5.6-luna",
+        codexReasoningEffortByState: { implementing: "ultra" },
+      }),
+      "implementing",
+      undefined,
+      "supervisor",
+      { reasoningLevelsByModel: capabilities },
+    ),
+    {
+      model: "gpt-5.6-luna",
+      reasoningEffort: "max",
+      requestedReasoningEffort: "ultra",
+      reasoningEffortFallbackReason: "unsupported_reasoning_effort",
+    },
+  );
+
+  assert.deepEqual(
+    resolveCodexExecutionPolicy(
+      createConfig({
+        codexModel: "future-model",
+        codexReasoningEffortByState: { implementing: "ultra" },
+      }),
+      "implementing",
+      undefined,
+      "supervisor",
+      { reasoningLevelsByModel: capabilities },
+    ),
+    {
+      model: "future-model",
+      reasoningEffort: "xhigh",
+      requestedReasoningEffort: "ultra",
+      reasoningEffortFallbackReason: "unsupported_reasoning_effort",
+    },
+  );
+});
+
+test("resolveCodexExecutionPolicy blocks ultra for every local-review execution target", () => {
+  const capabilities = new Map([
+    ["gpt-5.6-sol", new Set(["high", "xhigh", "max", "ultra"] as const)],
+  ]);
+  const config = createConfig({
+    codexModel: "gpt-5.6-sol",
+    codexReasoningEffortByState: { local_review: "ultra" },
+  });
+
+  for (const target of ["local_review_generic", "local_review_specialist", "local_review_verifier"] as const) {
+    assert.deepEqual(
+      resolveCodexExecutionPolicy(config, "local_review", undefined, target, {
+        reasoningLevelsByModel: capabilities,
+      }),
+      {
+        model: "gpt-5.6-sol",
+        reasoningEffort: "max",
+        requestedReasoningEffort: "ultra",
+        reasoningEffortFallbackReason: "nested_delegation_blocked",
+      },
+    );
+  }
+
+  assert.deepEqual(
+    resolveCodexExecutionPolicy(config, "local_review", undefined, "local_review_specialist", {
+      reasoningLevelsByModel: new Map([
+        ["gpt-5.6-sol", new Set(["high", "ultra"] as const)],
+      ]),
+    }),
+    {
+      model: "gpt-5.6-sol",
+      reasoningEffort: "high",
+      requestedReasoningEffort: "ultra",
+      reasoningEffortFallbackReason: "nested_delegation_blocked",
+    },
+  );
+});
+
+test("resolveCodexExecutionPolicy never upgrades non-ultra requests or escalation beyond max", () => {
+  const capabilities = new Map([
+    ["ultra-only", new Set(["ultra"] as const)],
+    ["gpt-5.6-sol", new Set(["high", "xhigh", "max", "ultra"] as const)],
+  ]);
+  const unsupportedPolicy = resolveCodexExecutionPolicy(
+    createConfig({ codexModel: "ultra-only", codexReasoningEffortByState: { implementing: "max" } }),
+    "implementing",
+    undefined,
+    "supervisor",
+    { reasoningLevelsByModel: capabilities },
+  );
+  assert.deepEqual(unsupportedPolicy, {
+    model: "ultra-only",
+    reasoningEffort: null,
+    requestedReasoningEffort: "max",
+    reasoningEffortFallbackReason: "unsupported_reasoning_effort",
+  });
+
+  for (const configured of ["max", "ultra"] as const) {
+    const policy = resolveCodexExecutionPolicy(
+      createConfig({
+        codexModel: "gpt-5.6-sol",
+        codexReasoningEffortByState: { implementing: configured },
+      }),
+      "implementing",
+      {
+        repeated_failure_signature_count: 1,
+        blocked_verification_retry_count: 0,
+        timeout_retry_count: 0,
+      },
+      "supervisor",
+      { reasoningLevelsByModel: capabilities },
+    );
+    assert.equal(policy.reasoningEffort, configured);
+  }
+});
+
+test("resolveCodexExecutionPolicy preserves inherited catalog-supported ultra without forcing a model override", () => {
+  const config = createConfig({
+    codexModelStrategy: "inherit",
+    codexModel: undefined,
+    codexReasoningEffortByState: { implementing: "ultra" },
+  });
+  assert.deepEqual(
+    resolveCodexExecutionPolicy(config, "implementing", undefined, "supervisor", {
+      inheritedModel: "gpt-5.6-sol",
+      reasoningLevelsByModel: new Map([
+        ["gpt-5.6-sol", new Set(["high", "xhigh", "max", "ultra"] as const)],
+      ]),
+    }),
+    { model: null, reasoningEffort: "ultra" },
+  );
 });
 
 test("resolveCodexExecutionPolicy inherits a fixed default model for explicit route-level inherit", () => {

--- a/src/codex/codex-policy.ts
+++ b/src/codex/codex-policy.ts
@@ -1,10 +1,18 @@
-import { CodexExecutionTarget, IssueRunRecord, ReasoningEffort, RunState, SupervisorConfig } from "../core/types";
+import {
+  CodexExecutionTarget,
+  IssueRunRecord,
+  ReasoningEffort,
+  ReasoningEffortFallbackReason,
+  RunState,
+  SupervisorConfig,
+} from "../core/types";
 import {
   codexConnectorStableSameFileChurnSignature,
   isCodexConnectorStableSameFileChurn,
 } from "../codex-connector-review-churn";
 
-const REASONING_ORDER: ReasoningEffort[] = ["none", "low", "medium", "high", "xhigh", "max"];
+const NON_DELEGATING_REASONING_ORDER: ReasoningEffort[] = ["none", "low", "medium", "high", "xhigh", "max"];
+const REASONING_ORDER: ReasoningEffort[] = [...NON_DELEGATING_REASONING_ORDER, "ultra"];
 const CODEX_MODEL_CATALOG_ALIASES: Readonly<Record<string, string>> = {
   "gpt-5.6": "gpt-5.6-sol",
 };
@@ -34,6 +42,7 @@ export interface CodexExecutionPolicy {
   model: string | null;
   reasoningEffort: ReasoningEffort | null;
   requestedReasoningEffort?: ReasoningEffort;
+  reasoningEffortFallbackReason?: ReasoningEffortFallbackReason;
 }
 
 export interface CodexExecutionPolicyContext {
@@ -80,9 +89,10 @@ function activeStableSameFileChurnDossierSignature(
 }
 
 function bumpReasoningEffort(effort: ReasoningEffort, steps = 1): ReasoningEffort {
-  const index = REASONING_ORDER.indexOf(effort);
-  const nextIndex = Math.min(REASONING_ORDER.length - 1, Math.max(0, index) + steps);
-  return REASONING_ORDER[nextIndex] ?? effort;
+  if (effort === "ultra") return effort;
+  const index = NON_DELEGATING_REASONING_ORDER.indexOf(effort);
+  const nextIndex = Math.min(NON_DELEGATING_REASONING_ORDER.length - 1, Math.max(0, index) + steps);
+  return NON_DELEGATING_REASONING_ORDER[nextIndex] ?? effort;
 }
 
 function reasoningEffortAtLeast(effort: ReasoningEffort, minimum: ReasoningEffort): ReasoningEffort {
@@ -130,26 +140,72 @@ function resolveCatalogReasoningLevels(
 function clampReasoningEffortForModel(
   model: string | null,
   effort: ReasoningEffort,
+  target: CodexExecutionTarget,
   reasoningLevelsByModel?: ReadonlyMap<string, ReadonlySet<ReasoningEffort>>,
-): ReasoningEffort | null {
+): Pick<CodexExecutionPolicy, "reasoningEffort" | "reasoningEffortFallbackReason"> {
   const normalized = model?.trim().toLowerCase();
   const supported = normalized && reasoningLevelsByModel
     ? resolveCatalogReasoningLevels(normalized, reasoningLevelsByModel)
     : undefined;
-  if (supported) {
-    if (supported.size === 0) return null;
-    if (supported.has(effort)) return effort;
 
-    const requestedIndex = REASONING_ORDER.indexOf(effort);
+  if (effort === "ultra") {
+    if (target === "supervisor" && supported?.has("ultra")) {
+      return { reasoningEffort: "ultra" };
+    }
+
+    let fallbackEffort: ReasoningEffort | null = null;
+    if (supported) {
+      for (let index = NON_DELEGATING_REASONING_ORDER.length - 1; index >= 0; index -= 1) {
+        const candidate = NON_DELEGATING_REASONING_ORDER[index];
+        if (candidate && supported.has(candidate)) {
+          fallbackEffort = candidate;
+          break;
+        }
+      }
+    } else {
+      fallbackEffort = clampReasoningEffortForModel(model, "max", target).reasoningEffort;
+    }
+
+    return {
+      reasoningEffort: fallbackEffort,
+      reasoningEffortFallbackReason: target === "supervisor"
+        ? "unsupported_reasoning_effort"
+        : "nested_delegation_blocked",
+    };
+  }
+
+  if (supported) {
+    if (supported.size === 0) {
+      return {
+        reasoningEffort: null,
+        reasoningEffortFallbackReason: "unsupported_reasoning_effort",
+      };
+    }
+    if (supported.has(effort)) return { reasoningEffort: effort };
+
+    const requestedIndex = NON_DELEGATING_REASONING_ORDER.indexOf(effort);
     for (let index = requestedIndex - 1; index >= 0; index -= 1) {
-      const candidate = REASONING_ORDER[index];
-      if (candidate && supported.has(candidate)) return candidate;
+      const candidate = NON_DELEGATING_REASONING_ORDER[index];
+      if (candidate && supported.has(candidate)) {
+        return {
+          reasoningEffort: candidate,
+          reasoningEffortFallbackReason: "unsupported_reasoning_effort",
+        };
+      }
     }
-    for (let index = requestedIndex + 1; index < REASONING_ORDER.length; index += 1) {
-      const candidate = REASONING_ORDER[index];
-      if (candidate && supported.has(candidate)) return candidate;
+    for (let index = requestedIndex + 1; index < NON_DELEGATING_REASONING_ORDER.length; index += 1) {
+      const candidate = NON_DELEGATING_REASONING_ORDER[index];
+      if (candidate && supported.has(candidate)) {
+        return {
+          reasoningEffort: candidate,
+          reasoningEffortFallbackReason: "unsupported_reasoning_effort",
+        };
+      }
     }
-    return null;
+    return {
+      reasoningEffort: null,
+      reasoningEffortFallbackReason: "unsupported_reasoning_effort",
+    };
   }
 
   let clamped = effort;
@@ -173,7 +229,10 @@ function clampReasoningEffortForModel(
     }
   }
 
-  return clamped;
+  return {
+    reasoningEffort: clamped,
+    ...(clamped === effort ? {} : { reasoningEffortFallbackReason: "unsupported_reasoning_effort" as const }),
+  };
 }
 
 function resolveRequestedReasoningEffort(
@@ -262,15 +321,19 @@ export function resolveCodexExecutionPolicy(
 ): CodexExecutionPolicy {
   const model = resolveConfiguredModel(config, state, target);
   const requestedEffort = resolveRequestedReasoningEffort(config, state, record);
-  const reasoningEffort = clampReasoningEffortForModel(
+  const reasoningResolution = clampReasoningEffortForModel(
     model ?? context.inheritedModel ?? null,
     requestedEffort,
+    target,
     context.reasoningLevelsByModel,
   );
   return {
     model,
-    reasoningEffort,
-    ...(reasoningEffort === requestedEffort ? {} : { requestedReasoningEffort: requestedEffort }),
+    reasoningEffort: reasoningResolution.reasoningEffort,
+    ...(reasoningResolution.reasoningEffort === requestedEffort ? {} : { requestedReasoningEffort: requestedEffort }),
+    ...(reasoningResolution.reasoningEffortFallbackReason
+      ? { reasoningEffortFallbackReason: reasoningResolution.reasoningEffortFallbackReason }
+      : {}),
   };
 }
 

--- a/src/codex/codex-runner.test.ts
+++ b/src/codex/codex-runner.test.ts
@@ -360,6 +360,58 @@ exit 0
   ]);
 });
 
+test("runCodexTurn forwards explicit ultra reasoning for a supported supervisor route", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-runner-ultra-"));
+  const workspacePath = path.join(root, "workspace");
+  const codexBinary = path.join(root, "fake-codex.sh");
+  const argsPath = path.join(root, "args.log");
+  t.after(async () => {
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  await fs.mkdir(workspacePath, { recursive: true });
+
+  await writeExecutableScript(
+    codexBinary,
+    `#!/bin/sh
+set -eu
+if [ "$1" = "debug" ] && [ "$2" = "models" ]; then
+  printf '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["high","xhigh","max","ultra"]}]}'
+  exit 0
+fi
+printf '%s\n' "$@" > "${argsPath}"
+exit 0
+`,
+  );
+
+  const result = await runCodexTurn(
+    createConfig({
+      codexBinary,
+      codexModelStrategy: "fixed",
+      codexModel: "gpt-5.6-terra",
+      codexReasoningEffortByState: { implementing: "ultra" },
+    }),
+    workspacePath,
+    "supported ultra prompt",
+    "implementing",
+  );
+  const args = (await fs.readFile(argsPath, "utf8")).trim().split("\n");
+
+  assert.deepEqual(args.slice(0, 5), [
+    "exec",
+    "-m",
+    "gpt-5.6-terra",
+    "-c",
+    'model_reasoning_effort="ultra"',
+  ]);
+  assert.deepEqual(result.routing, {
+    target: "supervisor",
+    model: "gpt-5.6-terra",
+    requestedReasoningEffort: "ultra",
+    reasoningEffort: "ultra",
+    reasoningEffortFallbackReason: null,
+  });
+});
+
 test("runCodexTurn removes its temp dir when command execution fails", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "codex-runner-test-"));
   const workspacePath = path.join(root, "workspace");

--- a/src/codex/codex-runner.ts
+++ b/src/codex/codex-runner.ts
@@ -51,12 +51,18 @@ export async function runCodexTurn(
       resolveHostCodexDefaultModel(workspacePath),
       resolveCodexModelCapabilities(config.codexBinary, workspacePath),
     ]);
-    const overrideArgs = buildCodexConfigOverrideArgs(
-      resolveCodexExecutionPolicy(config, state, record, "supervisor", {
-        inheritedModel: hostDefault.model,
-        reasoningLevelsByModel: capabilities.reasoningLevelsByModel,
-      }),
-    );
+    const policy = resolveCodexExecutionPolicy(config, state, record, "supervisor", {
+      inheritedModel: hostDefault.model,
+      reasoningLevelsByModel: capabilities.reasoningLevelsByModel,
+    });
+    const routing = {
+      target: "supervisor" as const,
+      model: policy.model,
+      requestedReasoningEffort: policy.requestedReasoningEffort ?? policy.reasoningEffort,
+      reasoningEffort: policy.reasoningEffort,
+      reasoningEffortFallbackReason: policy.reasoningEffortFallbackReason ?? null,
+    };
+    const overrideArgs = buildCodexConfigOverrideArgs(policy);
     const executionSafetyArgs = buildCodexExecutionSafetyArgs(config);
     const commandArgs = sessionId
       ? [
@@ -105,6 +111,7 @@ export async function runCodexTurn(
       lastMessage: lastMessage.trim(),
       stderr: result.stderr,
       stdout: result.stdout,
+      routing,
     };
   } finally {
     await fs.rm(tempDir, { recursive: true, force: true });

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -214,7 +214,7 @@ test("loadConfig leaves bare codexBinary values unresolved for PATH lookup", asy
   assert.equal(config.stateFile, path.join(tempDir, "state.json"));
 });
 
-test("loadConfig preserves max as a configured reasoning effort", async (t) => {
+test("loadConfig preserves explicit ultra and max reasoning efforts", async (t) => {
   const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-supervisor-config-"));
   t.after(async () => {
     await fs.rm(tempDir, { recursive: true, force: true });
@@ -232,8 +232,8 @@ test("loadConfig preserves max as a configured reasoning effort", async (t) => {
       codexBinary: "codex",
       branchPrefix: "codex/issue-",
       codexReasoningEffortByState: {
-        implementing: "max",
-        repairing_ci: "xhigh",
+        implementing: "ultra",
+        repairing_ci: "max",
         planning: "unsupported",
       },
     }),
@@ -243,8 +243,8 @@ test("loadConfig preserves max as a configured reasoning effort", async (t) => {
   const config = loadConfig(configPath);
 
   assert.deepEqual(config.codexReasoningEffortByState, {
-    implementing: "max",
-    repairing_ci: "xhigh",
+    implementing: "ultra",
+    repairing_ci: "max",
   });
 });
 

--- a/src/core/config-parsing.ts
+++ b/src/core/config-parsing.ts
@@ -25,7 +25,7 @@ import { mapConfiguredReviewProviders, normalizeReviewBotLogins } from "./review
 import { isValidGitRefName, resolveMaybeRelative } from "./utils";
 import { DEFAULT_CANDIDATE_DISCOVERY_FETCH_WINDOW } from "./config-constants";
 
-const VALID_REASONING_EFFORTS = new Set<ReasoningEffort>(["none", "low", "medium", "high", "xhigh", "max"]);
+const VALID_REASONING_EFFORTS = new Set<ReasoningEffort>(["none", "low", "medium", "high", "xhigh", "max", "ultra"]);
 const VALID_TRUST_MODES = new Set<TrustMode>(["trusted_repo_and_authors", "untrusted_or_mixed"]);
 const VALID_EXECUTION_SAFETY_MODES = new Set<ExecutionSafetyMode>(["unsandboxed_autonomous", "operator_gated"]);
 const VALID_LOCAL_REVIEW_POLICIES = new Set<LocalReviewPolicy>(["advisory", "block_ready", "block_merge"]);

--- a/src/core/config-types.ts
+++ b/src/core/config-types.ts
@@ -4,7 +4,8 @@ import type { RunState } from "./types";
 export type CodexModelStrategy = "inherit" | "fixed" | "alias";
 export type CodexExecutionTarget = "supervisor" | "local_review_generic" | "local_review_specialist" | "local_review_verifier";
 
-export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh" | "max";
+export type ReasoningEffort = "none" | "low" | "medium" | "high" | "xhigh" | "max" | "ultra";
+export type ReasoningEffortFallbackReason = "unsupported_reasoning_effort" | "nested_delegation_blocked";
 export type TrustMode = "trusted_repo_and_authors" | "untrusted_or_mixed";
 export type ExecutionSafetyMode = "unsandboxed_autonomous" | "operator_gated";
 export type LocalReviewPolicy = "advisory" | "block_ready" | "block_merge";

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,8 +1,11 @@
 import type { GitHubIssue } from "../github/types";
 import type {
+  CodexExecutionTarget,
   CopilotReviewTimeoutAction,
   LatestLocalCiResult,
   LocalCiRemediationTarget,
+  ReasoningEffort,
+  ReasoningEffortFallbackReason,
   SupervisorConfig,
 } from "./config-types";
 
@@ -44,6 +47,7 @@ export type {
   LocalReviewPosturePreset,
   LocalReviewPostureSummary,
   ReasoningEffort,
+  ReasoningEffortFallbackReason,
   ReleaseReadinessGatePosture,
   ReleaseReadinessGateSummary,
   ShellLocalCiCommandConfig,
@@ -373,6 +377,15 @@ export interface CodexTurnResult {
   lastMessage: string;
   stderr: string;
   stdout: string;
+  routing?: CodexExecutionRouting;
+}
+
+export interface CodexExecutionRouting {
+  target: CodexExecutionTarget;
+  model: string | null;
+  requestedReasoningEffort: ReasoningEffort | null;
+  reasoningEffort: ReasoningEffort | null;
+  reasoningEffortFallbackReason: ReasoningEffortFallbackReason | null;
 }
 
 export interface CliOptions {

--- a/src/doctor.test.ts
+++ b/src/doctor.test.ts
@@ -795,7 +795,7 @@ test("diagnoseSupervisorHost reports inherited host Codex defaults in doctor out
   assert.match(report, /doctor_codex_model_policy default=inherit->gpt-5\.4@inherited_host_default/);
   assert.match(report, /doctor_codex_route_overrides repair=default_route\(gpt-5\.4\) local_review=default_route\(gpt-5\.4\)/);
   assert.match(report, new RegExp(`doctor_codex_host_default model=gpt-5\\.4 source=${codexHome.replace(/[.*+?^${}()|[\]\\]/gu, "\\$&")}/config\\.toml`));
-  assert.match(report, /doctor_codex_reasoning active=supervisor requested=max effective=xhigh/);
+  assert.match(report, /doctor_codex_reasoning active=supervisor requested=max effective=xhigh reasoning_fallback_reason=unsupported_reasoning_effort/);
 });
 
 test("diagnoseSupervisorHost reports the active workspace Codex model and catalog", async (t) => {
@@ -827,7 +827,7 @@ test("diagnoseSupervisorHost reports the active workspace Codex model and catalo
 if [ ! -f .codex/config.toml ]; then
   exit 9
 fi
-printf '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["max"]}]}'
+printf '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["max","ultra"]}]}'
 `, { mode: 0o755 });
   await fs.mkdir(repoPath, { recursive: true });
   execFileSync("git", ["init", "-b", "main"], { cwd: repoPath });
@@ -841,7 +841,7 @@ printf '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["max"]}
       stateFile: path.join(root, "state.json"),
       codexBinary,
       codexModelStrategy: "inherit",
-      codexReasoningEffortByState: { implementing: "max" },
+      codexReasoningEffortByState: { implementing: "ultra" },
     }),
     authStatus: async () => ({ ok: true, message: null }),
     loadState: async () => ({ activeIssueNumber: activeRecord.issue_number, issues: { [activeRecord.issue_number]: activeRecord } }),
@@ -853,7 +853,7 @@ printf '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["max"]}
   const report = renderDoctorReport(diagnostics);
   assert.match(report, /doctor_codex_model_policy default=inherit->gpt-5\.6-terra@inherited_host_default/);
   assert.match(report, /doctor_codex_host_default model=gpt-5\.6-terra/);
-  assert.match(report, /doctor_codex_reasoning active=supervisor requested=max effective=max capability_source=live_catalog/);
+  assert.match(report, /doctor_codex_reasoning active=supervisor requested=ultra effective=ultra reasoning_fallback_reason=none capability_source=live_catalog/);
 });
 
 test("diagnoseSupervisorHost surfaces orphan prune candidates and representative eligibility reasons", async (t) => {

--- a/src/local-review/artifacts.test.ts
+++ b/src/local-review/artifacts.test.ts
@@ -15,7 +15,9 @@ import { createConfig } from "./test-helpers";
 const GENERIC_ROUTING = {
   target: "local_review_generic" as const,
   model: null,
+  requestedReasoningEffort: null,
   reasoningEffort: null,
+  reasoningEffortFallbackReason: null,
 };
 
 test("writeLocalReviewArtifacts renders durable guardrail provenance compactly", async () => {
@@ -111,7 +113,9 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
       routing: {
         target: "local_review_generic" as const,
         model: "local-review-fast",
-        reasoningEffort: "low" as const,
+        requestedReasoningEffort: "ultra" as const,
+        reasoningEffort: "max" as const,
+        reasoningEffortFallbackReason: "nested_delegation_blocked" as const,
       },
       exitCode: 0,
       rawOutput: "review raw output",
@@ -138,7 +142,9 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
       routing: {
         target: "local_review_specialist" as const,
         model: "gpt-5-codex",
+        requestedReasoningEffort: "low" as const,
         reasoningEffort: "low" as const,
+        reasoningEffortFallbackReason: null,
       },
       exitCode: 0,
       rawOutput: "specialist raw output",
@@ -170,7 +176,9 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
       routing: {
         target: "local_review_verifier",
         model: "gpt-5-codex",
-        reasoningEffort: "low",
+        requestedReasoningEffort: "ultra",
+        reasoningEffort: "max",
+        reasoningEffortFallbackReason: "nested_delegation_blocked",
       },
       exitCode: 0,
       rawOutput: "verifier raw output",
@@ -204,7 +212,9 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
       routing: {
         target: "local_review_verifier",
         model: "gpt-5-codex",
-        reasoningEffort: "low",
+        requestedReasoningEffort: "ultra",
+        reasoningEffort: "max",
+        reasoningEffortFallbackReason: "nested_delegation_blocked",
       },
       exitCode: 0,
       rawOutput: "verifier raw output",
@@ -221,11 +231,20 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
   const findings = JSON.parse(await fs.readFile(artifacts.findingsPath, "utf8"));
 
   assert.match(summary, /## Model routing/);
-  assert.match(summary, /- reviewer: target=local_review_generic model=local-review-fast reasoning=low/);
-  assert.match(summary, /- prisma_postgres_reviewer: target=local_review_specialist model=gpt-5-codex reasoning=low/);
-  assert.match(summary, /- verifier: target=local_review_verifier model=gpt-5-codex reasoning=low/);
+  assert.match(
+    summary,
+    /- reviewer: target=local_review_generic model=local-review-fast reasoning=max requested_reasoning=ultra effective_reasoning=max reasoning_fallback_reason=nested_delegation_blocked/,
+  );
+  assert.match(
+    summary,
+    /- prisma_postgres_reviewer: target=local_review_specialist model=gpt-5-codex reasoning=low requested_reasoning=low effective_reasoning=low reasoning_fallback_reason=none/,
+  );
+  assert.match(
+    summary,
+    /- verifier: target=local_review_verifier model=gpt-5-codex reasoning=max requested_reasoning=ultra effective_reasoning=max reasoning_fallback_reason=nested_delegation_blocked/,
+  );
   assert.deepEqual(
-    findings.roleReports.map((report: { role: string; routing: { target: string; model: string | null; reasoningEffort: string } }) => ({
+    findings.roleReports.map((report: { role: string; routing: Record<string, unknown> }) => ({
       role: report.role,
       routing: report.routing,
     })),
@@ -235,7 +254,9 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
         routing: {
           target: "local_review_generic",
           model: "local-review-fast",
-          reasoningEffort: "low",
+          requestedReasoningEffort: "ultra",
+          reasoningEffort: "max",
+          reasoningEffortFallbackReason: "nested_delegation_blocked",
         },
       },
       {
@@ -243,7 +264,9 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
         routing: {
           target: "local_review_specialist",
           model: "gpt-5-codex",
+          requestedReasoningEffort: "low",
           reasoningEffort: "low",
+          reasoningEffortFallbackReason: null,
         },
       },
     ],
@@ -251,7 +274,9 @@ test("writeLocalReviewArtifacts records deterministic model routing for generic,
   assert.deepEqual(findings.verifierReport?.routing, {
     target: "local_review_verifier",
     model: "gpt-5-codex",
-    reasoningEffort: "low",
+    requestedReasoningEffort: "ultra",
+    reasoningEffort: "max",
+    reasoningEffortFallbackReason: "nested_delegation_blocked",
   });
 });
 

--- a/src/local-review/artifacts.ts
+++ b/src/local-review/artifacts.ts
@@ -10,6 +10,7 @@ import { normalizeDurableTrackedArtifactContent } from "../core/journal";
 import { createPostMergeAuditResult, renderPostMergeAuditContractSummary } from "./post-merge-audit";
 import {
   type FinalizedLocalReview,
+  type LocalReviewExecutionRouting,
   type LocalReviewFinding,
   type LocalReviewResult,
   type LocalReviewRoleResult,
@@ -78,14 +79,16 @@ function summarizeGuardrailProvenance(provenance: FinalizedLocalReview["artifact
 }
 
 function summarizeModelRouting(finalized: FinalizedLocalReview): string[] {
+  const summarizeRouting = (routing: LocalReviewExecutionRouting): string =>
+    `target=${routing.target} model=${routing.model ?? "inherit"} reasoning=${routing.reasoningEffort ?? "default"} requested_reasoning=${routing.requestedReasoningEffort ?? routing.reasoningEffort ?? "default"} effective_reasoning=${routing.reasoningEffort ?? "default"} reasoning_fallback_reason=${routing.reasoningEffortFallbackReason ?? "none"}`;
   const lines = finalized.artifact.roleReports.map(
     (report) =>
-      `- ${report.role}: target=${report.routing.target} model=${report.routing.model ?? "inherit"} reasoning=${report.routing.reasoningEffort ?? "default"}`,
+      `- ${report.role}: ${summarizeRouting(report.routing)}`,
   );
 
   if (finalized.artifact.verifierReport) {
     lines.push(
-      `- verifier: target=${finalized.artifact.verifierReport.routing.target} model=${finalized.artifact.verifierReport.routing.model ?? "inherit"} reasoning=${finalized.artifact.verifierReport.routing.reasoningEffort ?? "default"}`,
+      `- verifier: ${summarizeRouting(finalized.artifact.verifierReport.routing)}`,
     );
   }
 

--- a/src/local-review/runner.test.ts
+++ b/src/local-review/runner.test.ts
@@ -354,6 +354,8 @@ exit 0
     target: "local_review_generic",
     model: null,
     reasoningEffort: "low",
+    requestedReasoningEffort: "low",
+    reasoningEffortFallbackReason: null,
   });
   assert.equal(args.includes("--dangerously-bypass-approvals-and-sandbox"), false);
   assert.deepEqual(args.slice(0, 5), [
@@ -406,6 +408,8 @@ exit 0
     target: "local_review_generic",
     model: "gpt-5.6-sol",
     reasoningEffort: "max",
+    requestedReasoningEffort: "max",
+    reasoningEffortFallbackReason: null,
   });
 
   assert.deepEqual(args.slice(0, 5), [
@@ -415,6 +419,70 @@ exit 0
     "-c",
     'model_reasoning_effort="max"',
   ]);
+});
+
+test("runCodexReviewTurn blocks nested ultra delegation for every local-review target", async (t) => {
+  const targets: LocalReviewTurnRequest["executionTarget"][] = [
+    "local_review_generic",
+    "local_review_specialist",
+    "local_review_verifier",
+  ];
+
+  for (const executionTarget of targets) {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), `local-review-runner-ultra-${executionTarget}-`));
+    const workspacePath = path.join(root, "workspace");
+    const codexBinary = path.join(root, "fake-codex.sh");
+    const argsPath = path.join(root, "args.log");
+    t.after(async () => {
+      await fs.rm(root, { recursive: true, force: true });
+    });
+    await fs.mkdir(workspacePath, { recursive: true });
+    await fs.writeFile(
+      codexBinary,
+      `#!/bin/sh
+set -eu
+if [ "$1" = "debug" ] && [ "$2" = "models" ]; then
+  printf '{"models":[{"slug":"gpt-5.6-terra","supported_reasoning_levels":["high","xhigh","max","ultra"]}]}'
+  exit 0
+fi
+printf '%s\n' "$@" > "${argsPath}"
+exit 0
+`,
+      { mode: 0o755 },
+    );
+
+    const result = await runCodexReviewTurn({
+      config: createConfig({
+        codexBinary,
+        codexModelStrategy: "fixed",
+        codexModel: "gpt-5.6-terra",
+        localReviewModelStrategy: "inherit",
+        codexReasoningEffortByState: { local_review: "ultra" },
+      }),
+      workspacePath,
+      role: executionTarget,
+      outputFileName: `${executionTarget}.txt`,
+      prompt: `nested delegation guard for ${executionTarget}`,
+      executionTarget,
+    });
+    const args = (await fs.readFile(argsPath, "utf8")).trim().split("\n");
+
+    assert.deepEqual(result.routing, {
+      target: executionTarget,
+      model: "gpt-5.6-terra",
+      reasoningEffort: "max",
+      requestedReasoningEffort: "ultra",
+      reasoningEffortFallbackReason: "nested_delegation_blocked",
+    });
+    assert.equal(args.includes('model_reasoning_effort="ultra"'), false);
+    assert.deepEqual(args.slice(0, 5), [
+      "exec",
+      "-m",
+      "gpt-5.6-terra",
+      "-c",
+      'model_reasoning_effort="max"',
+    ]);
+  }
 });
 
 test("runCodexReviewTurn returns the same routing used for a transient catalog fallback", async (t) => {
@@ -457,6 +525,8 @@ exit 0
     target: "local_review_generic",
     model: "gpt-5.6-terra",
     reasoningEffort: "xhigh",
+    requestedReasoningEffort: "max",
+    reasoningEffortFallbackReason: "unsupported_reasoning_effort",
   });
   assert.deepEqual(args.slice(0, 5), [
     "exec",

--- a/src/local-review/runner.ts
+++ b/src/local-review/runner.ts
@@ -61,6 +61,8 @@ export async function runCodexReviewTurn(args: LocalReviewTurnRequest): Promise<
     target: args.executionTarget,
     model: policy.model,
     reasoningEffort: policy.reasoningEffort,
+    requestedReasoningEffort: policy.requestedReasoningEffort ?? policy.reasoningEffort,
+    reasoningEffortFallbackReason: policy.reasoningEffortFallbackReason ?? null,
   };
   const overrideArgs = buildCodexConfigOverrideArgs(policy);
   const executionSafetyArgs = buildCodexExecutionSafetyArgs(args.config);

--- a/src/local-review/types.ts
+++ b/src/local-review/types.ts
@@ -1,5 +1,9 @@
 import { type LocalReviewRoleSelection } from "../review-role-detector";
-import { type CodexExecutionTarget, type ReasoningEffort } from "../core/config-types";
+import {
+  type CodexExecutionTarget,
+  type ReasoningEffort,
+  type ReasoningEffortFallbackReason,
+} from "../core/config-types";
 import { type VerifierGuardrailRule } from "../verifier-guardrails";
 
 export type LocalReviewSeverity = "none" | "low" | "medium" | "high";
@@ -168,6 +172,8 @@ export interface LocalReviewExecutionRouting {
   target: CodexExecutionTarget;
   model: string | null;
   reasoningEffort: ReasoningEffort | null;
+  requestedReasoningEffort?: ReasoningEffort | null;
+  reasoningEffortFallbackReason?: ReasoningEffortFallbackReason | null;
 }
 
 export interface LocalReviewArtifact {

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { executeCodexTurnPhase } from "./run-once-turn-execution";
+import { executeCodexTurnPhase, renderCodexExecutionSummary } from "./run-once-turn-execution";
 import {
   FailureContextCategory,
   GitHubIssue,
@@ -31,6 +31,29 @@ import { WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE } from 
 
 const SAMPLE_UNIX_WORKSTATION_PATH = `/${"home"}/alice/dev/private-repo`;
 const SAMPLE_MACOS_WORKSTATION_PATH = `/${"Users"}/alice/Dev/private-repo`;
+
+test("renderCodexExecutionSummary preserves requested and effective reasoning provenance", () => {
+  assert.equal(
+    renderCodexExecutionSummary({
+      supervisorMessage: "Summary: implemented the bounded ultra route.",
+      routing: {
+        target: "supervisor",
+        model: "gpt-5.6-luna",
+        requestedReasoningEffort: "ultra",
+        reasoningEffort: "max",
+        reasoningEffortFallbackReason: "unsupported_reasoning_effort",
+      },
+    }),
+    [
+      "codex_execution_routing target=supervisor model=gpt-5.6-luna requested_reasoning=ultra effective_reasoning=max reasoning_fallback_reason=unsupported_reasoning_effort",
+      "Summary: implemented the bounded ultra route.",
+    ].join("\n\n"),
+  );
+  assert.equal(
+    renderCodexExecutionSummary({ supervisorMessage: "Legacy runner summary." }),
+    "Legacy runner summary.",
+  );
+});
 
 test("run-once turn execution does not import Decision Kernel v2 action decisions", async () => {
   const source = await fs.readFile(path.join(process.cwd(), "src", "run-once-turn-execution.ts"), "utf8");

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -54,7 +54,12 @@ import {
   listChangedTrackedFilesBetween,
   pushBranch,
 } from "./core/workspace";
-import { AgentRunner, createCodexAgentRunner, parseAgentTurnStructuredResult } from "./supervisor/agent-runner";
+import {
+  AgentRunner,
+  type AgentTurnResult,
+  createCodexAgentRunner,
+  parseAgentTurnStructuredResult,
+} from "./supervisor/agent-runner";
 import {
   executionMetricsRetentionRootPath,
   syncExecutionMetricsRunSummarySafely,
@@ -117,6 +122,25 @@ export interface CodexTurnResult {
 
 const TRUSTED_DURABLE_ARTIFACT_NORMALIZATION_COMMIT_MESSAGE =
   "Normalize trusted durable artifacts for path hygiene";
+
+export function renderCodexExecutionSummary(
+  turnResult: Pick<AgentTurnResult, "supervisorMessage" | "routing">,
+): string {
+  if (!turnResult.routing) {
+    return turnResult.supervisorMessage;
+  }
+
+  const routing = turnResult.routing;
+  const routingSummary = [
+    "codex_execution_routing",
+    `target=${routing.target}`,
+    `model=${routing.model ?? "inherit"}`,
+    `requested_reasoning=${routing.requestedReasoningEffort ?? "default"}`,
+    `effective_reasoning=${routing.reasoningEffort ?? "default"}`,
+    `reasoning_fallback_reason=${routing.reasoningEffortFallbackReason ?? "none"}`,
+  ].join(" ");
+  return [routingSummary, turnResult.supervisorMessage.trim()].filter(Boolean).join("\n\n");
+}
 
 export interface CodexTurnShortCircuit {
   kind: "returned";
@@ -465,7 +489,7 @@ export async function executeCodexTurnPhase(
         record = stateStore.touch(record, {
           ...dossierConsumptionPatch,
           codex_session_id: turnResult.sessionId,
-          last_codex_summary: truncate(turnResult.supervisorMessage),
+          last_codex_summary: truncate(renderCodexExecutionSummary(turnResult)),
           last_failure_kind: turnResult.failureKind,
           last_error:
             turnResult.exitCode === 0

--- a/src/supervisor/agent-runner.test.ts
+++ b/src/supervisor/agent-runner.test.ts
@@ -402,6 +402,13 @@ test("createCodexAgentRunner adapts normalized start and resume turn contexts to
         ].join("\n"),
         stderr: sessionId ? "resume failed" : "",
         stdout: sessionId ? "resume output" : "fresh output",
+        routing: {
+          target: "supervisor",
+          model: "gpt-5.6-terra",
+          requestedReasoningEffort: "ultra",
+          reasoningEffort: "ultra",
+          reasoningEffortFallbackReason: null,
+        },
       };
     },
   });
@@ -479,6 +486,13 @@ test("createCodexAgentRunner adapts normalized start and resume turn contexts to
   assert.equal(startResult.structuredResult?.stateHint, "implementing");
   assert.equal(startResult.structuredResult?.blockedReason, null);
   assert.equal(startResult.structuredResult?.tests, "npx tsx --test src/supervisor/agent-runner.test.ts");
+  assert.deepEqual(startResult.routing, {
+    target: "supervisor",
+    model: "gpt-5.6-terra",
+    requestedReasoningEffort: "ultra",
+    reasoningEffort: "ultra",
+    reasoningEffortFallbackReason: null,
+  });
   assert.equal(resumeResult.sessionId, "session-123");
   assert.equal(resumeResult.failureKind, "codex_exit");
   assert.equal(resumeResult.structuredResult, null);

--- a/src/supervisor/agent-runner.ts
+++ b/src/supervisor/agent-runner.ts
@@ -9,6 +9,7 @@ import {
 import { truncatePreservingStartAndEnd } from "../core/utils";
 import type {
   BlockedReason,
+  CodexExecutionRouting,
   FailureContext,
   FailureKind,
   GitHubIssue,
@@ -100,6 +101,7 @@ export interface AgentTurnResult {
   supervisorMessage: string;
   stderr: string;
   stdout: string;
+  routing?: CodexExecutionRouting | null;
   // Structured output is only the normalized machine-readable footer from a
   // successful turn. Runner failures must be expressed via failureKind and
   // failureContext instead of mixing both channels.
@@ -211,6 +213,7 @@ export function createCodexAgentRunner(options: CreateCodexAgentRunnerOptions = 
           supervisorMessage: result.lastMessage,
           stderr: result.stderr,
           stdout: result.stdout,
+          routing: result.routing ?? null,
           structuredResult,
           failureKind,
           failureContext:
@@ -231,6 +234,7 @@ export function createCodexAgentRunner(options: CreateCodexAgentRunnerOptions = 
           supervisorMessage: "",
           stderr: message,
           stdout: "",
+          routing: null,
           structuredResult: null,
           failureKind: classifyFailureImpl(message),
           failureContext: buildFailureContextImpl("codex", "Codex turn execution failed.", [

--- a/src/supervisor/supervisor-status-rendering.test.ts
+++ b/src/supervisor/supervisor-status-rendering.test.ts
@@ -348,7 +348,9 @@ test("buildLocalReviewRoutingStatusLine summarizes explicit mini routing for gen
           routing: {
             target: "local_review_generic",
             model: "gpt-5.4-mini",
-            reasoningEffort: "low",
+            requestedReasoningEffort: "ultra",
+            reasoningEffort: "max",
+            reasoningEffortFallbackReason: "nested_delegation_blocked",
           },
         },
         {
@@ -365,7 +367,9 @@ test("buildLocalReviewRoutingStatusLine summarizes explicit mini routing for gen
         routing: {
           target: "local_review_verifier",
           model: "gpt-5-codex",
-          reasoningEffort: "low",
+          requestedReasoningEffort: "ultra",
+          reasoningEffort: "max",
+          reasoningEffortFallbackReason: "nested_delegation_blocked",
         },
       },
     },
@@ -384,7 +388,7 @@ test("buildLocalReviewRoutingStatusLine summarizes explicit mini routing for gen
         local_review_summary_path: summaryPath,
       }),
     }),
-    "local_review_routing generic=gpt-5.4-mini(1) specialists=gpt-5-codex(1) verifier=gpt-5-codex",
+    "local_review_routing generic=gpt-5.4-mini(requested_reasoning=ultra,effective_reasoning=max,reasoning_fallback_reason=nested_delegation_blocked)(1) specialists=gpt-5-codex(requested_reasoning=low,effective_reasoning=low,reasoning_fallback_reason=none)(1) verifier=gpt-5-codex(requested_reasoning=ultra,effective_reasoning=max,reasoning_fallback_reason=nested_delegation_blocked)",
   );
 });
 
@@ -437,7 +441,7 @@ test("buildLocalReviewRoutingStatusLine labels inherited generic local-review ro
         local_review_summary_path: summaryPath,
       }),
     }),
-    "local_review_routing generic=inherit->gpt-5-codex(1) specialists=gpt-5-codex(1) verifier=gpt-5-codex",
+    "local_review_routing generic=inherit->gpt-5-codex(requested_reasoning=low,effective_reasoning=low,reasoning_fallback_reason=none)(1) specialists=gpt-5-codex(requested_reasoning=low,effective_reasoning=low,reasoning_fallback_reason=none)(1) verifier=gpt-5-codex(requested_reasoning=low,effective_reasoning=low,reasoning_fallback_reason=none)",
   );
 });
 
@@ -474,9 +478,84 @@ test("renderStatusCodexModelPolicyLines reports inherited host defaults and over
   );
 
   assert.deepEqual(lines, [
-    "codex_execution_policy active=supervisor:inherit->gpt-5.4@inherited_host_default reasoning=xhigh requested_reasoning=max capability_source=fallback fallback_reason=catalog_probe_unavailable",
+    "codex_execution_policy active=supervisor:inherit->gpt-5.4@inherited_host_default reasoning=xhigh requested_reasoning=max effective_reasoning=xhigh reasoning_fallback_reason=unsupported_reasoning_effort capability_source=fallback fallback_reason=catalog_probe_unavailable",
     "codex_route_overrides repair=alias:gpt-5.4-mini@bounded_repair_override local_review=alias:local-review-fast@local_review_override",
   ]);
+});
+
+test("renderStatusCodexModelPolicyLines preserves ultra provenance for supported, unsupported, and nested routes", async (t) => {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "status-codex-policy-ultra-"));
+  const previousCodexHome = process.env.CODEX_HOME;
+  t.after(async () => {
+    if (previousCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = previousCodexHome;
+    await fs.rm(root, { recursive: true, force: true });
+  });
+  process.env.CODEX_HOME = path.join(root, "codex-home");
+  await fs.mkdir(process.env.CODEX_HOME, { recursive: true });
+
+  async function writeCatalogBinary(name: string, models: unknown[]): Promise<string> {
+    const binary = path.join(root, name);
+    await fs.writeFile(
+      binary,
+      `#!/usr/bin/env node\nprocess.stdout.write(${JSON.stringify(JSON.stringify({ models }))});\n`,
+      { mode: 0o755 },
+    );
+    return binary;
+  }
+
+  const solBinary = await writeCatalogBinary("sol-catalog", [
+    { slug: "gpt-5.6-sol", supported_reasoning_levels: ["max", "ultra"] },
+  ]);
+  const lunaBinary = await writeCatalogBinary("luna-catalog", [
+    { slug: "gpt-5.6-luna", supported_reasoning_levels: ["xhigh", "max"] },
+  ]);
+
+  const supported = await buildCodexModelPolicySnapshot({
+    config: createConfig({
+      codexBinary: solBinary,
+      codexModelStrategy: "fixed",
+      codexModel: "gpt-5.6-sol",
+      codexReasoningEffortByState: { implementing: "ultra" },
+    }),
+    activeState: "implementing",
+    activeRecord: null,
+  });
+  assert.equal(
+    renderStatusCodexModelPolicyLines(supported)[0],
+    "codex_execution_policy active=supervisor:fixed:gpt-5.6-sol@supervisor_config reasoning=ultra requested_reasoning=ultra effective_reasoning=ultra reasoning_fallback_reason=none capability_source=live_catalog fallback_reason=none",
+  );
+
+  const unsupported = await buildCodexModelPolicySnapshot({
+    config: createConfig({
+      codexBinary: lunaBinary,
+      codexModelStrategy: "fixed",
+      codexModel: "gpt-5.6-luna",
+      codexReasoningEffortByState: { implementing: "ultra" },
+    }),
+    activeState: "implementing",
+    activeRecord: null,
+  });
+  assert.equal(
+    renderStatusCodexModelPolicyLines(unsupported)[0],
+    "codex_execution_policy active=supervisor:fixed:gpt-5.6-luna@supervisor_config reasoning=max requested_reasoning=ultra effective_reasoning=max reasoning_fallback_reason=unsupported_reasoning_effort capability_source=live_catalog fallback_reason=none",
+  );
+
+  const nested = await buildCodexModelPolicySnapshot({
+    config: createConfig({
+      codexBinary: solBinary,
+      codexModelStrategy: "fixed",
+      codexModel: "gpt-5.6-sol",
+      localReviewModelStrategy: "inherit",
+      codexReasoningEffortByState: { local_review: "ultra" },
+    }),
+    activeState: "local_review",
+    activeRecord: null,
+  });
+  assert.equal(
+    renderStatusCodexModelPolicyLines(nested)[0],
+    "codex_execution_policy active=local_review_generic:default_route(gpt-5.6-sol) reasoning=max requested_reasoning=ultra effective_reasoning=max reasoning_fallback_reason=nested_delegation_blocked capability_source=live_catalog fallback_reason=none",
+  );
 });
 
 test("buildCodexModelPolicySnapshot probes and resolves inherited models from the active workspace", async (t) => {
@@ -611,7 +690,7 @@ test("buildCodexModelPolicySnapshot keeps the default route independent from act
   });
   assert.equal(
     renderStatusCodexModelPolicyLines(snapshot)[0],
-    "codex_execution_policy active=supervisor:alias:gpt-5.4-mini@bounded_repair_override reasoning=medium capability_source=fallback fallback_reason=catalog_probe_unavailable",
+    "codex_execution_policy active=supervisor:alias:gpt-5.4-mini@bounded_repair_override reasoning=medium requested_reasoning=medium effective_reasoning=medium reasoning_fallback_reason=none capability_source=fallback fallback_reason=catalog_probe_unavailable",
   );
 });
 
@@ -643,7 +722,7 @@ test("buildCodexModelPolicySnapshot uses the local-review route for active local
   );
 
   assert.deepEqual(lines, [
-    "codex_execution_policy active=local_review_generic:alias:local-review-fast@local_review_override reasoning=low capability_source=fallback fallback_reason=catalog_probe_unavailable",
+    "codex_execution_policy active=local_review_generic:alias:local-review-fast@local_review_override reasoning=low requested_reasoning=low effective_reasoning=low reasoning_fallback_reason=none capability_source=fallback fallback_reason=catalog_probe_unavailable",
     "codex_route_overrides repair=default_route(gpt-5.4) local_review=alias:local-review-fast@local_review_override",
   ]);
 });

--- a/src/supervisor/supervisor-status-rendering.ts
+++ b/src/supervisor/supervisor-status-rendering.ts
@@ -265,15 +265,23 @@ function describeGenericLocalReviewRouting(
   config: Pick<SupervisorConfig, "localReviewModelStrategy">,
   routing: LocalReviewExecutionRouting,
 ): string {
+  const reasoning = describeRoutingReasoning(routing);
   if (!config.localReviewModelStrategy || config.localReviewModelStrategy === "inherit") {
-    return routing.model ? `inherit->${routing.model}` : "inherit";
+    return `${routing.model ? `inherit->${routing.model}` : "inherit"}${reasoning}`;
   }
 
-  return routing.model ?? "inherit";
+  return `${routing.model ?? "inherit"}${reasoning}`;
 }
 
 function describeResolvedRouting(routing: LocalReviewExecutionRouting | null | undefined): string {
-  return routing?.model ?? "inherit";
+  return routing ? `${routing.model ?? "inherit"}${describeRoutingReasoning(routing)}` : "inherit";
+}
+
+function describeRoutingReasoning(routing: LocalReviewExecutionRouting): string {
+  const requested = routing.requestedReasoningEffort ?? routing.reasoningEffort ?? "default";
+  const effective = routing.reasoningEffort ?? "default";
+  const reason = routing.reasoningEffortFallbackReason ?? "none";
+  return `(requested_reasoning=${requested},effective_reasoning=${effective},reasoning_fallback_reason=${reason})`;
 }
 
 export async function buildLocalReviewRoutingStatusLine(args: {


### PR DESCRIPTION
## Summary

- add `ultra` as a parsed, catalog-aware reasoning effort while keeping every existing default unchanged
- forward explicit `ultra` only for catalog-supported supervisor turns; clamp unsupported and local-review turns with exact machine-readable fallback reasons
- cap automatic repeated-failure escalation at `max` and prevent non-ultra requests from being upgraded to delegated execution
- preserve requested/effective/reason provenance in runner results, durable supervisor turn summaries, doctor/status output, and local-review Markdown/JSON artifacts
- document the native-delegation boundary and its latency, concurrency, and cost tradeoffs

## Verification

- `npm run verify:supervisor-pre-pr`
- focused parser/policy/runner/doctor/status/artifact suite: 253/253 passed
- `node dist/index.js issue-lint 2444 --config /Users/jp.infra/Dev2/codex-supervisor/codex-supervisor-self/supervisor.config.codex.json` (`execution_ready=yes`)
- `npm run verify:pre-pr`: 2884/2886 passed; the two failures are pre-existing recovery-reconciliation assertions and reproduce unchanged on `origin/main`:
  - `reconcileRecoverableBlockedIssueStates does not promote required reviews with record-scoped proof`
  - `reconcileRecoverableBlockedIssueStates does not promote changes-requested reviews with record-scoped proof`

## Safety boundary

The offline fallback catalog intentionally does not advertise `ultra`. A failed or missing live catalog probe therefore falls back to a non-delegating effort.

Closes #2444