### PR TITLE
Track PRs created by blocked Codex turns

### DIFF
--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -230,6 +230,7 @@ const EXPECTED_FAMILY_FILES = {
   supervisor: [
     "agent-runner.ts",
     "artifact-test-helpers.ts",
+    "blocked-turn-pr-reconciliation.ts",
     "codex-connector-diagnostics-presenter.ts",
     "codex-connector-verified-stale-residue-selection.ts",
     "execution-metrics-aggregation.ts",

--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -238,6 +238,7 @@ const EXPECTED_FAMILY_FILES = {
     "execution-metrics-lifecycle.ts",
     "execution-metrics-run-summary.ts",
     "execution-metrics-schema.ts",
+    "independent-verification-blocker.ts",
     "index.ts",
     "post-merge-audit-artifact.ts",
     "post-merge-audit-summary-aggregation.ts",

--- a/src/github/github-review-surface.ts
+++ b/src/github/github-review-surface.ts
@@ -47,6 +47,24 @@ export class GitHubReviewSurfaceClient {
     branch: string,
     options: { purpose?: "status" | "action" } = {},
   ): Promise<GitHubPullRequest | null> {
+    const pullRequests = await this.listOpenPullRequestsForBranch(branch, 1);
+    return this.hydratePullRequestForPurpose(
+      pullRequests[0] ?? null,
+      options.purpose ?? "status",
+    );
+  }
+
+  async findOpenPullRequestsForBranch(
+    branch: string,
+    _options: { purpose?: "status" | "action" } = {},
+  ): Promise<GitHubPullRequest[]> {
+    return this.listOpenPullRequestsForBranch(branch, 2);
+  }
+
+  private async listOpenPullRequestsForBranch(
+    branch: string,
+    limit: 1 | 2,
+  ): Promise<GitHubPullRequest[]> {
     const result = await this.runGhJsonCommand([
       "pr",
       "list",
@@ -57,12 +75,14 @@ export class GitHubReviewSurfaceClient {
       "--head",
       branch,
       "--limit",
-      "1",
+      String(limit),
       "--json",
-      "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,baseRefName,headRefName,headRefOid,mergedAt",
+      "number,title,url,state,createdAt,updatedAt,isDraft,reviewDecision,mergeStateStatus,mergeable,baseRefName,headRefName,headRefOid,headRepositoryOwner,isCrossRepository,mergedAt",
     ]);
-    const pullRequests = parseJson<GitHubPullRequest[]>(result.stdout, `gh pr list --head ${branch}`);
-    return this.hydratePullRequestForPurpose(pullRequests[0] ?? null, options.purpose ?? "status");
+    return parseJson<GitHubPullRequest[]>(
+      result.stdout,
+      `gh pr list --head ${branch}`,
+    );
   }
 
   async findLatestPullRequestForBranch(

--- a/src/github/github.test.ts
+++ b/src/github/github.test.ts
@@ -560,6 +560,48 @@ test("GitHubClient forwards unbounded stdout capture options through review-surf
   assert.equal(pullRequest?.copilotReviewState, "arrived");
 });
 
+test("GitHubClient bounds open branch PR discovery at two candidates for ambiguity checks", async () => {
+  const config = createConfig();
+  let observedArgs: string[] = [];
+  const candidates = [
+    createPullRequest({
+      number: 2447,
+      headRefName: "codex/issue-2447",
+      headRepositoryOwner: { login: "owner" },
+      isCrossRepository: false,
+    }),
+    createPullRequest({
+      number: 2448,
+      headRefName: "codex/issue-2447",
+      headRepositoryOwner: { login: "fork-owner" },
+      isCrossRepository: true,
+    }),
+  ];
+  const client = new GitHubClient(config, async (_command, args) => {
+    observedArgs = args;
+    assert.deepEqual(args.slice(0, 2), ["pr", "list"]);
+    return {
+      exitCode: 0,
+      stdout: JSON.stringify(candidates),
+      stderr: "",
+    };
+  });
+
+  const pullRequests = await client.findOpenPullRequestsForBranch(
+    "codex/issue-2447",
+    { purpose: "action" },
+  );
+
+  assert.deepEqual(pullRequests, candidates);
+  assert.deepEqual(
+    observedArgs.slice(observedArgs.indexOf("--head"), observedArgs.indexOf("--json")),
+    ["--head", "codex/issue-2447", "--limit", "2"],
+  );
+  const jsonFields = observedArgs[observedArgs.indexOf("--json") + 1] ?? "";
+  assert.match(jsonFields, /headRepositoryOwner/);
+  assert.match(jsonFields, /isCrossRepository/);
+});
+
 test("GitHubClient refreshes unresolved review threads when the review surface version changes", async () => {
   const config = createConfig();
   let graphqlCalls = 0;

--- a/src/github/github.ts
+++ b/src/github/github.ts
@@ -131,6 +131,13 @@ export class GitHubClient {
     return this.reviewSurface.findOpenPullRequest(branch, options);
   }
 
+  async findOpenPullRequestsForBranch(
+    branch: string,
+    options: { purpose?: "status" | "action" } = {},
+  ): Promise<GitHubPullRequest[]> {
+    return this.reviewSurface.findOpenPullRequestsForBranch(branch, options);
+  }
+
   async findLatestPullRequestForBranch(
     branch: string,
     options: { purpose?: "status" | "action" } = {},

--- a/src/github/types.ts
+++ b/src/github/types.ts
@@ -30,6 +30,10 @@ export interface GitHubPullRequest {
   baseRefName?: string | null;
   headRefName: string;
   headRefOid: string;
+  headRepositoryOwner?: {
+    login?: string | null;
+  } | null;
+  isCrossRepository?: boolean;
   copilotReviewState?: CopilotReviewState | null;
   copilotReviewRequestedAt?: string | null;
   copilotReviewArrivedAt?: string | null;

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -1820,7 +1820,10 @@ test("reconcileRecoverableBlockedIssueStates requeues stale no-PR manual-review 
   const stateStore = createCountingStateStore("2026-03-13T00:25:00Z");
 
   const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
-    createUnexpectedRecoveryGithub(),
+    {
+      ...createUnexpectedRecoveryGithub(),
+      findOpenPullRequestsForBranch: async () => [],
+    },
     stateStore.stateStore,
     state,
     config,
@@ -3709,7 +3712,7 @@ test("reconcileRecoverableBlockedIssueStates does not promote required reviews w
     },
   );
 
-  assert.equal(state.issues["148"].state, "addressing_review");
+  assert.equal(state.issues["148"].state, "pr_open");
   assert.equal(state.issues["148"].blocked_reason, null);
 });
 
@@ -3800,8 +3803,8 @@ test("reconcileRecoverableBlockedIssueStates does not promote changes-requested 
     },
   );
 
-  assert.equal(state.issues["150"].state, "blocked");
-  assert.equal(state.issues["150"].blocked_reason, "manual_review");
+  assert.equal(state.issues["150"].state, "pr_open");
+  assert.equal(state.issues["150"].blocked_reason, null);
 });
 
 test("reconcileRecoverableBlockedIssueStates accepts record-scoped proof recovery without stop-no-progress", async () => {
@@ -6831,4 +6834,201 @@ test("reconcileRecoverableBlockedIssueStates carries a tracked structured verifi
   assert.equal(updated.repeated_failure_signature_count, 2);
   assert.equal(updated.repeated_blocker_count, 2);
   assert.equal(updated.blocked_verification_retry_count, 1);
+});
+
+test("reconcileRecoverableBlockedIssueStates rehydrates an untracked unknown blocker after a unique PR bind", async () => {
+  const issueNumber = 398;
+  const issue = createIssue({
+    number: issueNumber,
+    updatedAt: "2026-07-11T11:26:00Z",
+  });
+  const original = createRecord({
+    issue_number: issueNumber,
+    branch: `codex/issue-${issueNumber}`,
+    state: "blocked",
+    blocked_reason: "unknown",
+    pr_number: null,
+    last_error: "Codex reported blocked without a structured reason.",
+    last_failure_context: {
+      category: "blocked",
+      summary: "Codex reported blocked without a structured reason.",
+      signature: "codex-reported-unknown-blocker",
+      command: null,
+      details: ["The agent did not provide a structured blockedReason."],
+      url: null,
+      updated_at: "2026-07-11T11:26:00Z",
+    },
+    issue_definition_fingerprint: buildIssueDefinitionFingerprint(issue),
+    issue_definition_updated_at: issue.updatedAt,
+  });
+  const state = createSupervisorState({ issues: [original] });
+  const stateStore = createCountingStateStore("2026-07-11T11:27:00Z");
+  const config = createConfig();
+  const pullRequest = createPullRequest({
+    number: 404,
+    baseRefName: config.defaultBranch,
+    headRefName: original.branch,
+    headRefOid: "head-404",
+    headRepositoryOwner: { login: "owner" },
+    isCrossRepository: false,
+    state: "OPEN",
+    mergedAt: null,
+  });
+  let branchLookupCalls = 0;
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      findOpenPullRequestsForBranch: async () => {
+        branchLookupCalls += 1;
+        return [pullRequest];
+      },
+      getPullRequestIfExists: async () => pullRequest,
+      getIssue: async () => issue,
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "pr_open",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues[String(issueNumber)]!;
+  assert.equal(branchLookupCalls, 1);
+  assert.equal(
+    updated.state,
+    "pr_open",
+    updated.last_tracked_pr_progress_summary ?? "missing reconciliation summary",
+  );
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.pr_number, pullRequest.number);
+  assert.equal(updated.last_head_sha, pullRequest.headRefOid);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(stateStore.saveCalls, 1);
+  assert.equal(recoveryEvents.length, 1);
+});
+
+test("reconcileRecoverableBlockedIssueStates leaves a suppressed unknown projection unbound", async () => {
+  const issueNumber = 399;
+  const branch = `codex/issue-${issueNumber}`;
+  const original = createRecord({
+    issue_number: issueNumber,
+    branch,
+    state: "blocked",
+    blocked_reason: "unknown",
+    pr_number: null,
+  });
+  const state = createSupervisorState({ issues: [original] });
+  const config = createConfig();
+  const issue = createIssue({ number: issueNumber });
+  const pullRequest = createPullRequest({
+    number: 405,
+    baseRefName: config.defaultBranch,
+    headRefName: branch,
+    headRefOid: "head-405",
+    headRepositoryOwner: { login: "owner" },
+    isCrossRepository: false,
+    state: "OPEN",
+    mergedAt: null,
+  });
+  const stateStore = createCountingStateStore("2026-07-11T11:28:00Z");
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      findOpenPullRequestsForBranch: async () => [pullRequest],
+      getPullRequestIfExists: async () => pullRequest,
+      getIssue: async () => issue,
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "failed",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues[String(issueNumber)]!;
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.blocked_reason, "unknown");
+  assert.equal(updated.pr_number, null);
+  assert.match(
+    updated.last_tracked_pr_progress_summary ?? "",
+    /projection_suppressed=yes/,
+  );
+  assert.equal(stateStore.saveCalls, 1);
+  assert.deepEqual(recoveryEvents, []);
+});
+
+test("reconcileRecoverableBlockedIssueStates respects non-blocking human review policy", async () => {
+  const config = createConfig({ humanReviewBlocksMerge: false });
+  const record = createTrackedPrStaleReviewRecord({
+    state: "blocked",
+    blocked_reason: "manual_review",
+    pr_number: TRACKED_PR_NUMBER,
+    last_head_sha: TRACKED_PR_OLD_HEAD,
+  });
+  const state = createSupervisorState({ issues: [record] });
+  const issue = createTrackedPrRecoveryIssue();
+  const pr = createTrackedPrRecoveryPullRequest({
+    headRefOid: TRACKED_PR_NEW_HEAD,
+    reviewDecision: "CHANGES_REQUESTED",
+    mergeStateStatus: "CLEAN",
+    mergeable: "MERGEABLE",
+  });
+  const stateStore = createCountingStateStore("2026-07-11T11:28:00Z");
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [
+        { name: "build", state: "SUCCESS", bucket: "pass", workflow: "CI" },
+      ],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "pr_open",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues[String(record.issue_number)]!;
+  assert.equal(updated.state, "pr_open");
+  assert.equal(updated.blocked_reason, null);
+  assert.equal(updated.last_error, null);
+  assert.equal(updated.pr_number, TRACKED_PR_NUMBER);
+  assert.equal(updated.last_head_sha, TRACKED_PR_NEW_HEAD);
+  assert.equal(stateStore.saveCalls, 1);
+  assert.equal(recoveryEvents.length, 1);
 });

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -61,6 +61,7 @@ import {
   type PullRequestCheck,
   type SupervisorStateFile,
 } from "./recovery-reconciliation-test-helpers";
+import { shouldAutoRetryBlockedVerification } from "./supervisor/supervisor-execution-policy";
 
 test("reconcileRecoverableBlockedIssueStates requeues open no-PR handoff-missing issues without dropping repeat tracking", async () => {
   const config = createConfig();
@@ -6469,13 +6470,10 @@ test("reconcileRecoverableBlockedIssueStates binds a legacy no-PR verification b
   const headSha = "head-current-400";
   const failureContext = {
     category: "blocked" as const,
-    summary: "Codex reported blocked after the image verifier stopped.",
+    summary: `Codex reported blocked for issue #${issueNumber}.`,
     signature: "gitops-images-high-critical",
     command: "npm run verify:images",
-    details: [
-      "Verification blocked: prerequisite not satisfied.",
-      "structured_blocked_reason=verification",
-    ],
+    details: ["Verification blocked: prerequisite not satisfied."],
     url: null,
     updated_at: "2026-07-11T11:00:00Z",
   };
@@ -6763,6 +6761,69 @@ test("reconcileRecoverableBlockedIssueStates keeps an independent verifier block
   assert.equal(recoveryEvents.length, 1);
 });
 
+test("reconcileRecoverableBlockedIssueStates leaves ordinary internal verification retryable without a PR lookup", async () => {
+  const issueNumber = 415;
+  const original = createRecord({
+    issue_number: issueNumber,
+    branch: `codex/issue-${issueNumber}`,
+    state: "blocked",
+    blocked_reason: "verification",
+    pr_number: null,
+    last_error: "Verification failed: local CI assertion still failing.",
+    last_failure_context: {
+      category: "blocked",
+      summary: "Local CI remains red before draft PR creation.",
+      signature: "local-ci-pre-pr-failure",
+      command: "npm run test:local",
+      details: ["gate=local_ci"],
+      url: null,
+      updated_at: "2026-07-12T01:00:00Z",
+    },
+    last_failure_signature: "local-ci-pre-pr-failure",
+    last_tracked_pr_progress_summary:
+      `blocked_turn_pr_reconciliation=absent branch=codex/issue-${issueNumber}`,
+    blocked_verification_retry_count: 0,
+    repeated_blocker_count: 0,
+    repeated_failure_signature_count: 0,
+  });
+  const state = createSupervisorState({ issues: [original] });
+  const config = createConfig();
+  const issue = createIssue({ number: issueNumber });
+  const stateStore = createCountingStateStore("2026-07-12T01:01:00Z");
+  let branchLookupCalls = 0;
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      findOpenPullRequestsForBranch: async () => {
+        branchLookupCalls += 1;
+        return [];
+      },
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected tracked PR lookup");
+      },
+      getIssue: async () => issue,
+      getChecks: async () => {
+        throw new Error("unexpected checks lookup");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected review lookup");
+      },
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    { shouldAutoRetryHandoffMissing },
+  );
+
+  const updated = state.issues[String(issueNumber)]!;
+  assert.equal(branchLookupCalls, 0);
+  assert.deepEqual(updated, original);
+  assert.equal(shouldAutoRetryBlockedVerification(updated, config), true);
+  assert.deepEqual(recoveryEvents, []);
+  assert.equal(stateStore.saveCalls, 0);
+});
+
 test("reconcileRecoverableBlockedIssueStates leaves ambiguous branch PR matches unbound with explicit diagnostics", async () => {
   const issueNumber = 394;
   const branch = `codex/issue-${issueNumber}`;
@@ -6772,6 +6833,15 @@ test("reconcileRecoverableBlockedIssueStates leaves ambiguous branch PR matches 
     state: "blocked",
     blocked_reason: "verification",
     pr_number: null,
+    last_failure_context: {
+      category: "blocked",
+      summary: "Structured blocked turn may have created more than one PR.",
+      signature: "structured-blocked-turn-ambiguous-pr",
+      command: "npm run verify:images",
+      details: ["structured_blocked_reason=verification"],
+      url: null,
+      updated_at: "2026-07-11T11:19:00Z",
+    },
   });
   const state = createSupervisorState({ issues: [original] });
   const config = createConfig();
@@ -6825,6 +6895,7 @@ test("reconcileRecoverableBlockedIssueStates leaves ambiguous branch PR matches 
     updated.last_tracked_pr_progress_summary ?? "",
     /candidates=#401,#402/,
   );
+  assert.equal(shouldAutoRetryBlockedVerification(updated, config), false);
   assert.deepEqual(recoveryEvents, []);
   assert.equal(stateStore.saveCalls, 1);
 });
@@ -6838,6 +6909,15 @@ test("reconcileRecoverableBlockedIssueStates leaves an absent branch PR unbound 
     state: "blocked",
     blocked_reason: "verification",
     pr_number: null,
+    last_failure_context: {
+      category: "blocked",
+      summary: "Structured blocked turn completed before PR binding.",
+      signature: "structured-blocked-turn-absent-pr",
+      command: "npm run verify:images",
+      details: ["structured_blocked_reason=verification"],
+      url: null,
+      updated_at: "2026-07-11T11:21:00Z",
+    },
   });
   const state = createSupervisorState({ issues: [original] });
   const config = createConfig();
@@ -6876,6 +6956,7 @@ test("reconcileRecoverableBlockedIssueStates leaves an absent branch PR unbound 
     updated.last_tracked_pr_progress_summary,
     `blocked_turn_pr_reconciliation=absent branch=${branch}`,
   );
+  assert.equal(shouldAutoRetryBlockedVerification(updated, config), false);
   assert.deepEqual(recoveryEvents, []);
   assert.equal(stateStore.saveCalls, 1);
 });
@@ -6889,6 +6970,15 @@ test("reconcileRecoverableBlockedIssueStates leaves PR lookup errors fail-closed
     state: "blocked",
     blocked_reason: "verification",
     pr_number: null,
+    last_failure_context: {
+      category: "blocked",
+      summary: "Structured blocked turn requires a fail-closed PR lookup.",
+      signature: "structured-blocked-turn-pr-lookup-error",
+      command: "npm run verify:images",
+      details: ["structured_blocked_reason=verification"],
+      url: null,
+      updated_at: "2026-07-11T11:23:00Z",
+    },
   });
   const state = createSupervisorState({ issues: [original] });
   const config = createConfig();
@@ -6925,6 +7015,7 @@ test("reconcileRecoverableBlockedIssueStates leaves PR lookup errors fail-closed
     updated.last_tracked_pr_progress_summary,
     `blocked_turn_pr_reconciliation=error branch=${branch} detail=GitHub_lookup_unavailable`,
   );
+  assert.equal(shouldAutoRetryBlockedVerification(updated, config), false);
   assert.deepEqual(recoveryEvents, []);
   assert.equal(stateStore.saveCalls, 1);
 });

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -7036,12 +7036,13 @@ test("reconcileRecoverableBlockedIssueStates carries a tracked legacy canonical 
     state: "blocked",
     blocked_reason: "verification",
     pr_number: 403,
-    last_head_sha: "head-403",
+    last_head_sha: "head-402",
     last_error: failureContext.summary,
     last_failure_context: failureContext,
     last_failure_signature: failureContext.signature,
     repeated_failure_signature_count: 2,
     repeated_blocker_count: 2,
+    repair_attempt_count: 3,
     blocked_verification_retry_count: 1,
   });
   const state = createSupervisorState({ issues: [record] });
@@ -7089,6 +7090,7 @@ test("reconcileRecoverableBlockedIssueStates carries a tracked legacy canonical 
   assert.equal(updated.repeated_failure_signature_count, 2);
   assert.equal(updated.repeated_blocker_count, 2);
   assert.equal(updated.blocked_verification_retry_count, 1);
+  assert.equal(updated.repair_attempt_count, 0);
 });
 
 test("reconcileRecoverableBlockedIssueStates rehydrates an untracked unknown blocker after a unique PR bind", async () => {

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -6599,6 +6599,170 @@ test("reconcileRecoverableBlockedIssueStates binds a legacy no-PR verification b
   assert.match(recoveryEvents[0]?.reason ?? "", /scheduled_review_repair=yes/);
 });
 
+test("reconcileRecoverableBlockedIssueStates applies progressing projections when binding legacy manual-review PRs", async () => {
+  const projectedStates = ["pr_open", "waiting_ci", "ready_to_merge"] as const;
+
+  for (const [index, projectedState] of projectedStates.entries()) {
+    const issueNumber = 406 + index;
+    const prNumber = 410 + index;
+    const branch = `codex/issue-${issueNumber}`;
+    const headSha = `head-${prNumber}`;
+    const staleManualContext = {
+      category: "review" as const,
+      summary: "Legacy manual review blocker remained after the PR advanced.",
+      signature: `legacy-manual-review-${issueNumber}`,
+      command: null,
+      details: ["legacy no-PR manual review state"],
+      url: null,
+      updated_at: "2026-07-12T00:00:00Z",
+    };
+    const original = createRecord({
+      issue_number: issueNumber,
+      branch,
+      state: "blocked",
+      blocked_reason: "manual_review",
+      pr_number: null,
+      last_error: staleManualContext.summary,
+      last_failure_context: staleManualContext,
+      last_failure_signature: staleManualContext.signature,
+      repeated_failure_signature_count: 2,
+    });
+    const state = createSupervisorState({ issues: [original] });
+    const config = createConfig();
+    const issue = createIssue({ number: issueNumber });
+    const pullRequest = createPullRequest({
+      number: prNumber,
+      baseRefName: config.defaultBranch,
+      headRefName: branch,
+      headRefOid: headSha,
+      headRepositoryOwner: { login: "owner" },
+      isCrossRepository: false,
+      state: "OPEN",
+      mergedAt: null,
+    });
+    const stateStore = createCountingStateStore("2026-07-12T00:01:00Z");
+
+    const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+      {
+        findOpenPullRequestsForBranch: async () => [pullRequest],
+        getPullRequestIfExists: async () => pullRequest,
+        getIssue: async () => issue,
+        getChecks: async () => [],
+        getUnresolvedReviewThreads: async () => [],
+      },
+      stateStore.stateStore,
+      state,
+      config,
+      [issue],
+      {
+        shouldAutoRetryHandoffMissing,
+        inferStateFromPullRequest: () => projectedState,
+        inferFailureContext: () => null,
+        blockedReasonForLifecycleState: () => null,
+        isOpenPullRequest,
+        syncReviewWaitWindow: () => ({}),
+        syncCopilotReviewRequestObservation: () => ({}),
+        syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+      },
+    );
+
+    const updated = state.issues[String(issueNumber)]!;
+    assert.equal(updated.state, projectedState);
+    assert.equal(updated.blocked_reason, null);
+    assert.equal(updated.pr_number, prNumber);
+    assert.equal(updated.last_head_sha, headSha);
+    assert.equal(updated.last_error, null);
+    assert.equal(updated.last_failure_context, null);
+    assert.equal(updated.last_failure_signature, null);
+    assert.equal(updated.repeated_failure_signature_count, 0);
+    assert.equal(stateStore.saveCalls, 1);
+    assert.equal(recoveryEvents.length, 1);
+  }
+});
+
+test("reconcileRecoverableBlockedIssueStates keeps an independent verifier blocked when a unique PR projects open", async () => {
+  const issueNumber = 413;
+  const prNumber = 414;
+  const branch = `codex/issue-${issueNumber}`;
+  const headSha = `head-${prNumber}`;
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Independent verifier remains blocked.",
+    signature: "independent-verifier-blocked",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-12T00:02:00Z",
+  };
+  const original = createRecord({
+    issue_number: issueNumber,
+    branch,
+    state: "blocked",
+    blocked_reason: "verification",
+    pr_number: null,
+    last_head_sha: "head-before-414",
+    last_error: failureContext.summary,
+    last_failure_context: failureContext,
+    last_failure_signature: failureContext.signature,
+    repeated_failure_signature_count: 2,
+    repeated_blocker_count: 2,
+    blocked_verification_retry_count: 1,
+  });
+  const state = createSupervisorState({ issues: [original] });
+  const config = createConfig();
+  const issue = createIssue({ number: issueNumber });
+  const pullRequest = createPullRequest({
+    number: prNumber,
+    baseRefName: config.defaultBranch,
+    headRefName: branch,
+    headRefOid: headSha,
+    headRepositoryOwner: { login: "owner" },
+    isCrossRepository: false,
+    state: "OPEN",
+    mergedAt: null,
+  });
+  const stateStore = createCountingStateStore("2026-07-12T00:03:00Z");
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      findOpenPullRequestsForBranch: async () => [pullRequest],
+      getPullRequestIfExists: async () => pullRequest,
+      getIssue: async () => issue,
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "pr_open",
+      inferFailureContext: () => null,
+      blockedReasonForLifecycleState: () => null,
+      isOpenPullRequest,
+      syncReviewWaitWindow: () => ({}),
+      syncCopilotReviewRequestObservation: () => ({}),
+      syncCopilotReviewTimeoutState: noCopilotReviewTimeoutPatch,
+    },
+  );
+
+  const updated = state.issues[String(issueNumber)]!;
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.blocked_reason, "verification");
+  assert.equal(updated.pr_number, prNumber);
+  assert.equal(updated.last_head_sha, headSha);
+  assert.equal(updated.last_error, failureContext.summary);
+  assert.deepEqual(updated.last_failure_context, failureContext);
+  assert.equal(updated.last_failure_signature, failureContext.signature);
+  assert.match(
+    updated.last_tracked_pr_progress_summary ?? "",
+    /scheduled_review_repair=no/,
+  );
+  assert.equal(stateStore.saveCalls, 1);
+  assert.equal(recoveryEvents.length, 1);
+});
+
 test("reconcileRecoverableBlockedIssueStates leaves ambiguous branch PR matches unbound with explicit diagnostics", async () => {
   const issueNumber = 394;
   const branch = `codex/issue-${issueNumber}`;

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -6458,3 +6458,377 @@ test("reconcileRecoverableBlockedIssueStates clears stale head-scoped review sta
   assert.equal(saveCalls, 1);
   assert.deepEqual(recoveryEvents, []);
 });
+
+test("reconcileRecoverableBlockedIssueStates binds a legacy no-PR verification block and schedules current-head bot repair", async () => {
+  const issueNumber = 393;
+  const prNumber = 400;
+  const branch = `codex/issue-${issueNumber}`;
+  const headSha = "head-current-400";
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Codex reported blocked after the image verifier stopped.",
+    signature: "gitops-images-high-critical",
+    command: "npm run verify:images",
+    details: [
+      "Verification blocked: prerequisite not satisfied.",
+      "structured_blocked_reason=verification",
+    ],
+    url: null,
+    updated_at: "2026-07-11T11:00:00Z",
+  };
+  const original = createRecord({
+    issue_number: issueNumber,
+    branch,
+    state: "blocked",
+    blocked_reason: "verification",
+    pr_number: null,
+    last_head_sha: "head-before-400",
+    last_error: failureContext.summary,
+    last_failure_context: failureContext,
+    last_failure_signature: failureContext.signature,
+    repeated_failure_signature_count: 2,
+    repeated_blocker_count: 2,
+    blocked_verification_retry_count: 1,
+  });
+  const state = createSupervisorState({ issues: [original] });
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+    humanReviewBlocksMerge: true,
+  });
+  const issue = createIssue({
+    number: issueNumber,
+    updatedAt: "2026-07-11T11:10:00Z",
+  });
+  const pr = createPullRequest({
+    number: prNumber,
+    baseRefName: config.defaultBranch,
+    headRefName: branch,
+    headRefOid: headSha,
+    headRepositoryOwner: { login: "owner" },
+    isCrossRepository: false,
+    state: "OPEN",
+    mergedAt: null,
+    configuredBotCurrentHeadObservedAt: "2026-07-11T11:05:00Z",
+    configuredBotCurrentHeadObservationSource: "review_thread",
+    configuredBotLatestReviewedCommitSha: headSha,
+  });
+  const mustFixThread = createReviewThread({
+    id: "thread-current-p2-400",
+    isResolved: false,
+    isOutdated: false,
+    comments: {
+      nodes: [
+        {
+          id: "comment-current-p2-400",
+          body: "P2: Keep the repair fail-closed until the verifier passes.",
+          createdAt: "2026-07-11T11:05:00Z",
+          url: "https://example.test/pr/400#discussion_r400",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const stateStore = createCountingStateStore("2026-07-11T11:15:00Z");
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      findOpenPullRequestsForBranch: async (resolvedBranch, options) => {
+        assert.equal(resolvedBranch, branch);
+        assert.equal(options?.purpose, "action");
+        return [pr];
+      },
+      getPullRequestIfExists: async (prNumber, options) => {
+        assert.equal(prNumber, pr.number);
+        assert.equal(options?.purpose, "action");
+        return pr;
+      },
+      getIssue: async () => issue,
+      getChecks: async (resolvedPrNumber) => {
+        assert.equal(resolvedPrNumber, prNumber);
+        return [
+          {
+            name: "build",
+            state: "SUCCESS",
+            bucket: "pass",
+            workflow: "CI",
+          },
+        ];
+      },
+      getUnresolvedReviewThreads: async (resolvedPrNumber) => {
+        assert.equal(resolvedPrNumber, prNumber);
+        return [mustFixThread];
+      },
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest,
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues[String(issueNumber)]!;
+  assert.equal(updated.state, "addressing_review");
+  assert.equal(updated.blocked_reason, "verification");
+  assert.equal(updated.pr_number, prNumber);
+  assert.equal(updated.last_head_sha, headSha);
+  assert.deepEqual(updated.last_failure_context, failureContext);
+  assert.equal(updated.last_failure_signature, failureContext.signature);
+  assert.equal(updated.repeated_failure_signature_count, 2);
+  assert.equal(updated.repeated_blocker_count, 2);
+  assert.equal(updated.blocked_verification_retry_count, 1);
+  assert.match(
+    updated.last_tracked_pr_progress_summary ?? "",
+    /scheduled_review_repair=yes/,
+  );
+  assert.equal(stateStore.saveCalls, 1);
+  assert.match(recoveryEvents[0]?.reason ?? "", /scheduled_review_repair=yes/);
+});
+
+test("reconcileRecoverableBlockedIssueStates leaves ambiguous branch PR matches unbound with explicit diagnostics", async () => {
+  const issueNumber = 394;
+  const branch = `codex/issue-${issueNumber}`;
+  const original = createRecord({
+    issue_number: issueNumber,
+    branch,
+    state: "blocked",
+    blocked_reason: "verification",
+    pr_number: null,
+  });
+  const state = createSupervisorState({ issues: [original] });
+  const config = createConfig();
+  const issue = createIssue({ number: issueNumber });
+  const stateStore = createCountingStateStore("2026-07-11T11:20:00Z");
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      findOpenPullRequestsForBranch: async () => [
+        createPullRequest({
+          number: 401,
+          baseRefName: config.defaultBranch,
+          headRefName: branch,
+          state: "OPEN",
+          mergedAt: null,
+        }),
+        createPullRequest({
+          number: 402,
+          baseRefName: config.defaultBranch,
+          headRefName: branch,
+          state: "OPEN",
+          mergedAt: null,
+        }),
+      ],
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected tracked PR lookup");
+      },
+      getIssue: async () => issue,
+      getChecks: async () => {
+        throw new Error("unexpected checks lookup for ambiguous PRs");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected review lookup for ambiguous PRs");
+      },
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    { shouldAutoRetryHandoffMissing },
+  );
+
+  const updated = state.issues[String(issueNumber)]!;
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.pr_number, null);
+  assert.match(
+    updated.last_tracked_pr_progress_summary ?? "",
+    /blocked_turn_pr_reconciliation=ambiguous/,
+  );
+  assert.match(
+    updated.last_tracked_pr_progress_summary ?? "",
+    /candidates=#401,#402/,
+  );
+  assert.deepEqual(recoveryEvents, []);
+  assert.equal(stateStore.saveCalls, 1);
+});
+
+test("reconcileRecoverableBlockedIssueStates leaves an absent branch PR unbound with explicit diagnostics", async () => {
+  const issueNumber = 396;
+  const branch = `codex/issue-${issueNumber}`;
+  const original = createRecord({
+    issue_number: issueNumber,
+    branch,
+    state: "blocked",
+    blocked_reason: "verification",
+    pr_number: null,
+  });
+  const state = createSupervisorState({ issues: [original] });
+  const config = createConfig();
+  const issue = createIssue({ number: issueNumber });
+  const stateStore = createCountingStateStore("2026-07-11T11:22:00Z");
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      findOpenPullRequestsForBranch: async (resolvedBranch, options) => {
+        assert.equal(resolvedBranch, branch);
+        assert.equal(options?.purpose, "action");
+        return [];
+      },
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected tracked PR lookup");
+      },
+      getIssue: async () => issue,
+      getChecks: async () => {
+        throw new Error("unexpected checks lookup without a PR");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected review lookup without a PR");
+      },
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    { shouldAutoRetryHandoffMissing },
+  );
+
+  const updated = state.issues[String(issueNumber)]!;
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.pr_number, null);
+  assert.equal(
+    updated.last_tracked_pr_progress_summary,
+    `blocked_turn_pr_reconciliation=absent branch=${branch}`,
+  );
+  assert.deepEqual(recoveryEvents, []);
+  assert.equal(stateStore.saveCalls, 1);
+});
+
+test("reconcileRecoverableBlockedIssueStates leaves PR lookup errors fail-closed with explicit diagnostics", async () => {
+  const issueNumber = 397;
+  const branch = `codex/issue-${issueNumber}`;
+  const original = createRecord({
+    issue_number: issueNumber,
+    branch,
+    state: "blocked",
+    blocked_reason: "verification",
+    pr_number: null,
+  });
+  const state = createSupervisorState({ issues: [original] });
+  const config = createConfig();
+  const issue = createIssue({ number: issueNumber });
+  const stateStore = createCountingStateStore("2026-07-11T11:24:00Z");
+
+  const recoveryEvents = await reconcileRecoverableBlockedIssueStates(
+    {
+      findOpenPullRequestsForBranch: async () => {
+        throw new Error("GitHub lookup unavailable");
+      },
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected tracked PR lookup");
+      },
+      getIssue: async () => issue,
+      getChecks: async () => {
+        throw new Error("unexpected checks lookup after PR lookup error");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected review lookup after PR lookup error");
+      },
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    { shouldAutoRetryHandoffMissing },
+  );
+
+  const updated = state.issues[String(issueNumber)]!;
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.pr_number, null);
+  assert.equal(
+    updated.last_tracked_pr_progress_summary,
+    `blocked_turn_pr_reconciliation=error branch=${branch} detail=GitHub_lookup_unavailable`,
+  );
+  assert.deepEqual(recoveryEvents, []);
+  assert.equal(stateStore.saveCalls, 1);
+});
+
+test("reconcileRecoverableBlockedIssueStates carries a tracked structured verifier while scheduling review repair", async () => {
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Codex reported blocked after the verifier stopped.",
+    signature: "gitops-images-high-critical",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-11T11:00:00Z",
+  };
+  const record = createRecord({
+    issue_number: 395,
+    branch: "codex/issue-395",
+    state: "blocked",
+    blocked_reason: "verification",
+    pr_number: 403,
+    last_head_sha: "head-403",
+    last_error: failureContext.summary,
+    last_failure_context: failureContext,
+    last_failure_signature: failureContext.signature,
+    repeated_failure_signature_count: 2,
+    repeated_blocker_count: 2,
+    blocked_verification_retry_count: 1,
+  });
+  const state = createSupervisorState({ issues: [record] });
+  const config = createConfig();
+  const issue = createIssue({ number: 395 });
+  const pr = createPullRequest({
+    number: 403,
+    baseRefName: config.defaultBranch,
+    headRefName: record.branch,
+    headRefOid: "head-403",
+    state: "OPEN",
+    mergedAt: null,
+  });
+  const stateStore = createCountingStateStore("2026-07-11T11:25:00Z");
+
+  await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "addressing_review",
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["395"]!;
+  assert.equal(updated.state, "addressing_review");
+  assert.equal(updated.blocked_reason, "verification");
+  assert.equal(updated.last_error, failureContext.summary);
+  assert.deepEqual(updated.last_failure_context, failureContext);
+  assert.equal(updated.last_failure_signature, failureContext.signature);
+  assert.equal(updated.repeated_failure_signature_count, 2);
+  assert.equal(updated.repeated_blocker_count, 2);
+  assert.equal(updated.blocked_verification_retry_count, 1);
+});

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -7093,6 +7093,59 @@ test("reconcileRecoverableBlockedIssueStates carries a tracked legacy canonical 
   assert.equal(updated.repair_attempt_count, 0);
 });
 
+test("reconcileRecoverableBlockedIssueStates does not carry a legacy verifier without failure context", async () => {
+  const record = createRecord({
+    issue_number: 397,
+    branch: "codex/issue-397",
+    state: "blocked",
+    blocked_reason: "verification",
+    pr_number: 405,
+    last_head_sha: "head-404",
+    last_error: "Codex reported blocked for issue #397.",
+    last_failure_context: null,
+  });
+  const state = createSupervisorState({ issues: [record] });
+  const config = createConfig();
+  const issue = createIssue({ number: 397 });
+  const pr = createPullRequest({
+    number: 405,
+    baseRefName: config.defaultBranch,
+    headRefName: record.branch,
+    headRefOid: "head-405",
+    state: "OPEN",
+    mergedAt: null,
+  });
+  const stateStore = createCountingStateStore("2026-07-12T01:35:00Z");
+
+  await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => pr,
+      getIssue: async () => issue,
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+    },
+    stateStore.stateStore,
+    state,
+    config,
+    [issue],
+    {
+      shouldAutoRetryHandoffMissing,
+      inferStateFromPullRequest: () => "addressing_review",
+      inferFailureContext,
+      blockedReasonForLifecycleState,
+      isOpenPullRequest,
+      syncReviewWaitWindow,
+      syncCopilotReviewRequestObservation,
+      syncCopilotReviewTimeoutState,
+    },
+  );
+
+  const updated = state.issues["397"]!;
+  assert.equal(updated.state, "addressing_review");
+  assert.equal(updated.last_failure_context, null);
+  assert.equal(updated.blocked_reason, null);
+});
+
 test("reconcileRecoverableBlockedIssueStates rehydrates an untracked unknown blocker after a unique PR bind", async () => {
   const issueNumber = 398;
   const issue = createIssue({

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -7020,13 +7020,13 @@ test("reconcileRecoverableBlockedIssueStates leaves PR lookup errors fail-closed
   assert.equal(stateStore.saveCalls, 1);
 });
 
-test("reconcileRecoverableBlockedIssueStates carries a tracked structured verifier while scheduling review repair", async () => {
+test("reconcileRecoverableBlockedIssueStates carries a tracked legacy canonical verifier while scheduling review repair", async () => {
   const failureContext = {
     category: "blocked" as const,
-    summary: "Codex reported blocked after the verifier stopped.",
+    summary: "Codex reported blocked for issue #395.",
     signature: "gitops-images-high-critical",
     command: "npm run verify:images",
-    details: ["structured_blocked_reason=verification"],
+    details: [],
     url: null,
     updated_at: "2026-07-11T11:00:00Z",
   };

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -999,6 +999,7 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
 
       const carryIndependentVerificationBlocker =
         nextState === "addressing_review" &&
+        record.last_failure_context !== null &&
         hasBlockedTurnVerificationProvenance(record);
       const patch = buildTrackedPrStaleFailureConvergencePatch({
         record,

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -327,70 +327,125 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
       continue;
     }
 
-    const shouldReconcileUntrackedBlockedTurnPullRequest =
-      record.pr_number === null &&
-      (
-        record.blocked_reason === null ||
-        record.blocked_reason === "manual_review" ||
-        record.blocked_reason === "unknown" ||
-        record.blocked_reason === "verification"
-      ) &&
-      github.findOpenPullRequestsForBranch !== undefined;
-    if (shouldReconcileUntrackedBlockedTurnPullRequest) {
-      const reconciliation = await reconcileBlockedTurnPullRequest({
-        github,
-        state,
-        record,
-        defaultBranch: config.defaultBranch,
-        repoSlug: config.repoSlug,
-        purpose: "action",
-      });
-      if (reconciliation.kind !== "bound") {
-        const diagnosticPatch: Partial<IssueRunRecord> = {
-          last_tracked_pr_progress_summary: reconciliation.diagnostic,
-        };
-        if (needsRecordUpdate(record, diagnosticPatch)) {
-          const updated = stateStore.touch(record, diagnosticPatch);
-          state.issues[String(record.issue_number)] = updated;
-          changed = true;
+    untrackedBlockedTurnPullRequest: {
+      const shouldReconcileUntrackedBlockedTurnPullRequest =
+        record.pr_number === null &&
+        (
+          record.blocked_reason === null ||
+          record.blocked_reason === "manual_review" ||
+          record.blocked_reason === "unknown" ||
+          record.blocked_reason === "verification"
+        ) &&
+        github.findOpenPullRequestsForBranch !== undefined;
+      if (shouldReconcileUntrackedBlockedTurnPullRequest) {
+        const reconciliation = await reconcileBlockedTurnPullRequest({
+          github,
+          state,
+          record,
+          defaultBranch: config.defaultBranch,
+          repoSlug: config.repoSlug,
+          purpose: "action",
+        });
+        if (reconciliation.kind !== "bound") {
+          const diagnosticPatch: Partial<IssueRunRecord> = {
+            last_tracked_pr_progress_summary: reconciliation.diagnostic,
+          };
+          if (needsRecordUpdate(record, diagnosticPatch)) {
+            const updated = stateStore.touch(record, diagnosticPatch);
+            state.issues[String(record.issue_number)] = updated;
+            changed = true;
+          }
+          const absentCanUseExistingNoPrRecovery =
+            reconciliation.kind === "absent" &&
+            (
+              shouldReconsiderBlockedNoPrStaleManualStop(record, issue) ||
+              shouldReconsiderGenericNoPrIssueDefinitionChange(record, issue)
+            );
+          if (absentCanUseExistingNoPrRecovery) {
+            break untrackedBlockedTurnPullRequest;
+          }
+          continue;
         }
-        continue;
-      }
 
-      const trackedPullRequest = reconciliation.pullRequest;
-      const checks = await github.getChecks(trackedPullRequest.number);
-      const reviewThreads = await github.getUnresolvedReviewThreads(
-        trackedPullRequest.number,
-      );
-      const projection = projectTrackedPrLifecycle({
-        config,
-        record,
-        pr: trackedPullRequest,
-        checks,
-        reviewThreads,
-        inferStateFromPullRequest: inferStateFromPullRequestImpl,
-        blockedReasonForLifecycleState: blockedReasonForLifecycleStateImpl,
-        syncReviewWaitWindow: syncReviewWaitWindowImpl,
-        syncCopilotReviewRequestObservation:
-          syncCopilotReviewRequestObservationImpl,
-        syncCopilotReviewTimeoutState: syncCopilotReviewTimeoutStateImpl,
-      });
-      const schedulesReviewRepair =
-        !projection.shouldSuppressRecovery &&
-        projection.nextState === "addressing_review";
-      const preserveIndependentVerificationBlocker =
-        schedulesReviewRepair &&
-        record.blocked_reason === "verification" &&
-        record.last_failure_context !== null;
-      const recoveryEvent = buildRecoveryEvent(
-        record.issue_number,
-        `blocked_turn_pr_reconciled: bound issue #${record.issue_number} to PR #${trackedPullRequest.number} ` +
-          `at head ${trackedPullRequest.headRefOid} scheduled_review_repair=${schedulesReviewRepair ? "yes" : "no"}`,
-      );
-      const updated = stateStore.touch(
-        record,
-        applyRecoveryEvent(
-          {
+        const trackedPullRequest = reconciliation.pullRequest;
+        const checks = await github.getChecks(trackedPullRequest.number);
+        const reviewThreads = await github.getUnresolvedReviewThreads(
+          trackedPullRequest.number,
+        );
+        const projection = projectTrackedPrLifecycle({
+          config,
+          record,
+          pr: trackedPullRequest,
+          checks,
+          reviewThreads,
+          inferStateFromPullRequest: inferStateFromPullRequestImpl,
+          blockedReasonForLifecycleState: blockedReasonForLifecycleStateImpl,
+          syncReviewWaitWindow: syncReviewWaitWindowImpl,
+          syncCopilotReviewRequestObservation:
+            syncCopilotReviewRequestObservationImpl,
+          syncCopilotReviewTimeoutState: syncCopilotReviewTimeoutStateImpl,
+        });
+        if (
+          record.blocked_reason === "unknown" &&
+          projection.shouldSuppressRecovery
+        ) {
+          const suppressionPatch: Partial<IssueRunRecord> = {
+            last_tracked_pr_progress_summary:
+              `${reconciliation.diagnostic} projection_suppressed=yes`,
+          };
+          if (needsRecordUpdate(record, suppressionPatch)) {
+            const updated = stateStore.touch(record, suppressionPatch);
+            state.issues[String(record.issue_number)] = updated;
+            changed = true;
+          }
+          continue;
+        }
+
+        const schedulesReviewRepair =
+          !projection.shouldSuppressRecovery &&
+          projection.nextState === "addressing_review";
+        const preserveIndependentVerificationBlocker =
+          schedulesReviewRepair &&
+          record.blocked_reason === "verification" &&
+          record.last_failure_context !== null;
+        const rehydratesUnknownBlocker = record.blocked_reason === "unknown";
+        const projectedUnknownFailureContext =
+          rehydratesUnknownBlocker && projection.nextState === "blocked"
+            ? inferFailureContextImpl(
+              config,
+              projection.recordForState,
+              trackedPullRequest,
+              checks,
+              reviewThreads,
+            )
+            : null;
+        const recoveryEvent = buildRecoveryEvent(
+          record.issue_number,
+          `blocked_turn_pr_reconciled: bound issue #${record.issue_number} to PR #${trackedPullRequest.number} ` +
+            `at head ${trackedPullRequest.headRefOid} scheduled_review_repair=${schedulesReviewRepair ? "yes" : "no"}`,
+        );
+        const boundPatch: Partial<IssueRunRecord> = rehydratesUnknownBlocker
+          ? {
+            ...buildTrackedPrStaleFailureConvergencePatch({
+              record,
+              pr: trackedPullRequest,
+              nextState: projection.nextState,
+              failureContext: projectedUnknownFailureContext,
+              blockedReason: projection.nextBlockedReason,
+              reviewWaitPatch: projection.reviewWaitPatch,
+              codexConnectorReviewRequestObservationPatch:
+                projection.codexConnectorReviewRequestObservationPatch,
+              copilotReviewRequestObservationPatch:
+                projection.copilotReviewRequestObservationPatch,
+              copilotReviewTimeoutPatch: projection.copilotReviewTimeoutPatch,
+              mergeLatencyVisibilityPatch: projection.mergeLatencyVisibilityPatch,
+            }),
+            codex_session_id: null,
+            last_tracked_pr_progress_summary:
+              `${reconciliation.diagnostic} ` +
+              `scheduled_review_repair=${schedulesReviewRepair ? "yes" : "no"}`,
+          }
+          : {
             state: schedulesReviewRepair ? "addressing_review" : "blocked",
             blocked_reason: preserveIndependentVerificationBlocker
               ? "verification"
@@ -414,14 +469,16 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
             ...projection.copilotReviewRequestObservationPatch,
             ...projection.copilotReviewTimeoutPatch,
             ...projection.mergeLatencyVisibilityPatch,
-          },
-          recoveryEvent,
-        ),
-      );
-      state.issues[String(record.issue_number)] = updated;
-      changed = true;
-      recoveryEvents.push(recoveryEvent);
-      continue;
+          };
+        const updated = stateStore.touch(
+          record,
+          applyRecoveryEvent(boundPatch, recoveryEvent),
+        );
+        state.issues[String(record.issue_number)] = updated;
+        changed = true;
+        recoveryEvents.push(recoveryEvent);
+        continue;
+      }
     }
 
     if (shouldReconsiderBlockedNoPrStaleManualStop(record, issue)) {
@@ -710,17 +767,6 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         syncCopilotReviewTimeoutState: syncCopilotReviewTimeoutStateImpl,
       });
       let nextState = projection.nextState;
-      if (
-        nextState === "pr_open" &&
-        trackedPullRequest.reviewDecision === "REVIEW_REQUIRED"
-      ) {
-        nextState = "addressing_review";
-      } else if (
-        nextState === "pr_open" &&
-        trackedPullRequest.reviewDecision === "CHANGES_REQUESTED"
-      ) {
-        nextState = "blocked";
-      }
       if (projection.shouldSuppressRecovery) {
         continue;
       }
@@ -885,9 +931,7 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         ?? (preserveDraftReadyPromotionBlocker ? record.last_failure_context : null);
       const nextBlockedReason = preserveDraftReadyPromotionBlocker
         ? "verification"
-        : trackedPullRequest.reviewDecision === "CHANGES_REQUESTED"
-          ? "manual_review"
-          : projection.nextBlockedReason;
+        : projection.nextBlockedReason;
 
       if (nextState === "blocked" || preserveDraftReadyPromotionBlocker) {
         const headAdvanceResetPatch = resetTrackedPrHeadScopedStateOnAdvance(record, trackedPullRequest.headRefOid);

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -408,9 +408,11 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
           schedulesReviewRepair &&
           record.blocked_reason === "verification" &&
           record.last_failure_context !== null;
-        const rehydratesUnknownBlocker = record.blocked_reason === "unknown";
-        const projectedUnknownFailureContext =
-          rehydratesUnknownBlocker && projection.nextState === "blocked"
+        const rehydratesProjectedLifecycle =
+          !projection.shouldSuppressRecovery &&
+          record.blocked_reason !== "verification";
+        const projectedFailureContext =
+          rehydratesProjectedLifecycle && projection.nextState === "blocked"
             ? inferFailureContextImpl(
               config,
               projection.recordForState,
@@ -424,13 +426,13 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
           `blocked_turn_pr_reconciled: bound issue #${record.issue_number} to PR #${trackedPullRequest.number} ` +
             `at head ${trackedPullRequest.headRefOid} scheduled_review_repair=${schedulesReviewRepair ? "yes" : "no"}`,
         );
-        const boundPatch: Partial<IssueRunRecord> = rehydratesUnknownBlocker
+        const boundPatch: Partial<IssueRunRecord> = rehydratesProjectedLifecycle
           ? {
             ...buildTrackedPrStaleFailureConvergencePatch({
               record,
               pr: trackedPullRequest,
               nextState: projection.nextState,
-              failureContext: projectedUnknownFailureContext,
+              failureContext: projectedFailureContext,
               blockedReason: projection.nextBlockedReason,
               reviewWaitPatch: projection.reviewWaitPatch,
               codexConnectorReviewRequestObservationPatch:

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -59,6 +59,7 @@ import {
   trackedHandoffExternalProgressEvidence,
 } from "./recovery-current-head-evidence";
 import { applyRecoveryEvent, buildRecoveryEvent, needsRecordUpdate } from "./recovery-event-patch";
+import { reconcileBlockedTurnPullRequest } from "./supervisor/blocked-turn-pr-reconciliation";
 
 export { codexConnectorChurnStopEvidenceSource } from "./recovery-codex-connector-churn";
 
@@ -71,7 +72,15 @@ type RecoveryGitHubLike = Pick<
   | "getPullRequestIfExists"
   | "getUnresolvedReviewThreads"
 > & Partial<
-  Pick<import("./github").GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "getIssueComments" | "updateIssueComment">
+  Pick<
+    import("./github").GitHubClient,
+    | "addIssueComment"
+    | "findOpenPullRequestsForBranch"
+    | "getExternalReviewSurface"
+    | "getIssueComments"
+    | "resolvePullRequestForBranch"
+    | "updateIssueComment"
+  >
 >;
 
 function latestFiniteTimestamp(...values: Array<string | null | undefined>): number | null {
@@ -227,7 +236,17 @@ function hasSupervisorVerifiedNoSourceChangeStaleAcknowledgement(normalizedBody:
 
 export async function reconcileRecoverableBlockedIssueStatesInModule(
   github: Pick<RecoveryGitHubLike, "getPullRequestIfExists" | "getIssue" | "getChecks" | "getUnresolvedReviewThreads">
-    & Partial<Pick<RecoveryGitHubLike, "addIssueComment" | "getExternalReviewSurface" | "getIssueComments" | "updateIssueComment">>,
+    & Partial<
+      Pick<
+        RecoveryGitHubLike,
+        | "addIssueComment"
+        | "findOpenPullRequestsForBranch"
+        | "getExternalReviewSurface"
+        | "getIssueComments"
+        | "resolvePullRequestForBranch"
+        | "updateIssueComment"
+      >
+    >,
   stateStore: StateStoreLike,
   state: SupervisorStateFile,
   config: SupervisorConfig,
@@ -302,6 +321,103 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         copilot_review_timeout_reason: null,
         ...applyRecoveryEvent({}, recoveryEvent),
       });
+      state.issues[String(record.issue_number)] = updated;
+      changed = true;
+      recoveryEvents.push(recoveryEvent);
+      continue;
+    }
+
+    const shouldReconcileUntrackedBlockedTurnPullRequest =
+      record.pr_number === null &&
+      (
+        record.blocked_reason === null ||
+        record.blocked_reason === "manual_review" ||
+        record.blocked_reason === "unknown" ||
+        record.blocked_reason === "verification"
+      ) &&
+      github.findOpenPullRequestsForBranch !== undefined;
+    if (shouldReconcileUntrackedBlockedTurnPullRequest) {
+      const reconciliation = await reconcileBlockedTurnPullRequest({
+        github,
+        state,
+        record,
+        defaultBranch: config.defaultBranch,
+        repoSlug: config.repoSlug,
+        purpose: "action",
+      });
+      if (reconciliation.kind !== "bound") {
+        const diagnosticPatch: Partial<IssueRunRecord> = {
+          last_tracked_pr_progress_summary: reconciliation.diagnostic,
+        };
+        if (needsRecordUpdate(record, diagnosticPatch)) {
+          const updated = stateStore.touch(record, diagnosticPatch);
+          state.issues[String(record.issue_number)] = updated;
+          changed = true;
+        }
+        continue;
+      }
+
+      const trackedPullRequest = reconciliation.pullRequest;
+      const checks = await github.getChecks(trackedPullRequest.number);
+      const reviewThreads = await github.getUnresolvedReviewThreads(
+        trackedPullRequest.number,
+      );
+      const projection = projectTrackedPrLifecycle({
+        config,
+        record,
+        pr: trackedPullRequest,
+        checks,
+        reviewThreads,
+        inferStateFromPullRequest: inferStateFromPullRequestImpl,
+        blockedReasonForLifecycleState: blockedReasonForLifecycleStateImpl,
+        syncReviewWaitWindow: syncReviewWaitWindowImpl,
+        syncCopilotReviewRequestObservation:
+          syncCopilotReviewRequestObservationImpl,
+        syncCopilotReviewTimeoutState: syncCopilotReviewTimeoutStateImpl,
+      });
+      const schedulesReviewRepair =
+        !projection.shouldSuppressRecovery &&
+        projection.nextState === "addressing_review";
+      const preserveIndependentVerificationBlocker =
+        schedulesReviewRepair &&
+        record.blocked_reason === "verification" &&
+        record.last_failure_context !== null;
+      const recoveryEvent = buildRecoveryEvent(
+        record.issue_number,
+        `blocked_turn_pr_reconciled: bound issue #${record.issue_number} to PR #${trackedPullRequest.number} ` +
+          `at head ${trackedPullRequest.headRefOid} scheduled_review_repair=${schedulesReviewRepair ? "yes" : "no"}`,
+      );
+      const updated = stateStore.touch(
+        record,
+        applyRecoveryEvent(
+          {
+            state: schedulesReviewRepair ? "addressing_review" : "blocked",
+            blocked_reason: preserveIndependentVerificationBlocker
+              ? "verification"
+              : schedulesReviewRepair
+                ? null
+                : record.blocked_reason,
+            pr_number: trackedPullRequest.number,
+            last_head_sha: trackedPullRequest.headRefOid,
+            codex_session_id: schedulesReviewRepair
+              ? null
+              : record.codex_session_id,
+            last_tracked_pr_progress_summary:
+              `${reconciliation.diagnostic} ` +
+              `scheduled_review_repair=${schedulesReviewRepair ? "yes" : "no"}`,
+            ...resetTrackedPrHeadScopedStateOnAdvance(
+              record,
+              trackedPullRequest.headRefOid,
+            ),
+            ...projection.reviewWaitPatch,
+            ...projection.codexConnectorReviewRequestObservationPatch,
+            ...projection.copilotReviewRequestObservationPatch,
+            ...projection.copilotReviewTimeoutPatch,
+            ...projection.mergeLatencyVisibilityPatch,
+          },
+          recoveryEvent,
+        ),
+      );
       state.issues[String(record.issue_number)] = updated;
       changed = true;
       recoveryEvents.push(recoveryEvent);
@@ -594,6 +710,17 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         syncCopilotReviewTimeoutState: syncCopilotReviewTimeoutStateImpl,
       });
       let nextState = projection.nextState;
+      if (
+        nextState === "pr_open" &&
+        trackedPullRequest.reviewDecision === "REVIEW_REQUIRED"
+      ) {
+        nextState = "addressing_review";
+      } else if (
+        nextState === "pr_open" &&
+        trackedPullRequest.reviewDecision === "CHANGES_REQUESTED"
+      ) {
+        nextState = "blocked";
+      }
       if (projection.shouldSuppressRecovery) {
         continue;
       }
@@ -758,7 +885,9 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         ?? (preserveDraftReadyPromotionBlocker ? record.last_failure_context : null);
       const nextBlockedReason = preserveDraftReadyPromotionBlocker
         ? "verification"
-        : projection.nextBlockedReason;
+        : trackedPullRequest.reviewDecision === "CHANGES_REQUESTED"
+          ? "manual_review"
+          : projection.nextBlockedReason;
 
       if (nextState === "blocked" || preserveDraftReadyPromotionBlocker) {
         const headAdvanceResetPatch = resetTrackedPrHeadScopedStateOnAdvance(record, trackedPullRequest.headRefOid);
@@ -819,6 +948,12 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         continue;
       }
 
+      const carryIndependentVerificationBlocker =
+        nextState === "addressing_review" &&
+        record.blocked_reason === "verification" &&
+        record.last_failure_context?.details.includes(
+          "structured_blocked_reason=verification",
+        ) === true;
       const patch = buildTrackedPrStaleFailureConvergencePatch({
         record,
         pr: trackedPullRequest,
@@ -845,6 +980,27 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         patch.last_tracked_pr_progress_snapshot = null;
         patch.last_tracked_pr_progress_summary = null;
         patch.last_tracked_pr_repeat_failure_decision = null;
+      }
+      if (carryIndependentVerificationBlocker) {
+        Object.assign(patch, {
+          blocked_reason: "verification",
+          last_error: record.last_error,
+          last_failure_kind: record.last_failure_kind,
+          last_failure_context: record.last_failure_context,
+          last_blocker_signature: record.last_blocker_signature,
+          last_failure_signature: record.last_failure_signature,
+          repeated_failure_signature_count:
+            record.repeated_failure_signature_count,
+          repeated_blocker_count: record.repeated_blocker_count,
+          repair_attempt_count: record.repair_attempt_count,
+          timeout_retry_count: record.timeout_retry_count,
+          blocked_verification_retry_count:
+            record.blocked_verification_retry_count,
+          last_tracked_pr_progress_summary:
+            `scheduled_review_repair_with_independent_verification_blocker ` +
+            `pr=#${trackedPullRequest.number} head=${trackedPullRequest.headRefOid} ` +
+            `command=${record.last_failure_context!.command ?? "unknown"}`,
+        } satisfies Partial<IssueRunRecord>);
       }
       const recoveryEvent = staleLocalManualReviewResidueRecovery
         ? buildRecoveryEvent(

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -999,10 +999,7 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
 
       const carryIndependentVerificationBlocker =
         nextState === "addressing_review" &&
-        record.blocked_reason === "verification" &&
-        record.last_failure_context?.details.includes(
-          "structured_blocked_reason=verification",
-        ) === true;
+        hasBlockedTurnVerificationProvenance(record);
       const patch = buildTrackedPrStaleFailureConvergencePatch({
         record,
         pr: trackedPullRequest,

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -59,7 +59,10 @@ import {
   trackedHandoffExternalProgressEvidence,
 } from "./recovery-current-head-evidence";
 import { applyRecoveryEvent, buildRecoveryEvent, needsRecordUpdate } from "./recovery-event-patch";
-import { reconcileBlockedTurnPullRequest } from "./supervisor/blocked-turn-pr-reconciliation";
+import {
+  hasBlockedTurnVerificationProvenance,
+  reconcileBlockedTurnPullRequest,
+} from "./supervisor/blocked-turn-pr-reconciliation";
 
 export { codexConnectorChurnStopEvidenceSource } from "./recovery-codex-connector-churn";
 
@@ -334,7 +337,7 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
           record.blocked_reason === null ||
           record.blocked_reason === "manual_review" ||
           record.blocked_reason === "unknown" ||
-          record.blocked_reason === "verification"
+          hasBlockedTurnVerificationProvenance(record)
         ) &&
         github.findOpenPullRequestsForBranch !== undefined;
       if (shouldReconcileUntrackedBlockedTurnPullRequest) {

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -1038,7 +1038,6 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
           repeated_failure_signature_count:
             record.repeated_failure_signature_count,
           repeated_blocker_count: record.repeated_blocker_count,
-          repair_attempt_count: record.repair_attempt_count,
           timeout_retry_count: record.timeout_retry_count,
           blocked_verification_retry_count:
             record.blocked_verification_retry_count,

--- a/src/recovery-reconciliation.ts
+++ b/src/recovery-reconciliation.ts
@@ -66,7 +66,15 @@ type RecoveryGitHubLike = Pick<
   | "getPullRequestIfExists"
   | "getUnresolvedReviewThreads"
 > & Partial<
-  Pick<import("./github").GitHubClient, "addIssueComment" | "getExternalReviewSurface" | "getIssueComments" | "updateIssueComment">
+  Pick<
+    import("./github").GitHubClient,
+    | "addIssueComment"
+    | "findOpenPullRequestsForBranch"
+    | "getExternalReviewSurface"
+    | "getIssueComments"
+    | "resolvePullRequestForBranch"
+    | "updateIssueComment"
+  >
 >;
 
 async function fetchOriginDefaultBranch(
@@ -769,7 +777,17 @@ export async function reconcileStaleDoneIssueStates(
 
 export async function reconcileRecoverableBlockedIssueStates(
   github: Pick<RecoveryGitHubLike, "getPullRequestIfExists" | "getIssue" | "getChecks" | "getUnresolvedReviewThreads">
-    & Partial<Pick<RecoveryGitHubLike, "addIssueComment" | "getExternalReviewSurface" | "getIssueComments" | "updateIssueComment">>,
+    & Partial<
+      Pick<
+        RecoveryGitHubLike,
+        | "addIssueComment"
+        | "findOpenPullRequestsForBranch"
+        | "getExternalReviewSurface"
+        | "getIssueComments"
+        | "resolvePullRequestForBranch"
+        | "updateIssueComment"
+      >
+    >,
   stateStore: StateStoreLike,
   state: SupervisorStateFile,
   config: SupervisorConfig,

--- a/src/run-once-issue-preparation.test.ts
+++ b/src/run-once-issue-preparation.test.ts
@@ -313,6 +313,82 @@ test("prepareIssueExecutionContext prepares workspace, journal, memory, and head
   ]);
 });
 
+test("prepareIssueExecutionContext preserves a recovered independent verifier for the review turn", async () => {
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Image verification remains blocked.",
+    signature: "verification:images",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-11T12:40:00Z",
+  };
+  const record = createRecord({
+    state: "addressing_review",
+    pr_number: 240,
+    implementation_attempt_count: 0,
+    blocked_reason: "verification",
+    last_error: failureContext.summary,
+    last_failure_context: failureContext,
+    last_failure_signature: failureContext.signature,
+    repeated_failure_signature_count: 2,
+    last_blocker_signature: "verification:images",
+    repeated_blocker_count: 2,
+    blocked_verification_retry_count: 1,
+  });
+  const state = createState(record);
+  const pr = createPullRequest({ headRefOid: "pr-head-240" });
+
+  const result = await prepareIssueExecutionContext({
+    github: {
+      resolvePullRequestForBranch: async () => pr,
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+    },
+    config: createConfig(),
+    stateStore: {
+      touch: (currentRecord, patch) => ({ ...currentRecord, ...patch }),
+      save: async () => undefined,
+    },
+    state,
+    record,
+    issue: createIssue(),
+    options: { dryRun: false },
+    ensureWorkspace: async () => "/tmp/workspaces/issue-240",
+    syncIssueJournal: async () => undefined,
+    syncMemoryArtifacts: async ({ journalPath }) => ({
+      contextIndexPath: "/tmp/context-index.md",
+      agentsPath: "/tmp/AGENTS.generated.md",
+      alwaysReadFiles: [journalPath],
+      onDemandFiles: [],
+    }),
+    getWorkspaceStatus: async () =>
+      createWorkspaceStatus({
+        headSha: "pr-head-240",
+        remoteBranchExists: true,
+      }),
+    writeSupervisorCycleDecisionSnapshot: async () => "/tmp/decision.json",
+    writePreMergeAssessmentSnapshot: async () => "/tmp/assessment.json",
+  });
+
+  assert.equal(typeof result, "object");
+  assert.ok(result && !isRestartRunOnce(result) && typeof result !== "string");
+  assert.equal(result.record.state, "addressing_review");
+  assert.equal(result.record.blocked_reason, "verification");
+  assert.equal(result.record.last_error, failureContext.summary);
+  assert.deepEqual(result.record.last_failure_context, failureContext);
+  assert.equal(result.record.last_failure_signature, failureContext.signature);
+  assert.equal(result.record.repeated_failure_signature_count, 2);
+  assert.equal(result.record.last_blocker_signature, "verification:images");
+  assert.equal(result.record.repeated_blocker_count, 2);
+  assert.equal(result.record.blocked_verification_retry_count, 1);
+  assert.equal(result.pr?.number, 240);
+  assert.equal(state.issues["240"]?.blocked_reason, "verification");
+});
+
 test("prepareIssueExecutionContext records the workspace restore source for later diagnostics", async () => {
   const record = createRecord();
   const state = createState(record);

--- a/src/run-once-issue-preparation.test.ts
+++ b/src/run-once-issue-preparation.test.ts
@@ -661,9 +661,23 @@ test("prepareIssueExecutionContext blocks remote-ahead publication when tracked 
   );
   git(workspacePath, "add", "docs/guide.md");
 
+  const verifierFailureContext = {
+    category: "blocked" as const,
+    summary: "Image verification remains blocked.",
+    signature: "verification:images",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-12T01:30:00Z",
+  };
   const record = createRecord({
     implementation_attempt_count: 2,
-    state: "stabilizing",
+    state: "addressing_review",
+    pr_number: 240,
+    blocked_reason: "verification",
+    last_error: verifierFailureContext.summary,
+    last_failure_context: verifierFailureContext,
+    last_failure_signature: verifierFailureContext.signature,
     workspace: workspacePath,
     journal_path: path.join(workspacePath, ".codex-supervisor", "issue-journal.md"),
   });
@@ -724,7 +738,16 @@ test("prepareIssueExecutionContext blocks remote-ahead publication when tracked 
   assert.equal(resolvePullRequestCalls, 0);
   assert.equal(state.issues["240"]?.state, "blocked");
   assert.equal(state.issues["240"]?.blocked_reason, "verification");
-  assert.equal(state.issues["240"]?.last_failure_signature, "workstation-local-path-hygiene-failed");
+  assert.equal(state.issues["240"]?.last_failure_signature, "verification:images");
+  assert.equal(
+    state.issues["240"]?.last_failure_context?.command,
+    "npm run verify:images",
+  );
+  assert.ok(
+    state.issues["240"]?.last_failure_context?.details.some((detail) =>
+      detail.includes("workstation-local path hygiene")
+    ),
+  );
 });
 
 test("prepareIssueExecutionContext restarts when a tracked PR already merged", async () => {

--- a/src/run-once-issue-preparation.test.ts
+++ b/src/run-once-issue-preparation.test.ts
@@ -389,6 +389,62 @@ test("prepareIssueExecutionContext preserves a recovered independent verifier fo
   assert.equal(state.issues["240"]?.blocked_reason, "verification");
 });
 
+test("prepareIssueExecutionContext drops a carried verifier after stale PR hydration clears the binding", async () => {
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Image verification remains blocked.",
+    signature: "verification:images",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-11T12:40:00Z",
+  };
+  const record = createRecord({
+    state: "addressing_review",
+    pr_number: 240,
+    blocked_reason: "verification",
+    last_error: failureContext.summary,
+    last_failure_context: failureContext,
+    last_failure_signature: failureContext.signature,
+  });
+  const state = createState(record);
+
+  const result = await prepareIssueExecutionContext({
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+    },
+    config: createConfig(),
+    stateStore: {
+      touch: (currentRecord, patch) => ({ ...currentRecord, ...patch }),
+      save: async () => undefined,
+    },
+    state,
+    record,
+    issue: createIssue(),
+    options: { dryRun: true },
+    ensureWorkspace: async () => "/tmp/workspaces/issue-240",
+    syncIssueJournal: async () => undefined,
+    syncMemoryArtifacts: async ({ journalPath }) => ({
+      contextIndexPath: "/tmp/context-index.md",
+      agentsPath: "/tmp/AGENTS.generated.md",
+      alwaysReadFiles: [journalPath],
+      onDemandFiles: [],
+    }),
+    getWorkspaceStatus: async () => createWorkspaceStatus(),
+    writeSupervisorCycleDecisionSnapshot: async () => "/tmp/decision.json",
+    writePreMergeAssessmentSnapshot: async () => "/tmp/assessment.json",
+  });
+
+  assert.ok(result && !isRestartRunOnce(result) && typeof result !== "string");
+  assert.equal(result.record.pr_number, null);
+  assert.equal(result.independentVerificationBlocker, null);
+});
+
 test("prepareIssueExecutionContext records the workspace restore source for later diagnostics", async () => {
   const record = createRecord();
   const state = createState(record);

--- a/src/run-once-issue-preparation.ts
+++ b/src/run-once-issue-preparation.ts
@@ -38,6 +38,10 @@ import {
   syncExecutionMetricsRunSummarySafely,
 } from "./supervisor/execution-metrics-run-summary";
 import { syncPostMergeAuditArtifactSafely } from "./supervisor/post-merge-audit-artifact";
+import {
+  independentVerificationBlockerSnapshot,
+  type IndependentVerificationBlockerSnapshot,
+} from "./supervisor/independent-verification-blocker";
 
 export type IssueJournalSync = (record: IssueRunRecord) => Promise<void>;
 export type MemoryArtifacts = Awaited<ReturnType<typeof syncMemoryArtifactsImpl>>;
@@ -52,6 +56,7 @@ export interface PreparedWorkspaceContext {
   syncJournal: IssueJournalSync;
   memoryArtifacts: MemoryArtifacts;
   workspaceStatus: WorkspaceStatus;
+  independentVerificationBlocker?: IndependentVerificationBlockerSnapshot | null;
 }
 
 export interface HydratedPullRequestContext {
@@ -222,16 +227,32 @@ async function prepareWorkspaceContext(
       maxChars: args.config.issueJournalMaxChars,
     });
   };
+  const independentVerificationBlocker =
+    args.record.pr_number === null
+      ? null
+      : independentVerificationBlockerSnapshot(args.record);
+  const preserveIndependentVerificationBlocker =
+    independentVerificationBlocker !== null;
 
   const preparedRecord = args.stateStore.touch(args.record, {
     workspace: workspacePath,
     journal_path: journalPath,
-    state: args.record.implementation_attempt_count === 0 ? "planning" : args.record.state,
+    state:
+      args.record.implementation_attempt_count === 0 &&
+      !preserveIndependentVerificationBlocker
+        ? "planning"
+        : args.record.state,
     workspace_restore_source: ensuredWorkspace.restore.source,
     workspace_restore_ref: ensuredWorkspace.restore.ref,
-    last_error: shouldPreserveNoPrFailureTracking(args.record) ? args.record.last_error : null,
+    last_error:
+      shouldPreserveNoPrFailureTracking(args.record) ||
+        preserveIndependentVerificationBlocker
+        ? args.record.last_error
+        : null,
     last_failure_kind: null,
-    blocked_reason: null,
+    blocked_reason: preserveIndependentVerificationBlocker
+      ? "verification"
+      : null,
   });
   args.state.issues[String(preparedRecord.issue_number)] = preparedRecord;
   await args.stateStore.save(args.state);
@@ -265,6 +286,7 @@ async function prepareWorkspaceContext(
     syncJournal,
     memoryArtifacts,
     workspaceStatus,
+    independentVerificationBlocker,
   };
 }
 

--- a/src/run-once-issue-preparation.ts
+++ b/src/run-once-issue-preparation.ts
@@ -612,5 +612,9 @@ export async function prepareIssueExecutionContext(
   return {
     ...preparedWorkspace,
     ...hydratedPullRequest,
+    independentVerificationBlocker:
+      hydratedPullRequest.record.pr_number === null
+        ? null
+        : independentVerificationBlockerSnapshot(hydratedPullRequest.record),
   };
 }

--- a/src/run-once-issue-preparation.ts
+++ b/src/run-once-issue-preparation.ts
@@ -40,6 +40,7 @@ import {
 import { syncPostMergeAuditArtifactSafely } from "./supervisor/post-merge-audit-artifact";
 import {
   independentVerificationBlockerSnapshot,
+  preserveIndependentVerificationBlockerPatch,
   type IndependentVerificationBlockerSnapshot,
 } from "./supervisor/independent-verification-blocker";
 
@@ -296,6 +297,7 @@ async function hydratePullRequestContext(
     workspacePath: string;
     workspaceStatus: WorkspaceStatus;
     syncJournal: IssueJournalSync;
+    independentVerificationBlocker: IndependentVerificationBlockerSnapshot | null;
   },
 ): Promise<HydratedPullRequestContext | RestartRunOnce | string> {
   const pushBranch = args.pushBranch ?? pushBranchImpl;
@@ -320,7 +322,7 @@ async function hydratePullRequestContext(
 
     const failureContext = pathHygieneGate.failureContext;
     const previousRecord = record;
-    const blockedRecord = args.stateStore.touch(record, {
+    const failurePatch: Partial<IssueRunRecord> = {
       state: "blocked",
       last_error:
         failureContext?.summary ??
@@ -329,7 +331,17 @@ async function hydratePullRequestContext(
       last_failure_context: failureContext,
       ...applyFailureSignature(record, failureContext),
       blocked_reason: "verification",
-    });
+    };
+    const blockedRecord = args.stateStore.touch(
+      record,
+      args.independentVerificationBlocker
+        ? preserveIndependentVerificationBlockerPatch(
+            args.independentVerificationBlocker,
+            failurePatch,
+            { diagnosticPrefix: "review_repair_interruption" },
+          )
+        : failurePatch,
+    );
     record = blockedRecord;
     args.state.issues[String(blockedRecord.issue_number)] = blockedRecord;
     await args.stateStore.save(args.state);
@@ -601,6 +613,8 @@ export async function prepareIssueExecutionContext(
     workspacePath: preparedWorkspace.workspacePath,
     workspaceStatus: preparedWorkspace.workspaceStatus,
     syncJournal: preparedWorkspace.syncJournal,
+    independentVerificationBlocker:
+      preparedWorkspace.independentVerificationBlocker ?? null,
   });
   if (typeof hydratedPullRequest === "string") {
     return hydratedPullRequest;

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -4,7 +4,11 @@ import { execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { executeCodexTurnPhase, renderCodexExecutionSummary } from "./run-once-turn-execution";
+import {
+  executeCodexTurnPhase,
+  renderCodexExecutionSummary,
+  unresolvedIndependentVerificationBlockerAfterTurnEvidence,
+} from "./run-once-turn-execution";
 import {
   FailureContextCategory,
   GitHubIssue,
@@ -28,6 +32,7 @@ import { stableSameFileCodexConnectorChurnDossierConsumptionPatch } from "./supe
 import { interruptedTurnMarkerPath } from "./interrupted-turn-marker";
 import type { GitHubClient } from "./github";
 import { WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE } from "./workstation-local-path-gate";
+import type { IndependentVerificationBlockerSnapshot } from "./supervisor/independent-verification-blocker";
 import {
   codexTurnVerificationIncludesCommand,
   explicitFailedCodexTurnVerificationCommand,
@@ -179,6 +184,121 @@ test("failed structured verification retains a command identity that later passi
   );
 });
 
+test("passing verification evidence is command-scoped and failed outcomes dominate equivalent passes", () => {
+  const cases: Array<{
+    name: string;
+    evidence: string;
+    expected: string | null;
+  }> = [
+    {
+      name: "same inline command passes then fails",
+      evidence: "npm test: passed; npm test: failed",
+      expected: null,
+    },
+    {
+      name: "same inline command fails then passes",
+      evidence: "npm test: failed; npm test: passed",
+      expected: null,
+    },
+    {
+      name: "rtk wrapper and outcome delimiter variants still identify one command",
+      evidence: "rtk npm test (passed); npm test — failed",
+      expected: null,
+    },
+    {
+      name: "adjacent outcome entries still give failure precedence",
+      evidence: "$ npm test; passed; rtk npm test; failure",
+      expected: null,
+    },
+    {
+      name: "space-separated outcome variants still give failure precedence",
+      evidence: "npm run verify:images passed; rtk npm run verify:images failed",
+      expected: null,
+    },
+    {
+      name: "a failed command does not suppress a different passing command",
+      evidence: "npm run verify:images failed; npm test passed",
+      expected: "npm test",
+    },
+    {
+      name: "an independent pass survives alongside a conflicting command",
+      evidence: "npm test passed; rtk npm test failed; npm run verify:images passed",
+      expected: "npm run verify:images",
+    },
+    {
+      name: "equivalent passing variants are de-duplicated",
+      evidence: "rtk npm test: passed; npm test: passed",
+      expected: "rtk npm test",
+    },
+  ];
+
+  for (const fixture of cases) {
+    assert.equal(
+      explicitPassingCodexTurnVerificationCommand(fixture.evidence),
+      fixture.expected,
+      fixture.name,
+    );
+  }
+
+  assert.equal(
+    explicitSinglePassingCodexTurnVerificationCommand(
+      "rtk npm run verify:images",
+    ),
+    "rtk npm run verify:images",
+    "a commandless carried blocker can still be cleared by one unambiguous pass",
+  );
+  assert.equal(
+    explicitSinglePassingCodexTurnVerificationCommand(
+      "rtk npm run verify:images: passed; npm run verify:images: failed",
+    ),
+    null,
+    "mixed outcomes are never accepted as a single passing command",
+  );
+});
+
+test("matching turn evidence permanently resolves only the carried verifier command", () => {
+  const blocker: IndependentVerificationBlockerSnapshot = {
+    lastError: "Independent image verification remains blocked.",
+    lastBlockerSignature: "verification:images",
+    lastFailureContext: {
+      category: "blocked",
+      summary: "Independent image verification remains blocked.",
+      signature: "verification:images",
+      command: "npm run verify:images",
+      details: ["structured_blocked_reason=verification"],
+      url: null,
+      updated_at: "2026-07-12T00:00:00Z",
+    },
+    lastFailureSignature: "verification:images",
+    repeatedFailureSignatureCount: 3,
+    repeatedBlockerCount: 2,
+    blockedVerificationRetryCount: 1,
+  };
+
+  assert.equal(
+    unresolvedIndependentVerificationBlockerAfterTurnEvidence(
+      blocker,
+      "npm run verify:images passed; npm test failed",
+    ),
+    null,
+  );
+  assert.equal(
+    unresolvedIndependentVerificationBlockerAfterTurnEvidence(
+      blocker,
+      "npm test passed; npm run verify:images failed",
+    ),
+    blocker,
+  );
+  assert.equal(
+    unresolvedIndependentVerificationBlockerAfterTurnEvidence(
+      null,
+      "not run",
+    ),
+    null,
+    "a later same-turn retry cannot resurrect a verifier that already passed",
+  );
+});
+
 test("run-once turn execution does not import Decision Kernel v2 action decisions", async () => {
   const source = await fs.readFile(path.join(process.cwd(), "src", "run-once-turn-execution.ts"), "utf8");
 
@@ -213,6 +333,245 @@ function git(cwd: string, ...args: string[]): string {
     encoding: "utf8",
   });
 }
+
+test("executeCodexTurnPhase carries an independent verifier through a timeout persistence path", async () => {
+  await withTempWorkspace("run-once-carried-verifier-timeout-", async (workspacePath) => {
+    const issueNumber = 2447;
+    const journalPath = path.join(
+      workspacePath,
+      ".codex-supervisor",
+      "issue-journal.md",
+    );
+    await fs.mkdir(path.dirname(journalPath), { recursive: true });
+    await fs.writeFile(
+      journalPath,
+      "## Codex Working Notes\n### Current Handoff\n- Hypothesis: repair review feedback.\n",
+      "utf8",
+    );
+    const failureContext = {
+      category: "blocked" as const,
+      summary: "Independent image verification remains blocked.",
+      signature: "verification:images",
+      command: "npm run verify:images",
+      details: ["structured_blocked_reason=verification"],
+      url: null,
+      updated_at: "2026-07-12T00:00:00Z",
+    };
+    const record = createRecord({
+      issue_number: issueNumber,
+      state: "addressing_review",
+      branch: `codex/issue-${issueNumber}`,
+      workspace: workspacePath,
+      journal_path: journalPath,
+      pr_number: 2451,
+      last_head_sha: "head-2451",
+      blocked_reason: "verification",
+      last_error: failureContext.summary,
+      last_failure_context: failureContext,
+      last_failure_signature: failureContext.signature,
+      repeated_failure_signature_count: 3,
+      last_blocker_signature: "verification:images",
+      repeated_blocker_count: 2,
+      blocked_verification_retry_count: 1,
+      timeout_retry_count: 2,
+    });
+    const state: SupervisorStateFile = {
+      activeIssueNumber: issueNumber,
+      issues: { [String(issueNumber)]: record },
+    };
+    const issue = createIssue({ number: issueNumber });
+    const pr = createPullRequest({
+      number: 2451,
+      headRefName: record.branch,
+      headRefOid: "head-2451",
+      state: "OPEN",
+      mergedAt: null,
+    });
+
+    const result = await executeCodexTurnPhase({
+      config: createConfig(),
+      stateStore: {
+        touch: (current, patch) => ({
+          ...current,
+          ...patch,
+          updated_at: "2026-07-12T00:05:00Z",
+        }),
+        save: async () => undefined,
+      },
+      github: {
+        findOpenPullRequestsForBranch: async () => [pr],
+        getPullRequestIfExists: async () => pr,
+        resolvePullRequestForBranch: async () => pr,
+        createPullRequest: async () => {
+          throw new Error("unexpected createPullRequest call");
+        },
+        getChecks: async () => [],
+        getUnresolvedReviewThreads: async () => [],
+        getExternalReviewSurface: async () => ({ reviews: [], issueComments: [] }),
+      },
+      context: createCodexTurnContext({
+        state,
+        record,
+        issue,
+        pr,
+        workspacePath,
+        journalPath,
+        workspaceStatus: {
+          branch: record.branch,
+          headSha: "head-2451",
+        },
+      }),
+      acquireSessionLock: async () => null,
+      classifyFailure: () => "timeout",
+      buildCodexFailureContext: (category, summary, details) => ({
+        category,
+        summary,
+        signature: `${category}:${summary}`,
+        command: null,
+        details,
+        url: null,
+        updated_at: "2026-07-12T00:05:00Z",
+      }),
+      applyFailureSignature: () => ({
+        last_failure_signature: "superseding-timeout",
+        repeated_failure_signature_count: 1,
+      }),
+      normalizeBlockerSignature: () => "timeout:review-repair",
+      isVerificationBlockedMessage: () => false,
+      derivePullRequestLifecycleSnapshot: () => {
+        throw new Error("unexpected lifecycle projection");
+      },
+      inferStateWithoutPullRequest: () => "stabilizing",
+      blockedReasonFromReviewState: () => null,
+      recoverUnexpectedCodexTurnFailure: async ({ error }) => {
+        throw error instanceof Error ? error : new Error(String(error));
+      },
+      readIssueJournal: async () =>
+        "## Codex Working Notes\n### Current Handoff\n- Hypothesis: repair review feedback.\n",
+      agentRunner: createSuccessfulAgentRunner(async () => ({
+        exitCode: 1,
+        sessionId: "session-2447",
+        supervisorMessage: "Review repair timed out before verification.",
+        stderr: "Command timed out after 1800000ms: codex exec",
+        stdout: "",
+        structuredResult: {
+          summary: "Review repair timed out.",
+          stateHint: "failed",
+          blockedReason: null,
+          failureSignature: "timeout:review-repair",
+          nextAction: "retry review repair",
+          tests: "not run",
+        },
+        failureKind: "timeout",
+        failureContext: null,
+      })),
+    });
+
+    const updated = state.issues[String(issueNumber)]!;
+    assert.equal(result.kind, "returned");
+    assert.equal(updated.state, "blocked");
+    assert.equal(updated.blocked_reason, "verification");
+    assert.equal(updated.last_failure_context?.command, "npm run verify:images");
+    assert.equal(updated.last_failure_signature, "verification:images");
+    assert.equal(updated.repeated_failure_signature_count, 3);
+    assert.equal(updated.last_blocker_signature, "verification:images");
+    assert.equal(updated.repeated_blocker_count, 2);
+    assert.equal(updated.blocked_verification_retry_count, 1);
+    assert.equal(updated.timeout_retry_count, 3);
+    assert.match(
+      updated.last_failure_context?.details.join("\n") ?? "",
+      /review_repair_interruption_detail=.*timed out/i,
+    );
+  });
+});
+
+test("executeCodexTurnPhase passes the pre-preparation verifier to unexpected recovery", async () => {
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Independent image verification remains blocked.",
+    signature: "verification:images",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-12T00:00:00Z",
+  };
+  const record = createRecord({
+    issue_number: 2447,
+    state: "addressing_review",
+    pr_number: 2451,
+    blocked_reason: "verification",
+    last_error: failureContext.summary,
+    last_failure_context: failureContext,
+    last_failure_signature: failureContext.signature,
+    repeated_failure_signature_count: 3,
+    last_blocker_signature: "verification:images",
+    repeated_blocker_count: 2,
+    blocked_verification_retry_count: 1,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 2447,
+    issues: { "2447": record },
+  };
+  let recoveredVerifier: IndependentVerificationBlockerSnapshot | null = null;
+
+  const result = await executeCodexTurnPhase({
+    config: createConfig(),
+    stateStore: {
+      touch: (current, patch) => ({ ...current, ...patch }),
+      save: async () => undefined,
+    },
+    github: {
+      resolvePullRequestForBranch: async () => null,
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+      getExternalReviewSurface: async () => ({ reviews: [], issueComments: [] }),
+    },
+    context: createCodexTurnContext({ state, record }),
+    acquireSessionLock: async () => null,
+    classifyFailure: () => "command_error",
+    buildCodexFailureContext: (category, summary, details) => ({
+      category,
+      summary,
+      signature: `${category}:${summary}`,
+      command: null,
+      details,
+      url: null,
+      updated_at: "2026-07-12T00:05:00Z",
+    }),
+    applyFailureSignature: () => ({
+      last_failure_signature: null,
+      repeated_failure_signature_count: 0,
+    }),
+    normalizeBlockerSignature: () => null,
+    isVerificationBlockedMessage: () => false,
+    derivePullRequestLifecycleSnapshot: () => {
+      throw new Error("unexpected lifecycle projection");
+    },
+    inferStateWithoutPullRequest: () => "stabilizing",
+    blockedReasonFromReviewState: () => null,
+    recoverUnexpectedCodexTurnFailure: async (args) => {
+      recoveredVerifier = args.independentVerificationBlocker ?? null;
+      return args.record;
+    },
+    readIssueJournal: async () => {
+      throw new Error("journal read exploded before prompt preparation");
+    },
+    agentRunner: createSuccessfulAgentRunner(async () => {
+      throw new Error("unexpected runTurn call");
+    }),
+  });
+
+  const recovered = recoveredVerifier as IndependentVerificationBlockerSnapshot | null;
+  assert.ok(recovered);
+  assert.equal(result.kind, "returned");
+  assert.equal(recovered.lastFailureContext.command, "npm run verify:images");
+  assert.equal(recovered.lastFailureSignature, "verification:images");
+  assert.equal(recovered.repeatedFailureSignatureCount, 3);
+  assert.equal(recovered.blockedVerificationRetryCount, 1);
+});
 
 async function createTrackedRepo(): Promise<string> {
   const repoPath = await fs.mkdtemp(

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -216,6 +216,21 @@ test("passing verification evidence is command-scoped and failed outcomes domina
       expected: null,
     },
     {
+      name: "a skipped result conflicts with a pass for the same command",
+      evidence: "npm run verify:images passed; npm run verify:images skipped",
+      expected: null,
+    },
+    {
+      name: "a not-run result conflicts with a pass for the same command",
+      evidence: "npm run verify:images: passed; npm run verify:images: not run",
+      expected: null,
+    },
+    {
+      name: "an adjacent skipped result conflicts with an adjacent pass",
+      evidence: "$ npm test; passed; rtk npm test; skipped",
+      expected: null,
+    },
+    {
       name: "a failed command does not suppress a different passing command",
       evidence: "npm run verify:images failed; npm test passed",
       expected: "npm test",

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -32,6 +32,7 @@ import {
   codexTurnVerificationIncludesCommand,
   explicitFailedCodexTurnVerificationCommand,
   explicitPassingCodexTurnVerificationCommand,
+  explicitSinglePassingCodexTurnVerificationCommand,
 } from "./run-once-turn-verification-evidence";
 
 const SAMPLE_UNIX_WORKSTATION_PATH = `/${"home"}/alice/dev/private-repo`;
@@ -141,6 +142,40 @@ test("failed structured verification retains a command identity that later passi
       "npm run verify:images passed; npm test failed",
     ),
     "npm run verify:images",
+  );
+  assert.equal(
+    explicitSinglePassingCodexTurnVerificationCommand(
+      "npm run verify:images",
+    ),
+    "npm run verify:images",
+  );
+  assert.equal(
+    explicitSinglePassingCodexTurnVerificationCommand(
+      "npm run verify:images; passed",
+    ),
+    "npm run verify:images",
+  );
+  assert.equal(
+    explicitSinglePassingCodexTurnVerificationCommand("passed"),
+    null,
+  );
+  assert.equal(
+    explicitSinglePassingCodexTurnVerificationCommand(
+      "npm run verify:images passed; npm test failed",
+    ),
+    null,
+  );
+  assert.equal(
+    explicitSinglePassingCodexTurnVerificationCommand(
+      "npm run verify:images; ambiguous",
+    ),
+    null,
+  );
+  assert.equal(
+    explicitSinglePassingCodexTurnVerificationCommand(
+      "npm run verify:images; npm test",
+    ),
+    null,
   );
 });
 
@@ -5534,14 +5569,28 @@ test(`executeCodexTurnPhase binds a uniquely resolved open PR before persisting 
 });
 }
 
-test("executeCodexTurnPhase preserves an independent verifier when review repair ends with a structured terminal hint", async () => {
+for (const terminalVerifierScenario of [
+  {
+    name: "preserves an independent verifier when review repair ends with a structured terminal hint",
+    legacyCommand: "npm run verify:images",
+    tests: "not run",
+    preserves: true,
+  },
+  {
+    name: "replaces a legacy commandless verifier after one passing command and a structured terminal hint",
+    legacyCommand: null,
+    tests: "npm run verify:images",
+    preserves: false,
+  },
+] as const) {
+test(`executeCodexTurnPhase ${terminalVerifierScenario.name}`, async () => {
   const branch = "codex/issue-103";
   const repairedHead = "head-repaired-103";
   const failureContext = {
     category: "blocked" as const,
     summary: "Image verification remains blocked.",
     signature: "gitops-images-high-critical",
-    command: "npm run verify:images",
+    command: terminalVerifierScenario.legacyCommand,
     details: ["structured_blocked_reason=verification"],
     url: null,
     updated_at: "2026-07-11T12:35:00Z",
@@ -5665,7 +5714,7 @@ test("executeCodexTurnPhase preserves an independent verifier when review repair
         blockedReason: "secrets",
         failureSignature: "secrets:review-repair",
         nextAction: "provide the token",
-        tests: "not run",
+        tests: terminalVerifierScenario.tests,
       },
       failureKind: null,
       failureContext: null,
@@ -5675,22 +5724,49 @@ test("executeCodexTurnPhase preserves an independent verifier when review repair
   const updated = state.issues["103"]!;
   assert.equal(result.kind, "returned");
   assert.equal(updated.state, "blocked");
-  assert.equal(updated.blocked_reason, "verification");
+  assert.equal(
+    updated.blocked_reason,
+    terminalVerifierScenario.preserves ? "verification" : "secrets",
+  );
   assert.equal(updated.pr_number, 203);
   assert.equal(updated.last_head_sha, repairedHead);
-  assert.equal(updated.last_failure_context?.command, "npm run verify:images");
-  assert.equal(updated.last_failure_signature, failureContext.signature);
-  assert.equal(updated.repeated_failure_signature_count, 3);
-  assert.equal(updated.last_blocker_signature, "verification:images");
-  assert.equal(updated.repeated_blocker_count, 2);
-  assert.equal(updated.blocked_verification_retry_count, 1);
+  assert.equal(
+    updated.last_failure_context?.command,
+    terminalVerifierScenario.preserves ? "npm run verify:images" : null,
+  );
+  assert.equal(
+    updated.last_failure_signature,
+    terminalVerifierScenario.preserves
+      ? failureContext.signature
+      : "secrets:review-repair",
+  );
+  assert.equal(
+    updated.repeated_failure_signature_count,
+    terminalVerifierScenario.preserves ? 3 : 1,
+  );
+  assert.equal(
+    updated.last_blocker_signature,
+    terminalVerifierScenario.preserves
+      ? "verification:images"
+      : "secrets:review-repair",
+  );
+  assert.equal(
+    updated.repeated_blocker_count,
+    terminalVerifierScenario.preserves ? 2 : 1,
+  );
+  assert.equal(
+    updated.blocked_verification_retry_count,
+    terminalVerifierScenario.preserves ? 1 : 0,
+  );
   assert.match(updated.last_error ?? "", /Need token/);
-  assert.ok(
+  assert.equal(
     updated.last_failure_context?.details.includes(
       "review_repair_terminal_blocked_reason=secrets",
     ),
+    terminalVerifierScenario.preserves,
   );
 });
+}
 
 for (const verifierScenario of [
   { name: "keeps an unverified blocker", tests: "not run", preserves: true },
@@ -5699,6 +5775,36 @@ for (const verifierScenario of [
     name: "clears a blocker when its command passes in mixed results",
     tests: "npm run verify:images passed; npm test failed",
     preserves: false,
+  },
+  {
+    name: "clears a legacy commandless blocker after one passing command",
+    tests: "npm run verify:images",
+    preserves: false,
+    legacyCommandMissing: true,
+  },
+  {
+    name: "keeps a legacy commandless blocker after an arbitrary pass",
+    tests: "passed",
+    preserves: true,
+    legacyCommandMissing: true,
+  },
+  {
+    name: "keeps a legacy commandless blocker after mixed results",
+    tests: "npm run verify:images passed; npm test failed",
+    preserves: true,
+    legacyCommandMissing: true,
+  },
+  {
+    name: "keeps a legacy commandless blocker after multiple passing commands",
+    tests: "npm run verify:images; npm test",
+    preserves: true,
+    legacyCommandMissing: true,
+  },
+  {
+    name: "keeps a legacy commandless blocker after ambiguous evidence",
+    tests: "npm run verify:images; ambiguous",
+    preserves: true,
+    legacyCommandMissing: true,
   },
 ] as const) {
 test(`executeCodexTurnPhase ${verifierScenario.name} after review repair advances the PR head`, async () => {
@@ -5709,7 +5815,10 @@ test(`executeCodexTurnPhase ${verifierScenario.name} after review repair advance
     category: "blocked" as const,
     summary: "Image verification remains blocked.",
     signature: "gitops-images-high-critical",
-    command: "npm run verify:images",
+    command: "legacyCommandMissing" in verifierScenario &&
+        verifierScenario.legacyCommandMissing
+      ? null
+      : "npm run verify:images",
     details: ["structured_blocked_reason=verification"],
     url: null,
     updated_at: "2026-07-11T12:35:00Z",

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -28,6 +28,10 @@ import { stableSameFileCodexConnectorChurnDossierConsumptionPatch } from "./supe
 import { interruptedTurnMarkerPath } from "./interrupted-turn-marker";
 import type { GitHubClient } from "./github";
 import { WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE } from "./workstation-local-path-gate";
+import {
+  codexTurnVerificationIncludesCommand,
+  explicitFailedCodexTurnVerificationCommand,
+} from "./run-once-turn-verification-evidence";
 
 const SAMPLE_UNIX_WORKSTATION_PATH = `/${"home"}/alice/dev/private-repo`;
 const SAMPLE_MACOS_WORKSTATION_PATH = `/${"Users"}/alice/Dev/private-repo`;
@@ -59,6 +63,37 @@ test("renderCodexExecutionSummary preserves requested and effective reasoning pr
   assert.equal(
     renderCodexExecutionSummary({ supervisorMessage: "Legacy runner summary." }),
     "Legacy runner summary.",
+  );
+});
+
+test("failed structured verification retains a command identity that later passing evidence can match", () => {
+  const failedCommand = explicitFailedCodexTurnVerificationCommand(
+    "npm run verify:images; failed",
+  );
+  assert.equal(failedCommand, "npm run verify:images");
+  assert.equal(
+    codexTurnVerificationIncludesCommand(
+      "npm run verify:images",
+      failedCommand,
+    ),
+    true,
+  );
+  assert.equal(
+    explicitFailedCodexTurnVerificationCommand(
+      "npm run verify:images; failed\nnpm test; passed",
+    ),
+    "npm run verify:images",
+  );
+  const selectorCommand = explicitFailedCodexTurnVerificationCommand(
+    "pytest -k failed: failed",
+  );
+  assert.equal(selectorCommand, "pytest -k failed");
+  assert.equal(
+    codexTurnVerificationIncludesCommand(
+      "pytest -k passed: passed",
+      selectorCommand,
+    ),
+    false,
   );
 });
 
@@ -5286,3 +5321,511 @@ test("executeCodexTurnPhase normalizes workstation-local paths from a journal-on
     assert.match(content, /<redacted-local-path>/);
   });
 });
+
+for (const terminalState of ["blocked", "failed"] as const) {
+test(`executeCodexTurnPhase binds a uniquely resolved open PR before persisting structured ${terminalState}`, async () => {
+  const branch = "codex/issue-102";
+  const publishedHead = "head-published-102";
+  const record = createRecord({
+    state: "implementing",
+    branch,
+    pr_number: null,
+    last_head_sha: "head-before-102",
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: { "102": record },
+  };
+  const issue = createIssue({ number: 102 });
+  const pr = createPullRequest({
+    number: 202,
+    baseRefName: "main",
+    headRefName: branch,
+    headRefOid: publishedHead,
+    headRepositoryOwner: { login: "owner" },
+    isCrossRepository: false,
+    state: "OPEN",
+    mergedAt: null,
+  });
+  const context = createCodexTurnContext({
+    state,
+    record,
+    issue,
+    pr: null,
+    workspaceStatus: {
+      branch,
+      headSha: "head-before-102",
+    },
+  });
+  let workspaceReads = 0;
+  let pullRequestReads = 0;
+  let journalReads = 0;
+
+  const result = await executeCodexTurnPhase({
+    config: createConfig(),
+    stateStore: {
+      touch: (current, patch) => ({
+        ...current,
+        ...patch,
+        updated_at: current.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    github: {
+      findOpenPullRequestsForBranch: async (resolvedBranch, options) => {
+        pullRequestReads += 1;
+        assert.equal(resolvedBranch, branch);
+        assert.equal(options?.purpose, "action");
+        return [pr];
+      },
+      getPullRequestIfExists: async (prNumber, options) => {
+        assert.equal(prNumber, pr.number);
+        assert.equal(options?.purpose, "action");
+        return pr;
+      },
+      resolvePullRequestForBranch: async () => {
+        throw new Error("unexpected fallback PR resolution");
+      },
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+      getExternalReviewSurface: async () => {
+        throw new Error("unexpected getExternalReviewSurface call");
+      },
+    },
+    context,
+    acquireSessionLock: async () => null,
+    classifyFailure: () => "command_error",
+    buildCodexFailureContext: (category, summary, details) => ({
+      category,
+      summary,
+      signature: null,
+      command: null,
+      details,
+      url: null,
+      updated_at: "2026-07-11T12:30:00Z",
+    }),
+    applyFailureSignature: (_current, failureContext) => ({
+      last_failure_signature: failureContext?.signature ?? null,
+      repeated_failure_signature_count: failureContext ? 1 : 0,
+    }),
+    normalizeBlockerSignature: () => "verification:prerequisite",
+    isVerificationBlockedMessage: () => false,
+    derivePullRequestLifecycleSnapshot: () => {
+      throw new Error("unexpected lifecycle projection");
+    },
+    inferStateWithoutPullRequest: () => "stabilizing",
+    blockedReasonFromReviewState: () => null,
+    recoverUnexpectedCodexTurnFailure: async ({ error }) => {
+      throw error instanceof Error ? error : new Error(String(error));
+    },
+    getWorkspaceStatus: async () => {
+      workspaceReads += 1;
+      return createWorkspaceStatus({
+        branch,
+        headSha: publishedHead,
+      });
+    },
+    pushBranch: async () => {
+      throw new Error("unexpected pushBranch call");
+    },
+    readIssueJournal: async () => {
+      journalReads += 1;
+      return journalReads === 1
+        ? "## Codex Working Notes\n### Current Handoff\n- Hypothesis: publish the implementation.\n"
+        : "## Codex Working Notes\n### Current Handoff\n- Hypothesis: publish the implementation.\n- What changed: opened PR #202 before verification stopped.\n";
+    },
+    agentRunner: createSuccessfulAgentRunner(async () => ({
+      exitCode: 0,
+      sessionId: "session-102",
+      supervisorMessage: "Verification blocked: prerequisite not satisfied.",
+      stderr: "",
+      stdout: "",
+      structuredResult: {
+        summary: "Published the PR before the verifier stopped.",
+        stateHint: terminalState,
+        blockedReason: "verification",
+        failureSignature: "gitops-images-high-critical",
+        nextAction: "repair the verification prerequisite",
+        tests: "npm run verify:images; failed",
+      },
+      failureKind: null,
+      failureContext: null,
+    })),
+  });
+
+  const updated = state.issues["102"]!;
+  assert.equal(result.kind, "returned");
+  assert.equal(result.message, `Codex reported ${terminalState} for issue #102.`);
+  assert.equal(workspaceReads, 1);
+  assert.equal(pullRequestReads, 1);
+  assert.equal(updated.state, terminalState);
+  assert.equal(
+    updated.blocked_reason,
+    terminalState === "blocked" ? "verification" : null,
+  );
+  assert.equal(updated.pr_number, pr.number);
+  assert.equal(updated.last_head_sha, publishedHead);
+  assert.match(
+    updated.last_tracked_pr_progress_summary ?? "",
+    /blocked_turn_pr_reconciliation=bound/,
+  );
+  assert.equal(updated.last_failure_signature, "gitops-images-high-critical");
+  assert.equal(
+    updated.last_failure_context?.details.includes(
+      "structured_blocked_reason=verification",
+    ),
+    terminalState === "blocked",
+  );
+  assert.match(updated.last_failure_context?.command ?? "", /npm run verify:images/);
+});
+}
+
+test("executeCodexTurnPhase preserves an independent verifier when review repair ends with a structured terminal hint", async () => {
+  const branch = "codex/issue-103";
+  const repairedHead = "head-repaired-103";
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Image verification remains blocked.",
+    signature: "gitops-images-high-critical",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-11T12:35:00Z",
+  };
+  const record = createRecord({
+    issue_number: 103,
+    state: "addressing_review",
+    branch,
+    pr_number: 203,
+    last_head_sha: "head-old-103",
+    blocked_reason: "verification",
+    last_error: failureContext.summary,
+    last_failure_context: failureContext,
+    last_failure_signature: failureContext.signature,
+    repeated_failure_signature_count: 3,
+    last_blocker_signature: "verification:images",
+    repeated_blocker_count: 2,
+    blocked_verification_retry_count: 1,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 103,
+    issues: { "103": record },
+  };
+  const issue = createIssue({ number: 103 });
+  const pr = createPullRequest({
+    number: 203,
+    baseRefName: "main",
+    headRefName: branch,
+    headRefOid: repairedHead,
+    headRepositoryOwner: { login: "owner" },
+    isCrossRepository: false,
+    state: "OPEN",
+    mergedAt: null,
+  });
+  let journalReads = 0;
+
+  const result = await executeCodexTurnPhase({
+    config: createConfig(),
+    stateStore: {
+      touch: (current, patch) => ({
+        ...current,
+        ...patch,
+        updated_at: current.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    github: {
+      findOpenPullRequestsForBranch: async () => [pr],
+      getPullRequestIfExists: async () => pr,
+      resolvePullRequestForBranch: async () => pr,
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected review thread lookup");
+      },
+      getExternalReviewSurface: async () => {
+        throw new Error("unexpected external review lookup");
+      },
+    },
+    context: createCodexTurnContext({
+      state,
+      record,
+      issue,
+      pr: createPullRequest({
+        number: 203,
+        baseRefName: "main",
+        headRefName: branch,
+        headRefOid: "head-old-103",
+      }),
+      workspaceStatus: { branch, headSha: "head-old-103" },
+    }),
+    acquireSessionLock: async () => null,
+    classifyFailure: () => "command_error",
+    buildCodexFailureContext: (category, summary, details) => ({
+      category,
+      summary,
+      signature: null,
+      command: null,
+      details,
+      url: null,
+      updated_at: "2026-07-11T12:40:00Z",
+    }),
+    applyFailureSignature: (_current, nextFailureContext) => ({
+      last_failure_signature: nextFailureContext?.signature ?? null,
+      repeated_failure_signature_count: nextFailureContext ? 1 : 0,
+    }),
+    normalizeBlockerSignature: () => "secrets:review-repair",
+    isVerificationBlockedMessage: () => false,
+    derivePullRequestLifecycleSnapshot: () => {
+      throw new Error("unexpected lifecycle projection");
+    },
+    inferStateWithoutPullRequest: () => "stabilizing",
+    blockedReasonFromReviewState: () => null,
+    recoverUnexpectedCodexTurnFailure: async ({ error }) => {
+      throw error instanceof Error ? error : new Error(String(error));
+    },
+    getWorkspaceStatus: async () =>
+      createWorkspaceStatus({ branch, headSha: repairedHead }),
+    pushBranch: async () => {
+      throw new Error("unexpected pushBranch call");
+    },
+    readIssueJournal: async () => {
+      journalReads += 1;
+      return journalReads === 1
+        ? "## Codex Working Notes\n### Current Handoff\n- Hypothesis: repair review findings.\n"
+        : "## Codex Working Notes\n### Current Handoff\n- Hypothesis: repair review findings.\n- What changed: repair stopped on a permission boundary.\n";
+    },
+    agentRunner: createSuccessfulAgentRunner(async () => ({
+      exitCode: 0,
+      sessionId: "session-103",
+      supervisorMessage: "Need token before the review repair can continue.",
+      stderr: "",
+      stdout: "",
+      structuredResult: {
+        summary: "Review repair stopped before the verifier ran.",
+        stateHint: "blocked",
+        blockedReason: "secrets",
+        failureSignature: "secrets:review-repair",
+        nextAction: "provide the token",
+        tests: "not run",
+      },
+      failureKind: null,
+      failureContext: null,
+    })),
+  });
+
+  const updated = state.issues["103"]!;
+  assert.equal(result.kind, "returned");
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.blocked_reason, "verification");
+  assert.equal(updated.pr_number, 203);
+  assert.equal(updated.last_head_sha, repairedHead);
+  assert.equal(updated.last_failure_context?.command, "npm run verify:images");
+  assert.equal(updated.last_failure_signature, failureContext.signature);
+  assert.equal(updated.repeated_failure_signature_count, 3);
+  assert.equal(updated.last_blocker_signature, "verification:images");
+  assert.equal(updated.repeated_blocker_count, 2);
+  assert.equal(updated.blocked_verification_retry_count, 1);
+  assert.match(updated.last_error ?? "", /Need token/);
+  assert.ok(
+    updated.last_failure_context?.details.includes(
+      "review_repair_terminal_blocked_reason=secrets",
+    ),
+  );
+});
+
+for (const verifierScenario of [
+  { name: "keeps an unverified blocker", tests: "not run", preserves: true },
+  { name: "clears a verified blocker", tests: "npm run verify:images", preserves: false },
+] as const) {
+test(`executeCodexTurnPhase ${verifierScenario.name} after review repair advances the PR head`, async () => {
+  const branch = "codex/issue-102";
+  const oldHead = "head-old-102";
+  const repairedHead = "head-repaired-102";
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Image verification remains blocked.",
+    signature: "gitops-images-high-critical",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-11T12:35:00Z",
+  };
+  const record = createRecord({
+    state: "addressing_review",
+    branch,
+    pr_number: 202,
+    last_head_sha: oldHead,
+    blocked_reason: "verification",
+    last_error: failureContext.summary,
+    last_failure_context: failureContext,
+    last_failure_signature: failureContext.signature,
+    repeated_failure_signature_count: 2,
+    repeated_blocker_count: 2,
+    blocked_verification_retry_count: 1,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: { "102": record },
+  };
+  const issue = createIssue({ number: 102 });
+  const repairedPr = createPullRequest({
+    number: 202,
+    baseRefName: "main",
+    headRefName: branch,
+    headRefOid: repairedHead,
+    state: "OPEN",
+    mergedAt: null,
+  });
+  let journalReads = 0;
+
+  await executeCodexTurnPhase({
+    config: createConfig(),
+    stateStore: {
+      touch: (current, patch) => ({
+        ...current,
+        ...patch,
+        updated_at: current.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    github: {
+      resolvePullRequestForBranch: async (_branch, _prNumber, options) => {
+        assert.equal(options?.purpose, "action");
+        return repairedPr;
+      },
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [],
+      getExternalReviewSurface: async () => ({
+        issueComments: [],
+        reviews: [],
+      }),
+    },
+    context: createCodexTurnContext({
+      state,
+      record,
+      issue,
+      pr: createPullRequest({
+        number: 202,
+        baseRefName: "main",
+        headRefName: branch,
+        headRefOid: oldHead,
+      }),
+      workspaceStatus: { branch, headSha: oldHead },
+    }),
+    acquireSessionLock: async () => null,
+    classifyFailure: () => "command_error",
+    buildCodexFailureContext: (category, summary, details) => ({
+      category,
+      summary,
+      signature: null,
+      command: null,
+      details,
+      url: null,
+      updated_at: "2026-07-11T12:40:00Z",
+    }),
+    applyFailureSignature: (_current, context) => ({
+      last_failure_signature: context?.signature ?? null,
+      repeated_failure_signature_count: context ? 1 : 0,
+    }),
+    normalizeBlockerSignature: () => null,
+    isVerificationBlockedMessage: () => false,
+    derivePullRequestLifecycleSnapshot: (current) => ({
+      recordForState: current,
+      nextState: "pr_open",
+      failureContext: null,
+      reviewWaitPatch: {},
+      codexConnectorRequestObservationPatch: {},
+      copilotRequestObservationPatch: {},
+      copilotTimeoutPatch: {
+        copilot_review_timed_out_at: null,
+        copilot_review_timeout_action: null,
+        copilot_review_timeout_reason: null,
+      },
+      mergeLatencyVisibilityPatch: {
+        provider_success_observed_at: null,
+        provider_success_head_sha: null,
+        merge_readiness_last_evaluated_at: null,
+      },
+    }),
+    inferStateWithoutPullRequest: () => "stabilizing",
+    blockedReasonFromReviewState: () => null,
+    recoverUnexpectedCodexTurnFailure: async ({ error }) => {
+      throw error instanceof Error ? error : new Error(String(error));
+    },
+    getWorkspaceStatus: async () =>
+      createWorkspaceStatus({ branch, headSha: repairedHead }),
+    listChangedTrackedFilesBetween: async () => ["src/repaired.ts"],
+    pushBranch: async () => {
+      throw new Error("unexpected pushBranch call");
+    },
+    readIssueJournal: async () => {
+      journalReads += 1;
+      return journalReads === 1
+        ? "## Codex Working Notes\n### Current Handoff\n- Hypothesis: repair the review.\n"
+        : "## Codex Working Notes\n### Current Handoff\n- Hypothesis: repair the review.\n- What changed: pushed the review repair.\n";
+    },
+    agentRunner: createSuccessfulAgentRunner(async () => ({
+      exitCode: 0,
+      sessionId: "session-review-102",
+      supervisorMessage: "Applied the current-head review repair.",
+      stderr: "",
+      stdout: "",
+      structuredResult: {
+        summary: "Applied the current-head review repair.",
+        stateHint: "pr_open",
+        blockedReason: null,
+        failureSignature: null,
+        nextAction: "rerun the independent verifier",
+        tests: verifierScenario.tests,
+      },
+      failureKind: null,
+      failureContext: null,
+    })),
+  });
+
+  const updated = state.issues["102"]!;
+  assert.equal(updated.state, verifierScenario.preserves ? "blocked" : "pr_open");
+  assert.equal(
+    updated.blocked_reason,
+    verifierScenario.preserves ? "verification" : null,
+  );
+  assert.equal(updated.pr_number, repairedPr.number);
+  assert.equal(updated.last_head_sha, repairedHead);
+  assert.equal(
+    updated.last_error,
+    verifierScenario.preserves ? failureContext.summary : null,
+  );
+  assert.deepEqual(
+    updated.last_failure_context,
+    verifierScenario.preserves ? failureContext : null,
+  );
+  assert.equal(
+    updated.last_failure_signature,
+    verifierScenario.preserves ? failureContext.signature : null,
+  );
+  assert.equal(
+    updated.repeated_failure_signature_count,
+    verifierScenario.preserves ? 2 : 0,
+  );
+  assert.equal(updated.repeated_blocker_count, verifierScenario.preserves ? 2 : 0);
+  assert.equal(
+    updated.blocked_verification_retry_count,
+    verifierScenario.preserves ? 1 : 0,
+  );
+});
+}

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -31,6 +31,7 @@ import { WORKSTATION_LOCAL_PATH_HYGIENE_REPAIRABLE_PUBLICATION_SIGNATURE } from 
 import {
   codexTurnVerificationIncludesCommand,
   explicitFailedCodexTurnVerificationCommand,
+  explicitPassingCodexTurnVerificationCommand,
 } from "./run-once-turn-verification-evidence";
 
 const SAMPLE_UNIX_WORKSTATION_PATH = `/${"home"}/alice/dev/private-repo`;
@@ -94,6 +95,52 @@ test("failed structured verification retains a command identity that later passi
       selectorCommand,
     ),
     false,
+  );
+  assert.equal(
+    explicitFailedCodexTurnVerificationCommand("npm run verify:images failed"),
+    "npm run verify:images",
+  );
+  assert.equal(
+    explicitFailedCodexTurnVerificationCommand("npm test failed"),
+    "npm test",
+  );
+  assert.equal(
+    explicitFailedCodexTurnVerificationCommand("pytest -k failed"),
+    null,
+  );
+  assert.equal(
+    explicitFailedCodexTurnVerificationCommand("pytest -k smoke failed"),
+    null,
+  );
+  assert.equal(
+    explicitFailedCodexTurnVerificationCommand("npx vitest failed"),
+    null,
+  );
+  assert.equal(
+    explicitFailedCodexTurnVerificationCommand("npm run failed"),
+    null,
+  );
+  assert.equal(
+    explicitFailedCodexTurnVerificationCommand("npm test -- failed"),
+    null,
+  );
+  assert.equal(
+    explicitFailedCodexTurnVerificationCommand("npx vitest failed: failed"),
+    "npx vitest failed",
+  );
+  assert.equal(
+    explicitPassingCodexTurnVerificationCommand("npx vitest passed"),
+    null,
+  );
+  assert.equal(
+    explicitPassingCodexTurnVerificationCommand("npm test passed"),
+    "npm test",
+  );
+  assert.equal(
+    explicitPassingCodexTurnVerificationCommand(
+      "npm run verify:images passed; npm test failed",
+    ),
+    "npm run verify:images",
   );
 });
 
@@ -5648,6 +5695,11 @@ test("executeCodexTurnPhase preserves an independent verifier when review repair
 for (const verifierScenario of [
   { name: "keeps an unverified blocker", tests: "not run", preserves: true },
   { name: "clears a verified blocker", tests: "npm run verify:images", preserves: false },
+  {
+    name: "clears a blocker when its command passes in mixed results",
+    tests: "npm run verify:images passed; npm test failed",
+    preserves: false,
+  },
 ] as const) {
 test(`executeCodexTurnPhase ${verifierScenario.name} after review repair advances the PR head`, async () => {
   const branch = "codex/issue-102";
@@ -5672,6 +5724,7 @@ test(`executeCodexTurnPhase ${verifierScenario.name} after review repair advance
     last_failure_context: failureContext,
     last_failure_signature: failureContext.signature,
     repeated_failure_signature_count: 2,
+    last_blocker_signature: "verification:images",
     repeated_blocker_count: 2,
     blocked_verification_retry_count: 1,
   });
@@ -5823,6 +5876,10 @@ test(`executeCodexTurnPhase ${verifierScenario.name} after review repair advance
     verifierScenario.preserves ? 2 : 0,
   );
   assert.equal(updated.repeated_blocker_count, verifierScenario.preserves ? 2 : 0);
+  assert.equal(
+    updated.last_blocker_signature,
+    verifierScenario.preserves ? "verification:images" : null,
+  );
   assert.equal(
     updated.blocked_verification_retry_count,
     verifierScenario.preserves ? 1 : 0,

--- a/src/run-once-turn-execution.test.ts
+++ b/src/run-once-turn-execution.test.ts
@@ -269,6 +269,28 @@ test("passing verification evidence is command-scoped and failed outcomes domina
     null,
     "mixed outcomes are never accepted as a single passing command",
   );
+  assert.equal(
+    codexTurnVerificationIncludesCommand(
+      "npm run verify:images",
+      "npm run verify:images; failed",
+    ),
+    true,
+    "legacy adjacent failure outcomes are stripped before command matching",
+  );
+  assert.equal(
+    explicitFailedCodexTurnVerificationCommand(
+      "npm run verify:images; skipped",
+    ),
+    "npm run verify:images",
+    "skipped verifier outcomes retain their command identity",
+  );
+  assert.equal(
+    explicitFailedCodexTurnVerificationCommand(
+      "npm run verify:images\nnot run",
+    ),
+    "npm run verify:images",
+    "not-run verifier outcomes retain their command identity",
+  );
 });
 
 test("matching turn evidence permanently resolves only the carried verifier command", () => {

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -75,6 +75,7 @@ import { applyCodexTurnPublicationGate } from "./turn-execution-publication-gate
 import {
   explicitFailedCodexTurnVerificationCommand,
   explicitPassingCodexTurnVerificationCommand,
+  explicitSinglePassingCodexTurnVerificationCommand,
   codexTurnVerificationIncludesCommand,
 } from "./run-once-turn-verification-evidence";
 import {
@@ -515,6 +516,10 @@ export async function executeCodexTurnPhase(
           explicitFailedCodexTurnVerificationCommand(structuredResult?.tests);
         const hintedPassingVerificationCommand =
           explicitPassingCodexTurnVerificationCommand(structuredResult?.tests);
+        const hintedSinglePassingVerificationCommand =
+          explicitSinglePassingCodexTurnVerificationCommand(
+            structuredResult?.tests,
+          );
         const preTurnFailureContext = record.last_failure_context;
         const preTurnFailureSignature = record.last_failure_signature;
         const preTurnStaleNoPrRecoveryCount =
@@ -630,11 +635,13 @@ export async function executeCodexTurnPhase(
           const preservesCarriedVerificationBlocker =
             carriedVerificationBlocker !== null &&
             !(
-              hintedPassingVerificationCommand !== null &&
-              codexTurnVerificationIncludesCommand(
-                hintedPassingVerificationCommand,
-                carriedVerificationBlocker.lastFailureContext.command,
-              )
+              carriedVerificationBlocker.lastFailureContext.command === null
+                ? hintedSinglePassingVerificationCommand !== null
+                : hintedPassingVerificationCommand !== null &&
+                  codexTurnVerificationIncludesCommand(
+                    hintedPassingVerificationCommand,
+                    carriedVerificationBlocker.lastFailureContext.command,
+                  )
             );
           let workspaceReconciliationDiagnostic: string | null = null;
           let reconciledWorkspaceHeadSha: string | null = null;
@@ -686,6 +693,10 @@ export async function executeCodexTurnPhase(
               : {}),
             ...(reconciledPullRequest
               ? { pr_number: reconciledPullRequest.number }
+              : {}),
+            ...(carriedVerificationBlocker !== null &&
+                !preservesCarriedVerificationBlocker
+              ? { blocked_verification_retry_count: 0 }
               : {}),
             last_tracked_pr_progress_summary: terminalReconciliationDiagnostic,
           });
@@ -1011,6 +1022,10 @@ export async function executeCodexTurnPhase(
 
         const codexVerificationCommand =
           explicitPassingCodexTurnVerificationCommand(structuredResult?.tests);
+        const singlePassingCodexVerificationCommand =
+          explicitSinglePassingCodexTurnVerificationCommand(
+            structuredResult?.tests,
+          );
         const failedCodexVerificationCommand =
           explicitFailedCodexTurnVerificationCommand(structuredResult?.tests);
         const changedFilesAfterPublication =
@@ -1058,11 +1073,13 @@ export async function executeCodexTurnPhase(
             args.inferStateWithoutPullRequest(record, workspaceStatus));
         const carriedVerificationCommandPassed =
           carriedVerificationBlocker !== null &&
-          codexVerificationCommand !== null &&
-          codexTurnVerificationIncludesCommand(
-            codexVerificationCommand,
-            carriedVerificationBlocker.lastFailureContext.command,
-          );
+          (carriedVerificationBlocker.lastFailureContext.command === null
+            ? singlePassingCodexVerificationCommand !== null
+            : codexVerificationCommand !== null &&
+              codexTurnVerificationIncludesCommand(
+                codexVerificationCommand,
+                carriedVerificationBlocker.lastFailureContext.command,
+              ));
         const preserveCarriedVerificationBlocker =
           carriedVerificationBlocker !== null &&
           !carriedVerificationCommandPassed;

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -88,6 +88,10 @@ import {
 } from "./turn-execution-post-publication-review";
 import { runSameTurnDurableArtifactRepairRetry } from "./turn-execution-same-turn-repair";
 import { reconcileBlockedTurnPullRequest } from "./supervisor/blocked-turn-pr-reconciliation";
+import {
+  independentVerificationBlockerSnapshot,
+  type IndependentVerificationBlockerSnapshot,
+} from "./supervisor/independent-verification-blocker";
 
 export {
   handlePostTurnPullRequestTransitionsPhase,
@@ -112,6 +116,7 @@ export interface CodexTurnContext {
   checks: PullRequestCheck[];
   reviewThreads: ReviewThread[];
   options: { dryRun: boolean };
+  independentVerificationBlocker?: IndependentVerificationBlockerSnapshot | null;
 }
 
 export interface CodexTurnResult {
@@ -425,21 +430,8 @@ export async function executeCodexTurnPhase(
 
       const preRunState = record.state;
       const carriedVerificationBlocker =
-        preRunState === "addressing_review" &&
-        record.blocked_reason === "verification" &&
-        record.last_failure_context !== null
-          ? {
-              lastError: record.last_error,
-              lastBlockerSignature: record.last_blocker_signature,
-              lastFailureContext: record.last_failure_context,
-              lastFailureSignature: record.last_failure_signature,
-              repeatedFailureSignatureCount:
-                record.repeated_failure_signature_count,
-              repeatedBlockerCount: record.repeated_blocker_count,
-              blockedVerificationRetryCount:
-                record.blocked_verification_retry_count,
-            }
-          : null;
+        args.context.independentVerificationBlocker ??
+        independentVerificationBlockerSnapshot(record);
       const shouldResumeTurn = shouldResumeAgentTurn({
         record,
         agentRunnerCapabilities: agentRunner.capabilities,

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -90,6 +90,7 @@ import { runSameTurnDurableArtifactRepairRetry } from "./turn-execution-same-tur
 import { reconcileBlockedTurnPullRequest } from "./supervisor/blocked-turn-pr-reconciliation";
 import {
   independentVerificationBlockerSnapshot,
+  preserveIndependentVerificationBlockerPatch,
   type IndependentVerificationBlockerSnapshot,
 } from "./supervisor/independent-verification-blocker";
 
@@ -156,6 +157,26 @@ export function renderCodexExecutionSummary(
   return [routingSummary, turnResult.supervisorMessage.trim()].filter(Boolean).join("\n\n");
 }
 
+export function unresolvedIndependentVerificationBlockerAfterTurnEvidence(
+  blocker: IndependentVerificationBlockerSnapshot | null,
+  tests: string | null | undefined,
+): IndependentVerificationBlockerSnapshot | null {
+  if (blocker === null) {
+    return null;
+  }
+  const passingCommand = explicitPassingCodexTurnVerificationCommand(tests);
+  const singlePassingCommand =
+    explicitSinglePassingCodexTurnVerificationCommand(tests);
+  const passed = blocker.lastFailureContext.command === null
+    ? singlePassingCommand !== null
+    : passingCommand !== null &&
+      codexTurnVerificationIncludesCommand(
+        passingCommand,
+        blocker.lastFailureContext.command,
+      );
+  return passed ? null : blocker;
+}
+
 export interface CodexTurnShortCircuit {
   kind: "returned";
   message: string;
@@ -177,6 +198,7 @@ interface RecoverUnexpectedCodexTurnFailureArgs {
     GitHubPullRequest,
     "number" | "headRefOid" | "createdAt" | "mergedAt"
   > | null;
+  independentVerificationBlocker?: IndependentVerificationBlockerSnapshot | null;
 }
 
 interface ExecuteCodexTurnPhaseArgs {
@@ -262,6 +284,7 @@ interface ExecuteCodexTurnPhaseArgs {
       "last_failure_signature" | "repeated_failure_signature_count"
     >;
     retentionRootPath?: string;
+    preservedVerificationBlocker?: IndependentVerificationBlockerSnapshot | null;
   }) => Promise<IssueRunRecord>;
   persistCodexTurnExitFailure?: (args: {
     stateStore: Pick<StateStore, "touch" | "save">;
@@ -290,6 +313,7 @@ interface ExecuteCodexTurnPhaseArgs {
       "last_failure_signature" | "repeated_failure_signature_count"
     >;
     retentionRootPath?: string;
+    preservedVerificationBlocker?: IndependentVerificationBlockerSnapshot | null;
   }) => Promise<IssueRunRecord>;
   persistMissingCodexJournalHandoff?: (args: {
     stateStore: Pick<StateStore, "touch" | "save">;
@@ -311,6 +335,7 @@ interface ExecuteCodexTurnPhaseArgs {
       "last_failure_signature" | "repeated_failure_signature_count"
     >;
     retentionRootPath?: string;
+    preservedVerificationBlocker?: IndependentVerificationBlockerSnapshot | null;
   }) => Promise<IssueRunRecord>;
   persistHintedCodexTurnState?: (args: {
     stateStore: Pick<StateStore, "touch" | "save">;
@@ -324,15 +349,7 @@ interface ExecuteCodexTurnPhaseArgs {
     hintedBlockedReason: IssueRunRecord["blocked_reason"];
     hintedFailureSignature: string | null;
     hintedVerificationCommand?: string | null;
-    preservedVerificationBlocker?: {
-      blockedVerificationRetryCount: number;
-      lastBlockerSignature: string | null;
-      lastError: string | null;
-      lastFailureContext: FailureContext;
-      lastFailureSignature: string | null;
-      repeatedBlockerCount: number;
-      repeatedFailureSignatureCount: number;
-    } | null;
+    preservedVerificationBlocker?: IndependentVerificationBlockerSnapshot | null;
     buildCodexFailureContext: (
       category: FailureContext["category"],
       summary: string,
@@ -407,6 +424,26 @@ export async function executeCodexTurnPhase(
   const turnStartHeadSha = workspaceStatus.headSha;
   let usedSameTurnPathRepairRetry = false;
   let artifactOnlyChangedFilesAfterPublication: string[] = [];
+  const carriedVerificationBlocker =
+    args.context.independentVerificationBlocker ??
+    independentVerificationBlockerSnapshot(record);
+  let unresolvedCarriedVerificationBlocker = carriedVerificationBlocker;
+  const earlyFailureStateStore: Pick<StateStore, "touch" | "save"> = {
+    touch: (currentRecord, patch) =>
+      stateStore.touch(
+        currentRecord,
+        unresolvedCarriedVerificationBlocker !== null &&
+            (patch.state === "blocked" ||
+              patch.state === "failed" ||
+              patch.state === "repairing_ci")
+          ? preserveIndependentVerificationBlockerPatch(
+              unresolvedCarriedVerificationBlocker,
+              patch,
+            )
+          : patch,
+      ),
+    save: (nextState) => stateStore.save(nextState),
+  };
 
   const rememberArtifactOnlyChangedFilesAfterPublication = (
     filePaths: readonly string[],
@@ -429,9 +466,6 @@ export async function executeCodexTurnPhase(
       }
 
       const preRunState = record.state;
-      const carriedVerificationBlocker =
-        args.context.independentVerificationBlocker ??
-        independentVerificationBlockerSnapshot(record);
       const shouldResumeTurn = shouldResumeAgentTurn({
         record,
         agentRunnerCapabilities: agentRunner.capabilities,
@@ -456,7 +490,9 @@ export async function executeCodexTurnPhase(
         }
         const effectiveJournalContent = journalContent ?? "";
         const previousCodexSummary = record.last_codex_summary;
-        const previousError = record.last_error;
+        const previousError =
+          unresolvedCarriedVerificationBlocker?.lastError ??
+          record.last_error;
 
         const preparedTurn = await prepareCodexTurnPrompt({
           config,
@@ -466,6 +502,8 @@ export async function executeCodexTurnPhase(
           issue,
           previousCodexSummary,
           previousError,
+          failureContextOverride:
+            unresolvedCarriedVerificationBlocker?.lastFailureContext,
           workspacePath,
           journalPath,
           journalContent: effectiveJournalContent,
@@ -506,10 +544,9 @@ export async function executeCodexTurnPhase(
           structuredResult?.failureSignature ?? null;
         const hintedVerificationCommand =
           explicitFailedCodexTurnVerificationCommand(structuredResult?.tests);
-        const hintedPassingVerificationCommand =
-          explicitPassingCodexTurnVerificationCommand(structuredResult?.tests);
-        const hintedSinglePassingVerificationCommand =
-          explicitSinglePassingCodexTurnVerificationCommand(
+        unresolvedCarriedVerificationBlocker =
+          unresolvedIndependentVerificationBlockerAfterTurnEvidence(
+            unresolvedCarriedVerificationBlocker,
             structuredResult?.tests,
           );
         const preTurnFailureContext = record.last_failure_context;
@@ -557,6 +594,7 @@ export async function executeCodexTurnPhase(
             issueNumber: record.issue_number,
             buildCodexFailureContext: args.buildCodexFailureContext,
             applyFailureSignature: args.applyFailureSignature,
+            preservedVerificationBlocker: unresolvedCarriedVerificationBlocker,
             retentionRootPath: executionMetricsRetentionRootPath(
               args.config.stateFile,
             ),
@@ -587,6 +625,7 @@ export async function executeCodexTurnPhase(
             classifyFailure: args.classifyFailure,
             buildCodexFailureContext: args.buildCodexFailureContext,
             applyFailureSignature: args.applyFailureSignature,
+            preservedVerificationBlocker: unresolvedCarriedVerificationBlocker,
             retentionRootPath: executionMetricsRetentionRootPath(
               args.config.stateFile,
             ),
@@ -613,6 +652,7 @@ export async function executeCodexTurnPhase(
             classifyFailure: args.classifyFailure,
             buildCodexFailureContext: args.buildCodexFailureContext,
             applyFailureSignature: args.applyFailureSignature,
+            preservedVerificationBlocker: unresolvedCarriedVerificationBlocker,
             retentionRootPath: executionMetricsRetentionRootPath(
               args.config.stateFile,
             ),
@@ -625,16 +665,7 @@ export async function executeCodexTurnPhase(
 
         if (hintedState === "blocked" || hintedState === "failed") {
           const preservesCarriedVerificationBlocker =
-            carriedVerificationBlocker !== null &&
-            !(
-              carriedVerificationBlocker.lastFailureContext.command === null
-                ? hintedSinglePassingVerificationCommand !== null
-                : hintedPassingVerificationCommand !== null &&
-                  codexTurnVerificationIncludesCommand(
-                    hintedPassingVerificationCommand,
-                    carriedVerificationBlocker.lastFailureContext.command,
-                  )
-            );
+            unresolvedCarriedVerificationBlocker !== null;
           let workspaceReconciliationDiagnostic: string | null = null;
           let reconciledWorkspaceHeadSha: string | null = null;
           try {
@@ -705,7 +736,7 @@ export async function executeCodexTurnPhase(
             hintedFailureSignature,
             hintedVerificationCommand,
             preservedVerificationBlocker: preservesCarriedVerificationBlocker
-              ? carriedVerificationBlocker
+              ? unresolvedCarriedVerificationBlocker
               : null,
             buildCodexFailureContext: args.buildCodexFailureContext,
             applyFailureSignature: args.applyFailureSignature,
@@ -791,7 +822,7 @@ export async function executeCodexTurnPhase(
                 ...(pathHygieneGate.rewrittenTrustedGeneratedArtifactPaths ?? []),
               ];
               const retryResult = await runSameTurnDurableArtifactRepairRetry({
-                stateStore,
+                stateStore: earlyFailureStateStore,
                 state,
                 record,
                 issue,
@@ -822,7 +853,7 @@ export async function executeCodexTurnPhase(
             if (repairFailureContext !== null) {
               const persistenceResult =
                 await persistPublicationPathHygieneRepairQueued({
-                  stateStore,
+                  stateStore: earlyFailureStateStore,
                   state,
                   record,
                   issue,
@@ -843,7 +874,7 @@ export async function executeCodexTurnPhase(
             }
             const persistenceResult =
               await persistPublicationPathHygieneBlocked({
-                stateStore,
+                stateStore: earlyFailureStateStore,
                 state,
                 record,
                 issue,
@@ -892,7 +923,7 @@ export async function executeCodexTurnPhase(
               });
               const persistenceResult =
                 await persistPublicationPathHygieneBlocked({
-                  stateStore,
+                  stateStore: earlyFailureStateStore,
                   state,
                   record,
                   issue,
@@ -943,7 +974,7 @@ export async function executeCodexTurnPhase(
 
         const publicationGate = await applyCodexTurnPublicationGate({
           config,
-          stateStore,
+          stateStore: earlyFailureStateStore,
           state,
           record,
           issue,
@@ -971,7 +1002,7 @@ export async function executeCodexTurnPhase(
         record = publicationGate.record;
         if (publicationGate.kind === "same_turn_repair") {
           const retryResult = await runSameTurnDurableArtifactRepairRetry({
-            stateStore,
+            stateStore: earlyFailureStateStore,
             state,
             record,
             issue,
@@ -1014,10 +1045,6 @@ export async function executeCodexTurnPhase(
 
         const codexVerificationCommand =
           explicitPassingCodexTurnVerificationCommand(structuredResult?.tests);
-        const singlePassingCodexVerificationCommand =
-          explicitSinglePassingCodexTurnVerificationCommand(
-            structuredResult?.tests,
-          );
         const failedCodexVerificationCommand =
           explicitFailedCodexTurnVerificationCommand(structuredResult?.tests);
         const changedFilesAfterPublication =
@@ -1063,20 +1090,10 @@ export async function executeCodexTurnPhase(
           ? postRunSnapshot.nextState
           : (hintedState ??
             args.inferStateWithoutPullRequest(record, workspaceStatus));
-        const carriedVerificationCommandPassed =
-          carriedVerificationBlocker !== null &&
-          (carriedVerificationBlocker.lastFailureContext.command === null
-            ? singlePassingCodexVerificationCommand !== null
-            : codexVerificationCommand !== null &&
-              codexTurnVerificationIncludesCommand(
-                codexVerificationCommand,
-                carriedVerificationBlocker.lastFailureContext.command,
-              ));
-        const preserveCarriedVerificationBlocker =
-          carriedVerificationBlocker !== null &&
-          !carriedVerificationCommandPassed;
+        const preservedCarriedVerificationBlocker =
+          unresolvedCarriedVerificationBlocker;
         const postRunState =
-          preserveCarriedVerificationBlocker &&
+          preservedCarriedVerificationBlocker !== null &&
           lifecyclePostRunState !== "addressing_review"
             ? "blocked"
             : lifecyclePostRunState;
@@ -1116,38 +1133,38 @@ export async function executeCodexTurnPhase(
           ...processedReviewThreadPatch,
           ...reviewFollowUpPatch,
           blocked_verification_retry_count: pr
-            ? preserveCarriedVerificationBlocker
-              ? carriedVerificationBlocker.blockedVerificationRetryCount
+            ? preservedCarriedVerificationBlocker !== null
+              ? preservedCarriedVerificationBlocker.blockedVerificationRetryCount
               : 0
             : record.blocked_verification_retry_count,
-          repeated_blocker_count: preserveCarriedVerificationBlocker
-            ? carriedVerificationBlocker.repeatedBlockerCount
+          repeated_blocker_count: preservedCarriedVerificationBlocker !== null
+            ? preservedCarriedVerificationBlocker.repeatedBlockerCount
             : 0,
-          last_blocker_signature: preserveCarriedVerificationBlocker
-            ? carriedVerificationBlocker.lastBlockerSignature
+          last_blocker_signature: preservedCarriedVerificationBlocker !== null
+            ? preservedCarriedVerificationBlocker.lastBlockerSignature
             : null,
           stale_stabilizing_no_pr_recovery_count:
             preserveStaleNoPrRecoveryTracking
               ? preTurnStaleNoPrRecoveryCount
               : 0,
-          last_error: preserveCarriedVerificationBlocker
-            ? carriedVerificationBlocker.lastError
+          last_error: preservedCarriedVerificationBlocker !== null
+            ? preservedCarriedVerificationBlocker.lastError
             : preserveStaleNoPrRecoveryTracking
             ? preTurnLastError
             : postRunState === "blocked" && postRunSnapshot?.failureContext
               ? truncate(postRunSnapshot.failureContext.summary, 1000)
               : record.last_error,
-          last_failure_context: preserveCarriedVerificationBlocker
-            ? carriedVerificationBlocker.lastFailureContext
+          last_failure_context: preservedCarriedVerificationBlocker !== null
+            ? preservedCarriedVerificationBlocker.lastFailureContext
             : preserveStaleNoPrRecoveryTracking
             ? preTurnFailureContext
             : (postRunSnapshot?.failureContext ?? null),
-          ...(preserveCarriedVerificationBlocker
+          ...(preservedCarriedVerificationBlocker !== null
             ? {
                 last_failure_signature:
-                  carriedVerificationBlocker.lastFailureSignature,
+                  preservedCarriedVerificationBlocker.lastFailureSignature,
                 repeated_failure_signature_count:
-                  carriedVerificationBlocker.repeatedFailureSignatureCount,
+                  preservedCarriedVerificationBlocker.repeatedFailureSignatureCount,
               }
             : preserveStaleNoPrRecoveryTracking
             ? {
@@ -1159,7 +1176,7 @@ export async function executeCodexTurnPhase(
                 postRunSnapshot?.failureContext ?? null,
               )),
           blocked_reason:
-            preserveCarriedVerificationBlocker
+            preservedCarriedVerificationBlocker !== null
               ? "verification"
               : pr && postRunState === "blocked"
               ? args.blockedReasonFromReviewState(
@@ -1215,6 +1232,7 @@ export async function executeCodexTurnPhase(
       error,
       workspaceStatus,
       pr,
+      independentVerificationBlocker: unresolvedCarriedVerificationBlocker,
     });
     return {
       kind: "returned",

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -1114,7 +1114,9 @@ export async function executeCodexTurnPhase(
           repeated_blocker_count: preserveCarriedVerificationBlocker
             ? carriedVerificationBlocker.repeatedBlockerCount
             : 0,
-          last_blocker_signature: null,
+          last_blocker_signature: preserveCarriedVerificationBlocker
+            ? carriedVerificationBlocker.lastBlockerSignature
+            : null,
           stale_stabilizing_no_pr_recovery_count:
             preserveStaleNoPrRecoveryTracking
               ? preTurnStaleNoPrRecoveryCount

--- a/src/run-once-turn-execution.ts
+++ b/src/run-once-turn-execution.ts
@@ -75,6 +75,7 @@ import { applyCodexTurnPublicationGate } from "./turn-execution-publication-gate
 import {
   explicitFailedCodexTurnVerificationCommand,
   explicitPassingCodexTurnVerificationCommand,
+  codexTurnVerificationIncludesCommand,
 } from "./run-once-turn-verification-evidence";
 import {
   persistPublicationPathHygieneBlocked,
@@ -85,6 +86,7 @@ import {
   buildPostPublicationReviewPersistence,
 } from "./turn-execution-post-publication-review";
 import { runSameTurnDurableArtifactRepairRetry } from "./turn-execution-same-turn-repair";
+import { reconcileBlockedTurnPullRequest } from "./supervisor/blocked-turn-pr-reconciliation";
 
 export {
   handlePostTurnPullRequestTransitionsPhase,
@@ -181,7 +183,13 @@ interface ExecuteCodexTurnPhaseArgs {
     | "getChecks"
     | "getUnresolvedReviewThreads"
     | "getExternalReviewSurface"
-  >;
+  > &
+    Partial<
+      Pick<
+        GitHubClient,
+        "findOpenPullRequestsForBranch" | "getPullRequestIfExists"
+      >
+    >;
   context: CodexTurnContext;
   sessionLock?: LockHandle | null;
   acquireSessionLock: (sessionId: string) => Promise<LockHandle | null>;
@@ -309,6 +317,16 @@ interface ExecuteCodexTurnPhaseArgs {
     hintedState: "blocked" | "failed";
     hintedBlockedReason: IssueRunRecord["blocked_reason"];
     hintedFailureSignature: string | null;
+    hintedVerificationCommand?: string | null;
+    preservedVerificationBlocker?: {
+      blockedVerificationRetryCount: number;
+      lastBlockerSignature: string | null;
+      lastError: string | null;
+      lastFailureContext: FailureContext;
+      lastFailureSignature: string | null;
+      repeatedBlockerCount: number;
+      repeatedFailureSignatureCount: number;
+    } | null;
     buildCodexFailureContext: (
       category: FailureContext["category"],
       summary: string,
@@ -405,6 +423,22 @@ export async function executeCodexTurnPhase(
       }
 
       const preRunState = record.state;
+      const carriedVerificationBlocker =
+        preRunState === "addressing_review" &&
+        record.blocked_reason === "verification" &&
+        record.last_failure_context !== null
+          ? {
+              lastError: record.last_error,
+              lastBlockerSignature: record.last_blocker_signature,
+              lastFailureContext: record.last_failure_context,
+              lastFailureSignature: record.last_failure_signature,
+              repeatedFailureSignatureCount:
+                record.repeated_failure_signature_count,
+              repeatedBlockerCount: record.repeated_blocker_count,
+              blockedVerificationRetryCount:
+                record.blocked_verification_retry_count,
+            }
+          : null;
       const shouldResumeTurn = shouldResumeAgentTurn({
         record,
         agentRunnerCapabilities: agentRunner.capabilities,
@@ -477,6 +511,10 @@ export async function executeCodexTurnPhase(
         const hintedBlockedReason = structuredResult?.blockedReason ?? null;
         const hintedFailureSignature =
           structuredResult?.failureSignature ?? null;
+        const hintedVerificationCommand =
+          explicitFailedCodexTurnVerificationCommand(structuredResult?.tests);
+        const hintedPassingVerificationCommand =
+          explicitPassingCodexTurnVerificationCommand(structuredResult?.tests);
         const preTurnFailureContext = record.last_failure_context;
         const preTurnFailureSignature = record.last_failure_signature;
         const preTurnStaleNoPrRecoveryCount =
@@ -589,6 +627,68 @@ export async function executeCodexTurnPhase(
         }
 
         if (hintedState === "blocked" || hintedState === "failed") {
+          const preservesCarriedVerificationBlocker =
+            carriedVerificationBlocker !== null &&
+            !(
+              hintedPassingVerificationCommand !== null &&
+              codexTurnVerificationIncludesCommand(
+                hintedPassingVerificationCommand,
+                carriedVerificationBlocker.lastFailureContext.command,
+              )
+            );
+          let workspaceReconciliationDiagnostic: string | null = null;
+          let reconciledWorkspaceHeadSha: string | null = null;
+          try {
+            workspaceStatus = await getWorkspaceStatusImpl(
+              workspacePath,
+              record.branch,
+              config.defaultBranch,
+            );
+            reconciledWorkspaceHeadSha = workspaceStatus.headSha;
+          } catch (error) {
+            const detail = (error instanceof Error ? error.message : String(error))
+              .replace(/\s+/g, "_")
+              .slice(0, 300);
+            workspaceReconciliationDiagnostic =
+              `blocked_turn_workspace_reconciliation=error branch=${record.branch} ` +
+              `detail=${detail || "unknown"}`;
+          }
+
+          const pullRequestReconciliation =
+            await reconcileBlockedTurnPullRequest({
+              github,
+              state,
+              record,
+              defaultBranch: config.defaultBranch,
+              repoSlug: config.repoSlug,
+              purpose: "action",
+            });
+          const reconciledPullRequest =
+            pullRequestReconciliation.kind === "bound"
+              ? pullRequestReconciliation.pullRequest
+              : null;
+          const terminalReconciliationDiagnostic = [
+            pullRequestReconciliation.diagnostic,
+            workspaceReconciliationDiagnostic,
+          ]
+            .filter((value): value is string => value !== null)
+            .join(" | ");
+          if (reconciledPullRequest) {
+            pr = reconciledPullRequest;
+          }
+          record = stateStore.touch(record, {
+            ...(reconciledPullRequest || reconciledWorkspaceHeadSha
+              ? {
+                  last_head_sha:
+                    reconciledPullRequest?.headRefOid ??
+                    reconciledWorkspaceHeadSha,
+                }
+              : {}),
+            ...(reconciledPullRequest
+              ? { pr_number: reconciledPullRequest.number }
+              : {}),
+            last_tracked_pr_progress_summary: terminalReconciliationDiagnostic,
+          });
           record = await persistHintedCodexTurnStateImpl({
             stateStore,
             state,
@@ -600,6 +700,10 @@ export async function executeCodexTurnPhase(
             hintedState,
             hintedBlockedReason,
             hintedFailureSignature,
+            hintedVerificationCommand,
+            preservedVerificationBlocker: preservesCarriedVerificationBlocker
+              ? carriedVerificationBlocker
+              : null,
             buildCodexFailureContext: args.buildCodexFailureContext,
             applyFailureSignature: args.applyFailureSignature,
             normalizeBlockerSignature: args.normalizeBlockerSignature,
@@ -948,10 +1052,25 @@ export async function executeCodexTurnPhase(
               },
             )
           : null;
-        const postRunState = postRunSnapshot
+        const lifecyclePostRunState = postRunSnapshot
           ? postRunSnapshot.nextState
           : (hintedState ??
             args.inferStateWithoutPullRequest(record, workspaceStatus));
+        const carriedVerificationCommandPassed =
+          carriedVerificationBlocker !== null &&
+          codexVerificationCommand !== null &&
+          codexTurnVerificationIncludesCommand(
+            codexVerificationCommand,
+            carriedVerificationBlocker.lastFailureContext.command,
+          );
+        const preserveCarriedVerificationBlocker =
+          carriedVerificationBlocker !== null &&
+          !carriedVerificationCommandPassed;
+        const postRunState =
+          preserveCarriedVerificationBlocker &&
+          lifecyclePostRunState !== "addressing_review"
+            ? "blocked"
+            : lifecyclePostRunState;
         const codexTurnVerificationTimelineArtifacts =
           buildPostPublicationCodexVerificationTimelineArtifacts({
             record,
@@ -988,23 +1107,38 @@ export async function executeCodexTurnPhase(
           ...processedReviewThreadPatch,
           ...reviewFollowUpPatch,
           blocked_verification_retry_count: pr
-            ? 0
+            ? preserveCarriedVerificationBlocker
+              ? carriedVerificationBlocker.blockedVerificationRetryCount
+              : 0
             : record.blocked_verification_retry_count,
-          repeated_blocker_count: 0,
+          repeated_blocker_count: preserveCarriedVerificationBlocker
+            ? carriedVerificationBlocker.repeatedBlockerCount
+            : 0,
           last_blocker_signature: null,
           stale_stabilizing_no_pr_recovery_count:
             preserveStaleNoPrRecoveryTracking
               ? preTurnStaleNoPrRecoveryCount
               : 0,
-          last_error: preserveStaleNoPrRecoveryTracking
+          last_error: preserveCarriedVerificationBlocker
+            ? carriedVerificationBlocker.lastError
+            : preserveStaleNoPrRecoveryTracking
             ? preTurnLastError
             : postRunState === "blocked" && postRunSnapshot?.failureContext
               ? truncate(postRunSnapshot.failureContext.summary, 1000)
               : record.last_error,
-          last_failure_context: preserveStaleNoPrRecoveryTracking
+          last_failure_context: preserveCarriedVerificationBlocker
+            ? carriedVerificationBlocker.lastFailureContext
+            : preserveStaleNoPrRecoveryTracking
             ? preTurnFailureContext
             : (postRunSnapshot?.failureContext ?? null),
-          ...(preserveStaleNoPrRecoveryTracking
+          ...(preserveCarriedVerificationBlocker
+            ? {
+                last_failure_signature:
+                  carriedVerificationBlocker.lastFailureSignature,
+                repeated_failure_signature_count:
+                  carriedVerificationBlocker.repeatedFailureSignatureCount,
+              }
+            : preserveStaleNoPrRecoveryTracking
             ? {
                 last_failure_signature: preTurnFailureSignature,
                 repeated_failure_signature_count: 0,
@@ -1014,7 +1148,9 @@ export async function executeCodexTurnPhase(
                 postRunSnapshot?.failureContext ?? null,
               )),
           blocked_reason:
-            pr && postRunState === "blocked"
+            preserveCarriedVerificationBlocker
+              ? "verification"
+              : pr && postRunState === "blocked"
               ? args.blockedReasonFromReviewState(
                   postRunSnapshot?.recordForState ?? record,
                   pr,

--- a/src/run-once-turn-verification-evidence.ts
+++ b/src/run-once-turn-verification-evidence.ts
@@ -76,13 +76,63 @@ function splitCodexTurnVerificationEntries(value: string): string[] {
     .filter((candidate) => candidate.length > 0);
 }
 
-function stripVerificationOutcomeSuffix(value: string): string {
-  return normalizeCodexTurnVerificationCommandEntry(
-    value.replace(
-      /(?:\s*:\s*|\s+(?:-|—)\s+|\s*\(\s*)(?:passed|pass|success|succeeded|failed|failure|error|timeout|blocked)\b.*$/iu,
-      "",
-    ),
+type CodexTurnVerificationOutcome = "passed" | "failed";
+
+function normalizedCodexTurnVerificationOutcome(
+  value: string,
+): CodexTurnVerificationOutcome {
+  return /^(?:passed|pass|success|succeeded)$/iu.test(value)
+    ? "passed"
+    : "failed";
+}
+
+function isUnambiguousSpaceSeparatedOutcomeCommand(value: string): boolean {
+  const normalized = value.replace(/^rtk\s+/u, "").trim();
+  return /^(?:npm|pnpm|yarn|bun)\s+(?:test|run\s+\S+)$/u.test(normalized);
+}
+
+function hasSpaceSeparatedOutcomeSuffix(value: string): boolean {
+  return /\s+(?:passed|pass|success|succeeded|failed|failure|error|timeout|blocked)[.!]?$/iu.test(
+    normalizeCodexTurnVerificationCommandEntry(value),
   );
+}
+
+function splitVerificationOutcomeSuffix(value: string): {
+  command: string;
+  outcome: CodexTurnVerificationOutcome;
+} | null {
+  const normalized = normalizeCodexTurnVerificationCommandEntry(value);
+  const delimitedOutcome = normalized.match(
+    /^(.*\S)(?:\s*:\s+|\s+(?:-|—)\s+|\s*\(\s*)(passed|pass|success|succeeded|failed|failure|error|timeout|blocked)(?=$|[\s:.,;)]).*$/iu,
+  );
+  if (delimitedOutcome?.[1] && delimitedOutcome[2]) {
+    return {
+      command: normalizeCodexTurnVerificationCommandEntry(delimitedOutcome[1]),
+      outcome: normalizedCodexTurnVerificationOutcome(delimitedOutcome[2]),
+    };
+  }
+
+  const spaceSeparatedOutcome = normalized.match(
+    /^(.*\S)\s+(passed|pass|success|succeeded|failed|failure|error|timeout|blocked)[.!]?$/iu,
+  );
+  const command = spaceSeparatedOutcome?.[1]?.trim() ?? "";
+  const outcome = spaceSeparatedOutcome?.[2] ?? "";
+  if (
+    !command ||
+    !outcome ||
+    !isUnambiguousSpaceSeparatedOutcomeCommand(command)
+  ) {
+    return null;
+  }
+  return {
+    command: normalizeCodexTurnVerificationCommandEntry(command),
+    outcome: normalizedCodexTurnVerificationOutcome(outcome),
+  };
+}
+
+function stripVerificationOutcomeSuffix(value: string): string {
+  return splitVerificationOutcomeSuffix(value)?.command ??
+    normalizeCodexTurnVerificationCommandEntry(value);
 }
 
 function verificationCommandComparisonVariants(value: string): string[] {
@@ -143,11 +193,60 @@ export function explicitPassingCodexTurnVerificationCommand(
   if (!value) {
     return null;
   }
-  if (hasExplicitNegativeCodexTurnVerificationOutcome(value)) {
-    return null;
-  }
   if (!hasExplicitCodexTurnVerificationCommandEvidence(value)) {
     return null;
+  }
+  const entries = splitCodexTurnVerificationEntries(value);
+  const passingCommands: string[] = [];
+  let hasExplicitFailure = false;
+  for (const [index, entry] of entries.entries()) {
+    const inlineOutcome = splitVerificationOutcomeSuffix(entry);
+    const nextEntry = entries[index + 1] ?? "";
+    const hasAdjacentPassingOutcome =
+      CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(entry) &&
+      /^(?:passed|pass|success|succeeded)\b/iu.test(nextEntry);
+    const hasAdjacentFailedOutcome =
+      CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(entry) &&
+      /^(?:failed|failure|error|timeout|blocked)\b/iu.test(nextEntry);
+    if (
+      inlineOutcome?.outcome === "passed" ||
+      hasAdjacentPassingOutcome
+    ) {
+      const command = inlineOutcome?.command ?? entry;
+      if (CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(command)) {
+        passingCommands.push(command);
+      }
+    }
+    if (
+      inlineOutcome?.outcome === "failed" ||
+      hasAdjacentFailedOutcome
+    ) {
+      hasExplicitFailure = true;
+    }
+  }
+  if (hasExplicitFailure) {
+    return passingCommands.length > 0
+      ? [...new Set(passingCommands)].join("; ")
+      : null;
+  }
+  if (hasExplicitNegativeCodexTurnVerificationOutcome(value)) {
+    return passingCommands.length > 0
+      ? [...new Set(passingCommands)].join("; ")
+      : null;
+  }
+  if (
+    entries.some(
+      (entry) =>
+        hasSpaceSeparatedOutcomeSuffix(entry) &&
+        splitVerificationOutcomeSuffix(entry) === null,
+    )
+  ) {
+    return passingCommands.length > 0
+      ? [...new Set(passingCommands)].join("; ")
+      : null;
+  }
+  if (passingCommands.length > 0) {
+    return [...new Set(passingCommands)].join("; ");
   }
   return value;
 }
@@ -168,16 +267,13 @@ export function explicitFailedCodexTurnVerificationCommand(
   const entries = splitCodexTurnVerificationEntries(value);
   const explicitCommands: string[] = [];
   for (const [index, entry] of entries.entries()) {
-    const strippedEntry = stripVerificationOutcomeSuffix(entry);
-    const hasInlineFailure =
-      strippedEntry !== normalizeCodexTurnVerificationCommandEntry(entry) &&
-      hasExplicitFailedCodexTurnVerificationOutcome(entry);
+    const inlineOutcome = splitVerificationOutcomeSuffix(entry);
     const nextEntry = entries[index + 1] ?? "";
     const hasAdjacentFailure =
       CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(entry) &&
       /^(?:failed|failure|error|timeout|blocked)\b/iu.test(nextEntry);
-    const command = hasInlineFailure
-      ? strippedEntry
+    const command = inlineOutcome?.outcome === "failed"
+      ? inlineOutcome.command
       : hasAdjacentFailure
         ? entry
         : null;

--- a/src/run-once-turn-verification-evidence.ts
+++ b/src/run-once-turn-verification-evidence.ts
@@ -131,6 +131,16 @@ function splitVerificationOutcomeSuffix(value: string): {
 }
 
 function stripVerificationOutcomeSuffix(value: string): string {
+  const entries = splitCodexTurnVerificationEntries(value);
+  if (
+    entries.length === 2 &&
+    CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(entries[0]!) &&
+    /^(?:passed|pass|success|succeeded|failed|failure|error|timeout|blocked|skipped|skip|not\s+run)[.!]?$/iu.test(
+      entries[1]!,
+    )
+  ) {
+    return entries[0]!;
+  }
   return splitVerificationOutcomeSuffix(value)?.command ??
     normalizeCodexTurnVerificationCommandEntry(value);
 }
@@ -326,7 +336,7 @@ export function explicitFailedCodexTurnVerificationCommand(
   if (!hasExplicitCodexTurnVerificationCommandEvidence(value)) {
     return null;
   }
-  if (!hasExplicitFailedCodexTurnVerificationOutcome(value)) {
+  if (!hasExplicitNegativeCodexTurnVerificationOutcome(value)) {
     return null;
   }
   const entries = splitCodexTurnVerificationEntries(value);
@@ -336,7 +346,7 @@ export function explicitFailedCodexTurnVerificationCommand(
     const nextEntry = entries[index + 1] ?? "";
     const hasAdjacentFailure =
       CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(entry) &&
-      /^(?:failed|failure|error|timeout|blocked)\b/iu.test(nextEntry);
+      /^(?:failed|failure|error|timeout|blocked|skipped|skip|not\s+run)\b/iu.test(nextEntry);
     const command = inlineOutcome?.outcome === "failed"
       ? inlineOutcome.command
       : hasAdjacentFailure

--- a/src/run-once-turn-verification-evidence.ts
+++ b/src/run-once-turn-verification-evidence.ts
@@ -92,7 +92,7 @@ function isUnambiguousSpaceSeparatedOutcomeCommand(value: string): boolean {
 }
 
 function hasSpaceSeparatedOutcomeSuffix(value: string): boolean {
-  return /\s+(?:passed|pass|success|succeeded|failed|failure|error|timeout|blocked)[.!]?$/iu.test(
+  return /\s+(?:passed|pass|success|succeeded|failed|failure|error|timeout|blocked|skipped|skip|not\s+run)[.!]?$/iu.test(
     normalizeCodexTurnVerificationCommandEntry(value),
   );
 }
@@ -103,7 +103,7 @@ function splitVerificationOutcomeSuffix(value: string): {
 } | null {
   const normalized = normalizeCodexTurnVerificationCommandEntry(value);
   const delimitedOutcome = normalized.match(
-    /^(.*\S)(?:\s*:\s+|\s+(?:-|—)\s+|\s*\(\s*)(passed|pass|success|succeeded|failed|failure|error|timeout|blocked)(?=$|[\s:.,;)]).*$/iu,
+    /^(.*\S)(?:\s*:\s+|\s+(?:-|—)\s+|\s*\(\s*)(passed|pass|success|succeeded|failed|failure|error|timeout|blocked|skipped|skip|not\s+run)(?=$|[\s:.,;)]).*$/iu,
   );
   if (delimitedOutcome?.[1] && delimitedOutcome[2]) {
     return {
@@ -113,7 +113,7 @@ function splitVerificationOutcomeSuffix(value: string): {
   }
 
   const spaceSeparatedOutcome = normalized.match(
-    /^(.*\S)\s+(passed|pass|success|succeeded|failed|failure|error|timeout|blocked)[.!]?$/iu,
+    /^(.*\S)\s+(passed|pass|success|succeeded|failed|failure|error|timeout|blocked|skipped|skip|not\s+run)[.!]?$/iu,
   );
   const command = spaceSeparatedOutcome?.[1]?.trim() ?? "";
   const outcome = spaceSeparatedOutcome?.[2] ?? "";
@@ -223,7 +223,7 @@ export function explicitPassingCodexTurnVerificationCommand(
       /^(?:passed|pass|success|succeeded)\b/iu.test(nextEntry);
     const hasAdjacentFailedOutcome =
       CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(entry) &&
-      /^(?:failed|failure|error|timeout|blocked)\b/iu.test(nextEntry);
+      /^(?:failed|failure|error|timeout|blocked|skipped|skip|not\s+run)\b/iu.test(nextEntry);
     if (
       inlineOutcome?.outcome === "passed" ||
       hasAdjacentPassingOutcome

--- a/src/run-once-turn-verification-evidence.ts
+++ b/src/run-once-turn-verification-evidence.ts
@@ -145,6 +145,22 @@ function verificationCommandComparisonVariants(value: string): string[] {
     );
 }
 
+function verificationCommandsMatch(left: string, right: string): boolean {
+  const rightVariants = new Set(verificationCommandComparisonVariants(right));
+  return verificationCommandComparisonVariants(left)
+    .some((candidate) => rightVariants.has(candidate));
+}
+
+function uniqueVerificationCommands(commands: readonly string[]): string[] {
+  const uniqueCommands: string[] = [];
+  for (const command of commands) {
+    if (!uniqueCommands.some((candidate) => verificationCommandsMatch(candidate, command))) {
+      uniqueCommands.push(command);
+    }
+  }
+  return uniqueCommands;
+}
+
 export function codexTurnVerificationIncludesCommand(
   tests: string | null | undefined,
   expectedCommand: string | null | undefined,
@@ -198,7 +214,7 @@ export function explicitPassingCodexTurnVerificationCommand(
   }
   const entries = splitCodexTurnVerificationEntries(value);
   const passingCommands: string[] = [];
-  let hasExplicitFailure = false;
+  const failedCommands: string[] = [];
   for (const [index, entry] of entries.entries()) {
     const inlineOutcome = splitVerificationOutcomeSuffix(entry);
     const nextEntry = entries[index + 1] ?? "";
@@ -221,17 +237,26 @@ export function explicitPassingCodexTurnVerificationCommand(
       inlineOutcome?.outcome === "failed" ||
       hasAdjacentFailedOutcome
     ) {
-      hasExplicitFailure = true;
+      const command = inlineOutcome?.command ?? entry;
+      if (CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(command)) {
+        failedCommands.push(command);
+      }
     }
   }
-  if (hasExplicitFailure) {
-    return passingCommands.length > 0
-      ? [...new Set(passingCommands)].join("; ")
+  const confirmedPassingCommands = uniqueVerificationCommands(passingCommands)
+    .filter((passingCommand) =>
+      !failedCommands.some((failedCommand) =>
+        verificationCommandsMatch(passingCommand, failedCommand)
+      )
+    );
+  if (failedCommands.length > 0) {
+    return confirmedPassingCommands.length > 0
+      ? confirmedPassingCommands.join("; ")
       : null;
   }
   if (hasExplicitNegativeCodexTurnVerificationOutcome(value)) {
-    return passingCommands.length > 0
-      ? [...new Set(passingCommands)].join("; ")
+    return confirmedPassingCommands.length > 0
+      ? confirmedPassingCommands.join("; ")
       : null;
   }
   if (
@@ -241,12 +266,12 @@ export function explicitPassingCodexTurnVerificationCommand(
         splitVerificationOutcomeSuffix(entry) === null,
     )
   ) {
-    return passingCommands.length > 0
-      ? [...new Set(passingCommands)].join("; ")
+    return confirmedPassingCommands.length > 0
+      ? confirmedPassingCommands.join("; ")
       : null;
   }
-  if (passingCommands.length > 0) {
-    return [...new Set(passingCommands)].join("; ");
+  if (confirmedPassingCommands.length > 0) {
+    return confirmedPassingCommands.join("; ");
   }
   return value;
 }

--- a/src/run-once-turn-verification-evidence.ts
+++ b/src/run-once-turn-verification-evidence.ts
@@ -251,6 +251,46 @@ export function explicitPassingCodexTurnVerificationCommand(
   return value;
 }
 
+export function explicitSinglePassingCodexTurnVerificationCommand(
+  tests: string | null | undefined,
+): string | null {
+  const value = tests?.trim();
+  if (
+    !value ||
+    hasExplicitNegativeCodexTurnVerificationOutcome(value)
+  ) {
+    return null;
+  }
+
+  const entries = splitCodexTurnVerificationEntries(value);
+  const commands: string[] = [];
+  for (let index = 0; index < entries.length; index += 1) {
+    const entry = entries[index]!;
+    if (!CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(entry)) {
+      return null;
+    }
+
+    const inlineOutcome = splitVerificationOutcomeSuffix(entry);
+    if (inlineOutcome?.outcome === "failed") {
+      return null;
+    }
+    if (
+      hasSpaceSeparatedOutcomeSuffix(entry) &&
+      inlineOutcome === null
+    ) {
+      return null;
+    }
+
+    const nextEntry = entries[index + 1] ?? "";
+    if (/^(?:passed|pass|success|succeeded)[.!]?$/iu.test(nextEntry)) {
+      index += 1;
+    }
+    commands.push(inlineOutcome?.command ?? entry);
+  }
+
+  return commands.length === 1 ? commands[0]! : null;
+}
+
 export function explicitFailedCodexTurnVerificationCommand(
   tests: string | null | undefined,
 ): string | null {

--- a/src/run-once-turn-verification-evidence.ts
+++ b/src/run-once-turn-verification-evidence.ts
@@ -69,10 +69,30 @@ function codexTurnVerificationCommandEntries(value: string | null | undefined): 
   return [...new Set([normalized, ...splitEntries])];
 }
 
+function splitCodexTurnVerificationEntries(value: string): string[] {
+  return value
+    .split(/[\n;]+/)
+    .map(normalizeCodexTurnVerificationCommandEntry)
+    .filter((candidate) => candidate.length > 0);
+}
+
+function stripVerificationOutcomeSuffix(value: string): string {
+  return normalizeCodexTurnVerificationCommandEntry(
+    value.replace(
+      /(?:\s*:\s*|\s+(?:-|—)\s+|\s*\(\s*)(?:passed|pass|success|succeeded|failed|failure|error|timeout|blocked)\b.*$/iu,
+      "",
+    ),
+  );
+}
+
 function verificationCommandComparisonVariants(value: string): string[] {
   const normalized = normalizeCodexTurnVerificationCommandEntry(value);
-  const withoutRtk = normalized.replace(/^rtk\s+/u, "").trim();
-  return [...new Set([normalized, withoutRtk].filter((candidate) => candidate.length > 0))];
+  const withoutOutcome = stripVerificationOutcomeSuffix(normalized);
+  return [normalized, withoutOutcome]
+    .flatMap((candidate) => [candidate, candidate.replace(/^rtk\s+/u, "").trim()])
+    .filter((candidate, index, candidates) =>
+      candidate.length > 0 && candidates.indexOf(candidate) === index
+    );
 }
 
 export function codexTurnVerificationIncludesCommand(
@@ -145,7 +165,27 @@ export function explicitFailedCodexTurnVerificationCommand(
   if (!hasExplicitFailedCodexTurnVerificationOutcome(value)) {
     return null;
   }
-  return value;
+  const entries = splitCodexTurnVerificationEntries(value);
+  const explicitCommands: string[] = [];
+  for (const [index, entry] of entries.entries()) {
+    const strippedEntry = stripVerificationOutcomeSuffix(entry);
+    const hasInlineFailure =
+      strippedEntry !== normalizeCodexTurnVerificationCommandEntry(entry) &&
+      hasExplicitFailedCodexTurnVerificationOutcome(entry);
+    const nextEntry = entries[index + 1] ?? "";
+    const hasAdjacentFailure =
+      CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(entry) &&
+      /^(?:failed|failure|error|timeout|blocked)\b/iu.test(nextEntry);
+    const command = hasInlineFailure
+      ? strippedEntry
+      : hasAdjacentFailure
+        ? entry
+        : null;
+    if (command && CODEX_TURN_VERIFICATION_COMMAND_PATTERN.test(command)) {
+      explicitCommands.push(command);
+    }
+  }
+  return explicitCommands[0] ?? null;
 }
 
 export function conciseCodexVerificationSummary(summary: string | null | undefined): string {

--- a/src/supervisor/blocked-turn-pr-reconciliation.test.ts
+++ b/src/supervisor/blocked-turn-pr-reconciliation.test.ts
@@ -1,0 +1,128 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  blockedTurnPullRequestReconciliationStatusLine,
+  reconcileBlockedTurnPullRequest,
+} from "./blocked-turn-pr-reconciliation";
+import {
+  createPullRequest,
+  createRecord,
+} from "./supervisor-test-helpers";
+
+test("reconcileBlockedTurnPullRequest binds one same-repository open PR after action hydration", async () => {
+  const branch = "codex/issue-2447";
+  const record = createRecord({
+    issue_number: 2447,
+    branch,
+    pr_number: null,
+  });
+  const candidate = createPullRequest({
+    number: 2449,
+    baseRefName: "main",
+    headRefName: branch,
+    headRefOid: "head-2449",
+    headRepositoryOwner: { login: "owner" },
+    isCrossRepository: false,
+    state: "OPEN",
+    mergedAt: undefined,
+  });
+  let hydrated = false;
+
+  const result = await reconcileBlockedTurnPullRequest({
+    github: {
+      findOpenPullRequestsForBranch: async () => [candidate],
+      getPullRequestIfExists: async (prNumber, options) => {
+        assert.equal(prNumber, candidate.number);
+        assert.equal(options?.purpose, "action");
+        hydrated = true;
+        return candidate;
+      },
+    },
+    state: {
+      activeIssueNumber: null,
+      issues: { "2447": record },
+    },
+    record,
+    defaultBranch: "main",
+    repoSlug: "owner/repo",
+    purpose: "action",
+  });
+
+  assert.equal(result.kind, "bound");
+  assert.equal(result.pullRequest?.number, candidate.number);
+  assert.equal(hydrated, true);
+});
+
+test("reconcileBlockedTurnPullRequest rejects a unique same-name fork PR", async () => {
+  const branch = "codex/issue-2447";
+  const record = createRecord({
+    issue_number: 2447,
+    branch,
+    pr_number: null,
+  });
+  const forkCandidate = createPullRequest({
+    number: 2451,
+    baseRefName: "main",
+    headRefName: branch,
+    headRefOid: "fork-head-2451",
+    headRepositoryOwner: { login: "fork-owner" },
+    isCrossRepository: true,
+    state: "OPEN",
+    mergedAt: null,
+  });
+
+  const result = await reconcileBlockedTurnPullRequest({
+    github: {
+      findOpenPullRequestsForBranch: async () => [forkCandidate],
+      getPullRequestIfExists: async () => {
+        throw new Error("fork candidates must not be hydrated or bound");
+      },
+    },
+    state: {
+      activeIssueNumber: null,
+      issues: { "2447": record },
+    },
+    record,
+    defaultBranch: "main",
+    repoSlug: "owner/repo",
+  });
+
+  assert.equal(result.kind, "ambiguous");
+  assert.match(result.diagnostic, /no_unique_canonical_open_pr/);
+});
+
+test("reconcileBlockedTurnPullRequest fails closed without ambiguity-aware branch lookup", async () => {
+  const record = createRecord({
+    issue_number: 2447,
+    branch: "codex/issue-2447",
+    pr_number: null,
+  });
+  const result = await reconcileBlockedTurnPullRequest({
+    github: {
+      resolvePullRequestForBranch: async () =>
+        createPullRequest({ number: 2452 }),
+    },
+    state: {
+      activeIssueNumber: null,
+      issues: { "2447": record },
+    },
+    record,
+    defaultBranch: "main",
+    repoSlug: "owner/repo",
+  });
+
+  assert.equal(result.kind, "error");
+  assert.match(result.diagnostic, /ambiguity_aware_lookup_unavailable/);
+});
+
+test("blockedTurnPullRequestReconciliationStatusLine extracts PR diagnostics from composite summaries", () => {
+  assert.equal(
+    blockedTurnPullRequestReconciliationStatusLine(
+      createRecord({
+        last_tracked_pr_progress_summary:
+          "blocked_turn_workspace_reconciliation=error branch=codex/issue-2447 | blocked_turn_pr_reconciliation=absent branch=codex/issue-2447",
+      }),
+    ),
+    "blocked_turn_pr_reconciliation=absent branch=codex/issue-2447",
+  );
+});

--- a/src/supervisor/blocked-turn-pr-reconciliation.ts
+++ b/src/supervisor/blocked-turn-pr-reconciliation.ts
@@ -34,6 +34,31 @@ export type BlockedTurnPullRequestReconciliation =
       pullRequest: null;
     };
 
+export function hasBlockedTurnVerificationProvenance(
+  record: Pick<
+    IssueRunRecord,
+    "blocked_reason" | "issue_number" | "last_error" | "last_failure_context"
+  >,
+): boolean {
+  if (record.blocked_reason !== "verification") {
+    return false;
+  }
+
+  if (
+    record.last_failure_context?.details.includes(
+      "structured_blocked_reason=verification",
+    ) === true
+  ) {
+    return true;
+  }
+
+  const canonicalSummary = `Codex reported blocked for issue #${record.issue_number}.`;
+  return (
+    record.last_failure_context?.summary === canonicalSummary ||
+    record.last_error === canonicalSummary
+  );
+}
+
 export function blockedTurnPullRequestReconciliationStatusLine(
   record: Pick<
     IssueRunRecord,

--- a/src/supervisor/blocked-turn-pr-reconciliation.ts
+++ b/src/supervisor/blocked-turn-pr-reconciliation.ts
@@ -1,0 +1,189 @@
+import type {
+  GitHubPullRequest,
+  IssueRunRecord,
+  SupervisorStateFile,
+} from "../core/types";
+
+type ReadPurpose = "status" | "action";
+
+export interface BlockedTurnPullRequestLookup {
+  findOpenPullRequestsForBranch?: (
+    branch: string,
+    options?: { purpose?: ReadPurpose },
+  ) => Promise<GitHubPullRequest[]>;
+  getPullRequestIfExists?: (
+    prNumber: number,
+    options?: { purpose?: ReadPurpose },
+  ) => Promise<GitHubPullRequest | null>;
+  resolvePullRequestForBranch?: (
+    branch: string,
+    trackedPrNumber: number | null,
+    options?: { purpose?: ReadPurpose },
+  ) => Promise<GitHubPullRequest | null>;
+}
+
+export type BlockedTurnPullRequestReconciliation =
+  | {
+      kind: "bound";
+      diagnostic: string;
+      pullRequest: GitHubPullRequest;
+    }
+  | {
+      kind: "absent" | "ambiguous" | "error";
+      diagnostic: string;
+      pullRequest: null;
+    };
+
+export function blockedTurnPullRequestReconciliationStatusLine(
+  record: Pick<
+    IssueRunRecord,
+    | "blocked_reason"
+    | "issue_number"
+    | "last_tracked_pr_progress_summary"
+    | "pr_number"
+    | "state"
+  > | null,
+): string | null {
+  if (!record) {
+    return null;
+  }
+  const summary = record.last_tracked_pr_progress_summary ?? "";
+  const reconciliationDiagnostic = summary
+    .split(" | ")
+    .find((part) => part.startsWith("blocked_turn_pr_reconciliation="));
+  if (reconciliationDiagnostic) {
+    return reconciliationDiagnostic;
+  }
+  if (
+    record.state === "addressing_review" &&
+    record.blocked_reason === "verification" &&
+    record.pr_number !== null
+  ) {
+    return (
+      `blocked_turn_pr_reconciliation=scheduled_review_repair ` +
+      `issue=#${record.issue_number} pr=#${record.pr_number} ` +
+      "independent_verification_blocker=carried"
+    );
+  }
+  return null;
+}
+
+function compactDiagnosticDetail(value: unknown): string {
+  const message = value instanceof Error ? value.message : String(value);
+  return message.replace(/\s+/g, "_").slice(0, 300) || "unknown";
+}
+
+function candidateNumbers(candidates: readonly GitHubPullRequest[]): string {
+  return candidates.length === 0
+    ? "none"
+    : candidates.map((candidate) => `#${candidate.number}`).join(",");
+}
+
+export async function reconcileBlockedTurnPullRequest(args: {
+  github: BlockedTurnPullRequestLookup;
+  state: SupervisorStateFile;
+  record: IssueRunRecord;
+  defaultBranch: string;
+  repoSlug: string;
+  purpose?: ReadPurpose;
+}): Promise<BlockedTurnPullRequestReconciliation> {
+  const branchOwners = Object.values(args.state.issues).filter(
+    (candidate) =>
+      candidate.issue_number !== args.record.issue_number &&
+      candidate.branch === args.record.branch,
+  );
+  if (branchOwners.length > 0) {
+    return {
+      kind: "ambiguous",
+      diagnostic:
+        `blocked_turn_pr_reconciliation=ambiguous branch=${args.record.branch} ` +
+        `reason=shared_recorded_branch owners=${branchOwners
+          .map((candidate) => `#${candidate.issue_number}`)
+          .join(",")}`,
+      pullRequest: null,
+    };
+  }
+
+  try {
+    const purpose = args.purpose ?? "action";
+    if (!args.github.findOpenPullRequestsForBranch) {
+      return {
+        kind: "error",
+        diagnostic:
+          `blocked_turn_pr_reconciliation=error branch=${args.record.branch} ` +
+          "detail=ambiguity_aware_lookup_unavailable",
+        pullRequest: null,
+      };
+    }
+    const candidates = await args.github.findOpenPullRequestsForBranch(
+      args.record.branch,
+      { purpose },
+    );
+
+    if (candidates.length === 0) {
+      return {
+        kind: "absent",
+        diagnostic: `blocked_turn_pr_reconciliation=absent branch=${args.record.branch}`,
+        pullRequest: null,
+      };
+    }
+
+    const expectedHeadOwner = args.repoSlug.split("/", 1)[0]?.toLowerCase() ?? "";
+    const canonicalCandidates = candidates.filter(
+      (candidate) =>
+        candidate.state === "OPEN" &&
+        candidate.mergedAt == null &&
+        candidate.headRefName === args.record.branch &&
+        candidate.baseRefName === args.defaultBranch &&
+        candidate.isCrossRepository === false &&
+        candidate.headRepositoryOwner?.login?.toLowerCase() === expectedHeadOwner,
+    );
+    if (candidates.length !== 1 || canonicalCandidates.length !== 1) {
+      return {
+        kind: "ambiguous",
+        diagnostic:
+          `blocked_turn_pr_reconciliation=ambiguous branch=${args.record.branch} ` +
+          `reason=no_unique_canonical_open_pr candidates=${candidateNumbers(candidates)}`,
+        pullRequest: null,
+      };
+    }
+
+    const candidate = canonicalCandidates[0]!;
+    const hydratedPullRequest = args.github.getPullRequestIfExists
+      ? await args.github.getPullRequestIfExists(candidate.number, { purpose })
+      : candidate;
+    if (
+      !hydratedPullRequest ||
+      hydratedPullRequest.number !== candidate.number ||
+      hydratedPullRequest.state !== "OPEN" ||
+      hydratedPullRequest.mergedAt != null ||
+      hydratedPullRequest.headRefName !== args.record.branch ||
+      hydratedPullRequest.baseRefName !== args.defaultBranch ||
+      hydratedPullRequest.headRefOid !== candidate.headRefOid
+    ) {
+      return {
+        kind: "ambiguous",
+        diagnostic:
+          `blocked_turn_pr_reconciliation=ambiguous branch=${args.record.branch} ` +
+          `reason=candidate_changed_during_hydration candidates=${candidateNumbers(candidates)}`,
+        pullRequest: null,
+      };
+    }
+    const pullRequest = hydratedPullRequest;
+    return {
+      kind: "bound",
+      diagnostic:
+        `blocked_turn_pr_reconciliation=bound branch=${args.record.branch} ` +
+        `pr=#${pullRequest.number} head=${pullRequest.headRefOid}`,
+      pullRequest,
+    };
+  } catch (error) {
+    return {
+      kind: "error",
+      diagnostic:
+        `blocked_turn_pr_reconciliation=error branch=${args.record.branch} ` +
+        `detail=${compactDiagnosticDetail(error)}`,
+      pullRequest: null,
+    };
+  }
+}

--- a/src/supervisor/independent-verification-blocker.test.ts
+++ b/src/supervisor/independent-verification-blocker.test.ts
@@ -47,6 +47,19 @@ test("independentVerificationBlockerSnapshot carries a queued tracked verifier i
     ),
     null,
   );
+  assert.ok(
+    independentVerificationBlockerSnapshot(
+      createRecord({ ...tracked, state: "blocked" }),
+    ),
+    "a blocked tracked verifier remains authoritative for the next selection",
+  );
+  assert.equal(
+    independentVerificationBlockerSnapshot(
+      createRecord({ ...tracked, state: "blocked", blocked_reason: "secrets" }),
+    ),
+    null,
+    "unrelated tracked blockers are not treated as verifier snapshots",
+  );
 });
 
 test("preserveIndependentVerificationBlockerPatch nests a later hard blocker without replacing the verifier", () => {

--- a/src/supervisor/independent-verification-blocker.test.ts
+++ b/src/supervisor/independent-verification-blocker.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  independentVerificationBlockerSnapshot,
+  preserveIndependentVerificationBlockerPatch,
+} from "./independent-verification-blocker";
+import { createRecord } from "./supervisor-test-helpers";
+
+function verifierFailureContext() {
+  return {
+    category: "blocked" as const,
+    summary: "Independent image verification remains blocked.",
+    signature: "verification:images",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-12T00:00:00Z",
+  };
+}
+
+test("independentVerificationBlockerSnapshot carries a queued tracked verifier into dispatch", () => {
+  const failureContext = verifierFailureContext();
+  const tracked = createRecord({
+    issue_number: 2447,
+    state: "queued",
+    pr_number: 2451,
+    blocked_reason: "verification",
+    last_error: failureContext.summary,
+    last_failure_context: failureContext,
+    last_failure_signature: failureContext.signature,
+    repeated_failure_signature_count: 3,
+    last_blocker_signature: "verification:images",
+    repeated_blocker_count: 2,
+    blocked_verification_retry_count: 1,
+  });
+
+  const snapshot = independentVerificationBlockerSnapshot(tracked);
+
+  assert.ok(snapshot);
+  assert.equal(snapshot.lastFailureContext.command, "npm run verify:images");
+  assert.equal(snapshot.repeatedFailureSignatureCount, 3);
+  assert.equal(snapshot.blockedVerificationRetryCount, 1);
+  assert.equal(
+    independentVerificationBlockerSnapshot(
+      createRecord({ ...tracked, pr_number: null }),
+    ),
+    null,
+  );
+});
+
+test("preserveIndependentVerificationBlockerPatch nests a later hard blocker without replacing the verifier", () => {
+  const failureContext = verifierFailureContext();
+  const snapshot = independentVerificationBlockerSnapshot(
+    createRecord({
+      issue_number: 2447,
+      state: "addressing_review",
+      pr_number: 2451,
+      blocked_reason: "verification",
+      last_error: failureContext.summary,
+      last_failure_context: failureContext,
+      last_failure_signature: failureContext.signature,
+      repeated_failure_signature_count: 3,
+      last_blocker_signature: "verification:images",
+      repeated_blocker_count: 2,
+      blocked_verification_retry_count: 1,
+    }),
+  );
+  assert.ok(snapshot);
+
+  const patch = preserveIndependentVerificationBlockerPatch(snapshot, {
+    state: "blocked",
+    blocked_reason: "secrets",
+    last_error: "A deployment token is required.",
+    last_failure_kind: null,
+    last_failure_context: {
+      category: "blocked",
+      summary: "Review repair cannot continue without a token.",
+      signature: "secrets:deployment-token",
+      command: null,
+      details: ["Provide DEPLOY_TOKEN."],
+      url: null,
+      updated_at: "2026-07-12T00:05:00Z",
+    },
+  });
+
+  assert.equal(patch.state, "blocked");
+  assert.equal(patch.blocked_reason, "verification");
+  assert.equal(patch.last_failure_context?.command, "npm run verify:images");
+  assert.equal(patch.last_failure_signature, "verification:images");
+  assert.equal(patch.repeated_failure_signature_count, 3);
+  assert.equal(patch.blocked_verification_retry_count, 1);
+  assert.match(patch.last_error ?? "", /deployment token/i);
+  assert.ok(
+    patch.last_failure_context?.details.includes(
+      "review_repair_interruption_blocked_reason=secrets",
+    ),
+  );
+  assert.ok(
+    patch.last_failure_context?.details.includes(
+      "review_repair_interruption_detail=Provide DEPLOY_TOKEN.",
+    ),
+  );
+
+  let rollingSnapshot = snapshot;
+  let rollingPatch = patch;
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    rollingSnapshot = {
+      ...rollingSnapshot,
+      lastError: rollingPatch.last_error ?? null,
+      lastFailureContext:
+        rollingPatch.last_failure_context ?? rollingSnapshot.lastFailureContext,
+    };
+    rollingPatch = preserveIndependentVerificationBlockerPatch(
+      rollingSnapshot,
+      {
+        state: "failed",
+        blocked_reason: null,
+        last_error: `Transient review repair failure ${attempt}: ${"x".repeat(100)}`,
+        last_failure_kind: "command_error",
+        last_failure_context: {
+          category: "codex",
+          summary: `Transient review repair failure ${attempt}.`,
+          signature: `review-repair-${attempt}`,
+          command: null,
+          details: [`attempt=${attempt}`],
+          url: null,
+          updated_at: `2026-07-12T00:${String(attempt % 60).padStart(2, "0")}:00Z`,
+        },
+      },
+    );
+  }
+  assert.ok((rollingPatch.last_error?.length ?? 0) <= 1000);
+  assert.ok((rollingPatch.last_failure_context?.details.length ?? 0) <= 32);
+  assert.ok(
+    rollingPatch.last_failure_context?.details.includes(
+      "review_repair_interruption_blocked_reason=secrets",
+    ),
+  );
+  assert.ok(
+    rollingPatch.last_failure_context?.details.includes(
+      "review_repair_interruption_detail=attempt=99",
+    ),
+  );
+});

--- a/src/supervisor/independent-verification-blocker.ts
+++ b/src/supervisor/independent-verification-blocker.ts
@@ -1,0 +1,34 @@
+import { FailureContext, IssueRunRecord } from "../core/types";
+import { hasBlockedTurnVerificationProvenance } from "./blocked-turn-pr-reconciliation";
+
+export interface IndependentVerificationBlockerSnapshot {
+  lastError: string | null;
+  lastBlockerSignature: string | null;
+  lastFailureContext: FailureContext;
+  lastFailureSignature: string | null;
+  repeatedFailureSignatureCount: number;
+  repeatedBlockerCount: number;
+  blockedVerificationRetryCount: number;
+}
+
+export function independentVerificationBlockerSnapshot(
+  record: IssueRunRecord,
+): IndependentVerificationBlockerSnapshot | null {
+  if (
+    record.state !== "addressing_review" ||
+    record.last_failure_context === null ||
+    !hasBlockedTurnVerificationProvenance(record)
+  ) {
+    return null;
+  }
+
+  return {
+    lastError: record.last_error,
+    lastBlockerSignature: record.last_blocker_signature,
+    lastFailureContext: record.last_failure_context,
+    lastFailureSignature: record.last_failure_signature,
+    repeatedFailureSignatureCount: record.repeated_failure_signature_count,
+    repeatedBlockerCount: record.repeated_blocker_count,
+    blockedVerificationRetryCount: record.blocked_verification_retry_count,
+  };
+}

--- a/src/supervisor/independent-verification-blocker.ts
+++ b/src/supervisor/independent-verification-blocker.ts
@@ -1,4 +1,5 @@
 import { FailureContext, IssueRunRecord } from "../core/types";
+import { truncatePreservingStartAndEnd } from "../core/utils";
 import { hasBlockedTurnVerificationProvenance } from "./blocked-turn-pr-reconciliation";
 
 export interface IndependentVerificationBlockerSnapshot {
@@ -11,11 +12,18 @@ export interface IndependentVerificationBlockerSnapshot {
   blockedVerificationRetryCount: number;
 }
 
+export interface IndependentVerificationBlockerPersistenceOptions {
+  diagnosticPrefix?: "review_repair_interruption" | "review_repair_terminal";
+}
+
 export function independentVerificationBlockerSnapshot(
   record: IssueRunRecord,
 ): IndependentVerificationBlockerSnapshot | null {
+  const carriesTrackedReviewRepairVerifier =
+    record.state === "addressing_review" ||
+    (record.state === "queued" && record.pr_number !== null);
   if (
-    record.state !== "addressing_review" ||
+    !carriesTrackedReviewRepairVerifier ||
     record.last_failure_context === null ||
     !hasBlockedTurnVerificationProvenance(record)
   ) {
@@ -30,5 +38,113 @@ export function independentVerificationBlockerSnapshot(
     repeatedFailureSignatureCount: record.repeated_failure_signature_count,
     repeatedBlockerCount: record.repeated_blocker_count,
     blockedVerificationRetryCount: record.blocked_verification_retry_count,
+  };
+}
+
+function compactPersistenceDetail(value: string, maxLength = 1000): string {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  return (normalized || "unknown").slice(0, maxLength);
+}
+
+/**
+ * Keep an independent verifier failure authoritative until that exact verifier
+ * passes, while retaining a later review-repair failure as nested diagnostic
+ * evidence. Callers can safely use this over any terminal persistence patch.
+ */
+export function preserveIndependentVerificationBlockerPatch(
+  snapshot: IndependentVerificationBlockerSnapshot,
+  nextPatch: Partial<IssueRunRecord>,
+  options: IndependentVerificationBlockerPersistenceOptions = {},
+): Partial<IssueRunRecord> {
+  const diagnosticPrefix =
+    options.diagnosticPrefix ?? "review_repair_interruption";
+  const supersedingFailureContext = nextPatch.last_failure_context ?? null;
+  const supersedingBlockedReason = nextPatch.blocked_reason ?? "unknown";
+  const supersedingState = nextPatch.state ?? "unknown";
+  const supersedingFailureKind = nextPatch.last_failure_kind ?? "none";
+  const diagnosticDetails = [
+    `${diagnosticPrefix}_state=${supersedingState}`,
+    `${diagnosticPrefix}_blocked_reason=${supersedingBlockedReason}`,
+    `${diagnosticPrefix}_failure_kind=${supersedingFailureKind}`,
+    ...(supersedingFailureContext
+      ? [
+          `${diagnosticPrefix}_category=${supersedingFailureContext.category}`,
+          `${diagnosticPrefix}_summary=${compactPersistenceDetail(
+            supersedingFailureContext.summary,
+          )}`,
+          ...supersedingFailureContext.details.map(
+            (detail) =>
+              `${diagnosticPrefix}_detail=${compactPersistenceDetail(detail)}`,
+          ),
+        ]
+      : []),
+  ];
+  const existingDetails = snapshot.lastFailureContext.details;
+  const foundationalDetails = existingDetails
+    .filter((detail) => !detail.startsWith("review_repair_"))
+    .slice(0, 12);
+  const durableBlockedReasonDetails = existingDetails
+    .filter((detail) =>
+      /^review_repair_(?:interruption|terminal)_blocked_reason=/.test(detail),
+    )
+    .slice(-8);
+  const recentDiagnosticDetails = [
+    ...existingDetails.filter(
+      (detail) =>
+        detail.startsWith("review_repair_") &&
+        !/^review_repair_(?:interruption|terminal)_blocked_reason=/.test(
+          detail,
+        ),
+    ),
+    ...diagnosticDetails,
+  ].slice(-12);
+  const details = [
+    ...foundationalDetails,
+    ...durableBlockedReasonDetails,
+    ...recentDiagnosticDetails,
+  ].filter((detail, index, all) => all.indexOf(detail) === index);
+  const supersedingError = nextPatch.last_error ??
+    supersedingFailureContext?.summary ??
+    null;
+  const foundationalLastError = snapshot.lastError
+    ?.split("\n")
+    .filter(
+      (line) =>
+        !/^review_repair_(?:interruption|terminal):/.test(line.trim()),
+    )
+    .join("\n")
+    .trim();
+  const lastError = truncatePreservingStartAndEnd(
+    [
+      foundationalLastError,
+      supersedingError
+        ? `${diagnosticPrefix}: ${compactPersistenceDetail(supersedingError)}`
+        : null,
+    ]
+      .filter((value): value is string => Boolean(value))
+      .join("\n"),
+    1000,
+  );
+
+  return {
+    ...nextPatch,
+    state: "blocked",
+    blocked_reason: "verification",
+    last_error: lastError,
+    last_failure_kind: null,
+    last_failure_context: {
+      ...snapshot.lastFailureContext,
+      details,
+      updated_at:
+        supersedingFailureContext?.updated_at ??
+        snapshot.lastFailureContext.updated_at,
+    },
+    last_failure_signature: snapshot.lastFailureSignature,
+    repeated_failure_signature_count:
+      snapshot.repeatedFailureSignatureCount,
+    last_blocker_signature: snapshot.lastBlockerSignature,
+    repeated_blocker_count: snapshot.repeatedBlockerCount,
+    blocked_verification_retry_count:
+      snapshot.blockedVerificationRetryCount,
   };
 }

--- a/src/supervisor/independent-verification-blocker.ts
+++ b/src/supervisor/independent-verification-blocker.ts
@@ -21,7 +21,9 @@ export function independentVerificationBlockerSnapshot(
 ): IndependentVerificationBlockerSnapshot | null {
   const carriesTrackedReviewRepairVerifier =
     record.state === "addressing_review" ||
-    (record.state === "queued" && record.pr_number !== null);
+    (record.pr_number !== null &&
+      (record.state === "queued" ||
+        (record.state === "blocked" && record.blocked_reason === "verification")));
   if (
     !carriesTrackedReviewRepairVerifier ||
     record.last_failure_context === null ||

--- a/src/supervisor/prepared-issue-runner.test.ts
+++ b/src/supervisor/prepared-issue-runner.test.ts
@@ -18,6 +18,200 @@ import {
   createSupervisorState,
 } from "./supervisor-test-helpers";
 
+async function runTrackedIndependentVerificationRetryCase(
+  verificationPassed: boolean,
+): Promise<{
+  dispatchedState: IssueRunRecord["state"] | null;
+  postTurnTransitionCount: number;
+  postTurnMergeCount: number;
+  savedRecord: IssueRunRecord;
+}> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "prepared-verifier-retry-"));
+  try {
+    const stateFile = path.join(root, "state.json");
+    const config = createConfig({
+      repoPath: path.join(root, "repo"),
+      stateFile,
+      workspaceRoot: path.join(root, "workspaces"),
+    });
+    const failureContext = {
+      category: "blocked" as const,
+      summary: "Codex reported blocked for issue #2086.",
+      signature: "verification:images",
+      command: "npm run verify:images",
+      details: ["structured_blocked_reason=verification"],
+      url: null,
+      updated_at: "2026-07-11T12:40:00Z",
+    };
+    const record = createRecord({
+      issue_number: 2086,
+      state: "queued",
+      branch: "codex/issue-2086",
+      pr_number: 2086,
+      workspace: path.join(config.workspaceRoot, "issue-2086"),
+      journal_path: path.join(
+        config.workspaceRoot,
+        "issue-2086",
+        ".codex-supervisor",
+        "issue-journal.md",
+      ),
+      blocked_reason: "verification",
+      last_error: "Auto-retrying after verification failure (2/3).",
+      last_failure_context: failureContext,
+      last_failure_signature: failureContext.signature,
+      last_blocker_signature: failureContext.signature,
+      blocked_verification_retry_count: 2,
+    });
+    const state = createSupervisorState({
+      activeIssueNumber: record.issue_number,
+      issues: [record],
+    });
+    const stateStore = new StateStore(stateFile, { backend: "json" });
+    const pr = createPullRequest({
+      number: record.pr_number ?? 2086,
+      headRefName: record.branch,
+      headRefOid: "head-2086",
+      isDraft: false,
+      mergeStateStatus: "CLEAN",
+    });
+    const workspaceStatus = {
+      branch: record.branch,
+      headSha: pr.headRefOid,
+      hasUncommittedChanges: false,
+      baseAhead: 1,
+      baseBehind: 0,
+      remoteBranchExists: true,
+      remoteAhead: 0,
+      remoteBehind: 0,
+    };
+    const independentVerificationBlocker = {
+      lastError: record.last_error,
+      lastBlockerSignature: record.last_blocker_signature,
+      lastFailureContext: failureContext,
+      lastFailureSignature: record.last_failure_signature,
+      repeatedFailureSignatureCount: record.repeated_failure_signature_count,
+      repeatedBlockerCount: record.repeated_blocker_count,
+      blockedVerificationRetryCount: record.blocked_verification_retry_count,
+    };
+    let dispatchedState: IssueRunRecord["state"] | null = null;
+    let postTurnTransitionCount = 0;
+    let postTurnMergeCount = 0;
+
+    await runPreparedIssueFlow(
+      {
+        config,
+        stateStore,
+        github: {} as GitHubClient,
+        executeCodexTurn: async (context) => {
+          dispatchedState = context.record.state;
+          return {
+            kind: "completed",
+            record: verificationPassed
+              ? {
+                  ...context.record,
+                  state: "ready_to_merge",
+                  blocked_reason: null,
+                  last_error: null,
+                  last_failure_context: null,
+                  last_failure_signature: null,
+                  last_blocker_signature: null,
+                }
+              : {
+                  ...context.record,
+                  state: "addressing_review",
+                  blocked_reason: "verification",
+                  last_error: failureContext.summary,
+                  last_failure_context: failureContext,
+                  last_failure_signature: failureContext.signature,
+                  last_blocker_signature: failureContext.signature,
+                },
+            workspaceStatus,
+            pr,
+            checks: [],
+            reviewThreads: [],
+          };
+        },
+        handlePostTurnPullRequestTransitions: async (context) => {
+          postTurnTransitionCount += 1;
+          state.issues[String(context.record.issue_number)] = context.record;
+          await stateStore.save(state);
+          return {
+            record: context.record,
+            pr: context.pr,
+            checks: [],
+            reviewThreads: [],
+          };
+        },
+        handlePostTurnMergeAndCompletion: async (_state, _issue, postTurnRecord) => {
+          postTurnMergeCount += 1;
+          return postTurnRecord;
+        },
+      },
+      {
+        state,
+        record,
+        issue: createIssue({ number: record.issue_number }),
+        previousCodexSummary: null,
+        previousError: failureContext.summary,
+        workspacePath: record.workspace,
+        journalPath:
+          record.journal_path ??
+          path.join(record.workspace, ".codex-supervisor", "issue-journal.md"),
+        syncJournal: async () => undefined,
+        memoryArtifacts: {
+          alwaysReadFiles: [],
+          onDemandFiles: [],
+          contextIndexPath: path.join(root, "context-index.md"),
+          agentsPath: path.join(root, "AGENTS.generated.md"),
+        },
+        workspaceStatus,
+        pr,
+        checks: [],
+        reviewThreads: [],
+        independentVerificationBlocker,
+        options: { dryRun: false },
+        recoveryEvents: [],
+        recoveryLog: null,
+      },
+    );
+
+    const savedState = JSON.parse(await fs.readFile(stateFile, "utf8")) as {
+      issues: Record<string, IssueRunRecord>;
+    };
+    return {
+      dispatchedState,
+      postTurnTransitionCount,
+      postTurnMergeCount,
+      savedRecord: savedState.issues[String(record.issue_number)]!,
+    };
+  } finally {
+    await fs.rm(root, { recursive: true, force: true });
+  }
+}
+
+test("runPreparedIssueFlow dispatches a tracked independent verifier before clean PR lifecycle projection and stops while it remains blocked", async () => {
+  const result = await runTrackedIndependentVerificationRetryCase(false);
+
+  assert.equal(result.dispatchedState, "queued");
+  assert.equal(result.postTurnTransitionCount, 0);
+  assert.equal(result.postTurnMergeCount, 0);
+  assert.equal(result.savedRecord.state, "blocked");
+  assert.equal(result.savedRecord.blocked_reason, "verification");
+  assert.equal(
+    result.savedRecord.last_failure_context?.command,
+    "npm run verify:images",
+  );
+});
+
+test("runPreparedIssueFlow resumes tracked PR transitions after the independent verifier passes", async () => {
+  const result = await runTrackedIndependentVerificationRetryCase(true);
+
+  assert.equal(result.dispatchedState, "queued");
+  assert.equal(result.postTurnTransitionCount, 1);
+  assert.equal(result.postTurnMergeCount, 1);
+  assert.equal(result.savedRecord.blocked_reason, null);
+});
+
 test("runPreparedIssueFlow persists no-PR prepared issues without dispatching Codex when lifecycle says to wait", async () => {
   const root = await fs.mkdtemp(path.join(os.tmpdir(), "prepared-issue-runner-"));
   try {

--- a/src/supervisor/prepared-issue-runner.ts
+++ b/src/supervisor/prepared-issue-runner.ts
@@ -270,8 +270,11 @@ export async function runPreparedIssueFlow(
   let checks = context.checks;
   let reviewThreads = context.reviewThreads;
   let skipCodexAfterPreStopStaleConfiguredBotAutoResolve = false;
+  const hasIndependentVerificationRetryIntent = Boolean(
+    independentVerificationBlocker,
+  );
 
-  if (pr) {
+  if (pr && !hasIndependentVerificationRetryIntent) {
     const recordBeforePullRequestLifecycle = record;
     const lifecycle = derivePullRequestLifecycleSnapshot(config, record, pr, checks, reviewThreads);
     const localReviewRepairSummary =
@@ -567,7 +570,7 @@ export async function runPreparedIssueFlow(
         );
       }
     }
-  } else {
+  } else if (!pr) {
     const nextState = inferStateWithoutPullRequest(record, workspaceStatus);
     record = stateStore.touch(record, {
       state: nextState,
@@ -575,7 +578,9 @@ export async function runPreparedIssueFlow(
     });
   }
   const shouldExecuteCodex =
-    !skipCodexAfterPreStopStaleConfiguredBotAutoResolve && shouldRunCodex(record, pr, checks, reviewThreads, config);
+    hasIndependentVerificationRetryIntent ||
+    (!skipCodexAfterPreStopStaleConfiguredBotAutoResolve &&
+      shouldRunCodex(record, pr, checks, reviewThreads, config));
 
   if (shouldExecuteCodex) {
     state.issues[String(record.issue_number)] = record;
@@ -610,6 +615,19 @@ export async function runPreparedIssueFlow(
     state.issues[String(record.issue_number)] = record;
     await stateStore.save(state);
     await syncJournal(record);
+  }
+
+  if (
+    hasIndependentVerificationRetryIntent &&
+    record.blocked_reason === "verification"
+  ) {
+    if (record.state !== "blocked") {
+      record = stateStore.touch(record, { state: "blocked" });
+    }
+    state.issues[String(record.issue_number)] = record;
+    await stateStore.save(state);
+    await syncJournal(record);
+    return prependRecoveryLog(formatPreparedIssueStatus(record, state), recoveryLog);
   }
 
   if (pr) {

--- a/src/supervisor/prepared-issue-runner.ts
+++ b/src/supervisor/prepared-issue-runner.ts
@@ -259,6 +259,7 @@ export async function runPreparedIssueFlow(
     journalPath,
     syncJournal,
     memoryArtifacts,
+    independentVerificationBlocker,
     options,
     recoveryLog,
     recoveryEvents,
@@ -594,6 +595,7 @@ export async function runPreparedIssueFlow(
       checks,
       reviewThreads,
       options,
+      independentVerificationBlocker,
     });
     if (codexTurn.kind === "returned") {
       return prependRecoveryLog(codexTurn.message, recoveryLog);

--- a/src/supervisor/supervisor-active-detailed-status-presenters.ts
+++ b/src/supervisor/supervisor-active-detailed-status-presenters.ts
@@ -44,6 +44,7 @@ import { summarizePreservedPartialWork } from "./supervisor-preserved-partial-wo
 import { buildConversationResolutionBlockerDiagnostic } from "../conversation-resolution-blocker-diagnostics";
 import { sanitizeStatusValue } from "./supervisor-detailed-status-formatting";
 import { currentHeadLocalCiMissing, hasConfiguredLocalCiCommand } from "../local-ci-policy";
+import { blockedTurnPullRequestReconciliationStatusLine } from "./blocked-turn-pr-reconciliation";
 
 type ActiveDetailedStatusArgs = Omit<BuildDetailedStatusModelArgs, "latestRecord" | "trackedIssueCount"> & {
   activeRecord: NonNullable<BuildDetailedStatusModelArgs["activeRecord"]>;
@@ -57,6 +58,8 @@ function unresolvedReviewThreads(reviewThreads: BuildDetailedStatusModelArgs["re
 
 export function buildActiveRecordBaselineLines(args: Pick<ActiveDetailedStatusArgs, "activeRecord">): string[] {
   const { activeRecord } = args;
+  const blockedTurnPrReconciliation =
+    blockedTurnPullRequestReconciliationStatusLine(activeRecord);
   return [
     `issue=#${activeRecord.issue_number}`,
     `state=${activeRecord.state}`,
@@ -80,6 +83,7 @@ export function buildActiveRecordBaselineLines(args: Pick<ActiveDetailedStatusAr
     `last_failure_signature=${activeRecord.last_failure_signature ?? "none"}`,
     `merge_latency provider_success_observed_at=${activeRecord.provider_success_observed_at ?? "none"} provider_success_head_sha=${activeRecord.provider_success_head_sha ?? "none"} merge_readiness_last_evaluated_at=${activeRecord.merge_readiness_last_evaluated_at ?? "none"}`,
     `retries timeout=${activeRecord.timeout_retry_count} verification=${activeRecord.blocked_verification_retry_count} same_blocker=${activeRecord.repeated_blocker_count} same_failure_signature=${activeRecord.repeated_failure_signature_count}`,
+    ...(blockedTurnPrReconciliation ? [blockedTurnPrReconciliation] : []),
   ];
 }
 

--- a/src/supervisor/supervisor-detailed-status-assembly.ts
+++ b/src/supervisor/supervisor-detailed-status-assembly.ts
@@ -22,6 +22,7 @@ import { classifyStaleReviewBotRecoverability } from "./stale-diagnostic-recover
 import { isWorkstationLocalPathHygieneFailureSignature } from "../workstation-local-path-gate";
 import { formatLatestRecoveryStatusLine, sanitizeStatusValue } from "./supervisor-detailed-status-formatting";
 import { currentHeadLocalCiMissing, hasConfiguredLocalCiCommand } from "../local-ci-policy";
+import { blockedTurnPullRequestReconciliationStatusLine } from "./blocked-turn-pr-reconciliation";
 
 export { buildActiveDetailedStatusLines } from "./supervisor-active-detailed-status-presenters";
 export { formatLatestRecoveryStatusLine, sanitizeStatusValue } from "./supervisor-detailed-status-formatting";
@@ -192,6 +193,11 @@ export function buildInactiveDetailedStatusLines(
   const classificationLine = formatNoActiveTrackedRecordClassificationLine(config, latestRecord, staleReviewBotRemediation);
   if (classificationLine) {
     lines.push(classificationLine);
+  }
+  const blockedTurnPrReconciliation =
+    blockedTurnPullRequestReconciliationStatusLine(latestRecord);
+  if (blockedTurnPrReconciliation) {
+    lines.push(blockedTurnPrReconciliation);
   }
   if (latestRecord && staleReviewBotRemediation) {
     lines.push(formatStaleReviewBotRemediationLine(staleReviewBotRemediation));

--- a/src/supervisor/supervisor-execution-cleanup.test.ts
+++ b/src/supervisor/supervisor-execution-cleanup.test.ts
@@ -5,6 +5,11 @@ import path from "node:path";
 import { Supervisor } from "./supervisor";
 import { StateStore } from "../core/state-store";
 import {
+  isRestartRunOnce,
+  prepareIssueExecutionContext,
+} from "../run-once-issue-preparation";
+import type { PreparedIssueRunContext } from "./prepared-issue-runner";
+import {
   GitHubIssue,
   GitHubPullRequest,
   IssueRunRecord,
@@ -18,6 +23,7 @@ import {
   createIssue,
   createPullRequest,
   createRecord,
+  createReviewThread,
   createSupervisorFixture,
   executionReadyBody,
   git,
@@ -142,6 +148,225 @@ test("executeCodexTurn does not consume attempts when the Codex session lock is 
   assert.equal(persisted.issues[String(issueNumber)]?.attempt_count, 4);
   assert.equal(persisted.issues[String(issueNumber)]?.implementation_attempt_count, 3);
   assert.equal(persisted.issues[String(issueNumber)]?.repair_attempt_count, 1);
+});
+
+test("recovered independent verification survives preparation and Supervisor pre-turn reprojection", async () => {
+  const fixture = await createSupervisorFixture();
+  fixture.config.reviewBotLogins = ["copilot-pull-request-reviewer"];
+  const issueNumber = 122;
+  const branch = branchName(fixture.config, issueNumber);
+  const workspacePath = path.join(fixture.workspaceRoot, `issue-${issueNumber}`);
+  const journalPath = path.join(
+    workspacePath,
+    fixture.config.issueJournalRelativePath,
+  );
+  git([
+    "-C",
+    fixture.repoPath,
+    "worktree",
+    "add",
+    "-b",
+    branch,
+    workspacePath,
+    "origin/main",
+  ]);
+  const headSha = git(["-C", workspacePath, "rev-parse", "HEAD"]);
+  await fs.mkdir(path.dirname(journalPath), { recursive: true });
+  await fs.writeFile(
+    journalPath,
+    [
+      "## Codex Working Notes",
+      "### Current Handoff",
+      "- Hypothesis: repair the review without losing the independent verifier.",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Image verification remains blocked.",
+    signature: "verification:images",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-11T12:40:00Z",
+  };
+  const recoveredRecord = createRecord({
+    issue_number: issueNumber,
+    state: "addressing_review",
+    branch,
+    pr_number: 222,
+    workspace: workspacePath,
+    journal_path: journalPath,
+    codex_session_id: null,
+    last_head_sha: headSha,
+    blocked_reason: "verification",
+    last_error: failureContext.summary,
+    last_failure_context: failureContext,
+    last_failure_signature: failureContext.signature,
+    repeated_failure_signature_count: 2,
+    last_blocker_signature: "verification:images",
+    repeated_blocker_count: 2,
+    blocked_verification_retry_count: 1,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: { [String(issueNumber)]: recoveredRecord },
+  };
+  await fs.writeFile(
+    fixture.stateFile,
+    `${JSON.stringify(state, null, 2)}\n`,
+    "utf8",
+  );
+  const issue = createIssue({
+    number: issueNumber,
+    title: "Carry an independent verifier through production dispatch",
+  });
+  const pr = createPullRequest({
+    number: 222,
+    headRefName: branch,
+    headRefOid: headSha,
+  });
+  const reviewThread = createReviewThread();
+  const workspaceStatus = {
+    branch,
+    headSha,
+    hasUncommittedChanges: false,
+    baseAhead: 0,
+    baseBehind: 0,
+    remoteBranchExists: true,
+    remoteAhead: 0,
+    remoteBehind: 0,
+  };
+  const stateStore = new StateStore(fixture.stateFile, {
+    backend: fixture.config.stateBackend,
+    bootstrapFilePath: fixture.config.stateBootstrapFile,
+  });
+  const prepared = await prepareIssueExecutionContext({
+    github: {
+      resolvePullRequestForBranch: async () => pr,
+      getChecks: async () => [],
+      getUnresolvedReviewThreads: async () => [reviewThread],
+      createPullRequest: async () => {
+        throw new Error("unexpected createPullRequest call");
+      },
+    },
+    config: fixture.config,
+    stateStore,
+    state,
+    record: recoveredRecord,
+    issue,
+    options: { dryRun: false },
+    ensureWorkspace: async () => workspacePath,
+    syncIssueJournal: async () => undefined,
+    syncMemoryArtifacts: async () => ({
+      contextIndexPath: path.join(workspacePath, "context-index.md"),
+      agentsPath: path.join(workspacePath, "AGENTS.generated.md"),
+      alwaysReadFiles: [journalPath],
+      onDemandFiles: [],
+    }),
+    getWorkspaceStatus: async () => workspaceStatus,
+    writeSupervisorCycleDecisionSnapshot: async () =>
+      path.join(workspacePath, "decision.json"),
+    writePreMergeAssessmentSnapshot: async () =>
+      path.join(workspacePath, "assessment.json"),
+  });
+  assert.equal(typeof prepared, "object");
+  assert.ok(
+    prepared &&
+      !isRestartRunOnce(prepared) &&
+      typeof prepared !== "string",
+  );
+
+  let blockedReasonAtAgentDispatch: IssueRunRecord["blocked_reason"] =
+    "verification";
+  let agentDispatched = false;
+  const supervisor = new Supervisor(fixture.config, {
+    agentRunner: {
+      capabilities: {
+        supportsResume: false,
+        supportsStructuredResult: true,
+      },
+      async runTurn() {
+        agentDispatched = true;
+        blockedReasonAtAgentDispatch =
+          state.issues[String(issueNumber)]?.blocked_reason ?? null;
+        await fs.writeFile(
+          journalPath,
+          [
+            "## Codex Working Notes",
+            "### Current Handoff",
+            "- Hypothesis: repair the review without losing the independent verifier.",
+            "- What changed: review repair stopped on a token boundary.",
+          ].join("\n"),
+          "utf8",
+        );
+        return {
+          exitCode: 0,
+          sessionId: "session-122",
+          supervisorMessage: "Need token before continuing review repair.",
+          stderr: "",
+          stdout: "",
+          structuredResult: {
+            summary: "Review repair stopped on a token boundary.",
+            stateHint: "blocked" as const,
+            blockedReason: "secrets" as const,
+            failureSignature: "secrets:review-repair",
+            nextAction: "provide the token",
+            tests: "not run",
+          },
+          failureKind: null,
+          failureContext: null,
+        };
+      },
+    },
+  });
+  (supervisor as unknown as { github: Record<string, unknown> }).github = {
+    findOpenPullRequestsForBranch: async () => [pr],
+    resolvePullRequestForBranch: async () => pr,
+    getPullRequestIfExists: async () => pr,
+    getChecks: async () => [],
+    getUnresolvedReviewThreads: async () => [reviewThread],
+    getExternalReviewSurface: async () => ({ issueComments: [], reviews: [] }),
+    createPullRequest: async () => {
+      throw new Error("unexpected createPullRequest call");
+    },
+  };
+
+  const message = await (
+    supervisor as unknown as {
+      runPreparedIssue: (context: PreparedIssueRunContext) => Promise<string>;
+    }
+  ).runPreparedIssue({
+    ...prepared,
+    state,
+    issue,
+    options: { dryRun: false },
+    recoveryEvents: [],
+    recoveryLog: null,
+  });
+
+  assert.equal(
+    agentDispatched,
+    true,
+    `${message}\n${JSON.stringify(state.issues[String(issueNumber)])}`,
+  );
+  assert.match(message, /Codex reported blocked for issue #122/);
+  assert.equal(blockedReasonAtAgentDispatch, null);
+  const updated = state.issues[String(issueNumber)]!;
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.blocked_reason, "verification");
+  assert.equal(updated.last_failure_context?.command, "npm run verify:images");
+  assert.equal(updated.last_failure_signature, failureContext.signature);
+  assert.equal(updated.repeated_failure_signature_count, 2);
+  assert.equal(updated.last_blocker_signature, "verification:images");
+  assert.equal(updated.repeated_blocker_count, 2);
+  assert.equal(updated.blocked_verification_retry_count, 1);
+  assert.ok(
+    updated.last_failure_context?.details.includes(
+      "review_repair_terminal_blocked_reason=secrets",
+    ),
+  );
 });
 
 test("runPreparedIssue skips pre-turn persistence when the Codex session lock is already held", async () => {

--- a/src/supervisor/supervisor-execution-cleanup.test.ts
+++ b/src/supervisor/supervisor-execution-cleanup.test.ts
@@ -287,8 +287,16 @@ test("recovered independent verification survives preparation and Supervisor pre
         supportsResume: false,
         supportsStructuredResult: true,
       },
-      async runTurn() {
+      async runTurn(turnContext) {
         agentDispatched = true;
+        assert.equal(
+          turnContext.failureContext?.command,
+          "npm run verify:images",
+        );
+        assert.match(
+          turnContext.previousError ?? "",
+          /Image verification remains blocked/,
+        );
         blockedReasonAtAgentDispatch =
           state.issues[String(issueNumber)]?.blocked_reason ?? null;
         await fs.writeFile(
@@ -369,22 +377,38 @@ test("recovered independent verification survives preparation and Supervisor pre
   );
 });
 
-test("runPreparedIssue skips pre-turn persistence when the Codex session lock is already held", async () => {
+test("runPreparedIssue preserves tracked verifier intent across a held session lock and dry run", async () => {
   const fixture = await createSupervisorFixture();
   const issueNumber = 122;
   const branch = branchName(fixture.config, issueNumber);
   const workspacePath = path.join(fixture.workspaceRoot, `issue-${issueNumber}`);
   const journalPath = path.join(workspacePath, ".codex-supervisor/issue-journal.md");
+  const failureContext = {
+    category: "blocked" as const,
+    summary: `Codex reported blocked for issue #${issueNumber}.`,
+    signature: "verification:images",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-11T12:40:00Z",
+  };
   const initialRecord = createRecord({
     issue_number: issueNumber,
-    state: "stabilizing",
+    state: "queued",
     branch,
+    pr_number: 222,
     workspace: workspacePath,
     journal_path: journalPath,
     codex_session_id: "session-122",
     attempt_count: 4,
     implementation_attempt_count: 3,
     repair_attempt_count: 1,
+    blocked_verification_retry_count: 1,
+    blocked_reason: "verification",
+    last_error: failureContext.summary,
+    last_failure_context: failureContext,
+    last_failure_signature: failureContext.signature,
+    last_blocker_signature: failureContext.signature,
   });
   const state: SupervisorStateFile = {
     activeIssueNumber: issueNumber,
@@ -413,42 +437,20 @@ test("runPreparedIssue skips pre-turn persistence when the Codex session lock is
     url: `https://example.test/issues/${issueNumber}`,
     state: "OPEN",
   };
+  const pr = createPullRequest({
+    number: 222,
+    headRefName: branch,
+    headRefOid: "head-122",
+    isDraft: false,
+    mergeStateStatus: "CLEAN",
+  });
 
-  const result = await (
+  const runPreparedIssue = (
     supervisor as unknown as {
-      runPreparedIssue: (context: {
-        state: SupervisorStateFile;
-        record: IssueRunRecord;
-        issue: GitHubIssue;
-        previousCodexSummary: string | null;
-        previousError: string | null;
-        workspacePath: string;
-        journalPath: string;
-        syncJournal: (record: IssueRunRecord) => Promise<void>;
-        memoryArtifacts: {
-          alwaysReadFiles: string[];
-          onDemandFiles: string[];
-          contextIndexPath: string;
-          agentsPath: string;
-        };
-        workspaceStatus: {
-          branch: string;
-          headSha: string;
-          hasUncommittedChanges: boolean;
-          baseAhead: number;
-          baseBehind: number;
-          remoteBranchExists: boolean;
-          remoteAhead: number;
-          remoteBehind: number;
-        };
-        pr: GitHubPullRequest | null;
-        checks: PullRequestCheck[];
-        reviewThreads: ReviewThread[];
-        options: { dryRun: boolean };
-        recoveryLog: string | null;
-      }) => Promise<string>;
+      runPreparedIssue: (context: PreparedIssueRunContext) => Promise<string>;
     }
-  ).runPreparedIssue({
+  ).runPreparedIssue.bind(supervisor);
+  const preparedContext: PreparedIssueRunContext = {
     state,
     record: initialRecord,
     issue,
@@ -475,12 +477,25 @@ test("runPreparedIssue skips pre-turn persistence when the Codex session lock is
       remoteAhead: 0,
       remoteBehind: 0,
     },
-    pr: null,
+    pr,
     checks: [],
     reviewThreads: [],
+    independentVerificationBlocker: {
+      lastError: failureContext.summary,
+      lastBlockerSignature: failureContext.signature,
+      lastFailureContext: failureContext,
+      lastFailureSignature: failureContext.signature,
+      repeatedFailureSignatureCount:
+        initialRecord.repeated_failure_signature_count,
+      repeatedBlockerCount: initialRecord.repeated_blocker_count,
+      blockedVerificationRetryCount:
+        initialRecord.blocked_verification_retry_count,
+    },
     options: { dryRun: false },
+    recoveryEvents: [],
     recoveryLog: null,
-  });
+  };
+  const result = await runPreparedIssue(preparedContext);
 
   assert.match(result, /Skipped issue #122: lock held by pid/);
   assert.equal(syncJournalCalls, 0);
@@ -492,6 +507,51 @@ test("runPreparedIssue skips pre-turn persistence when the Codex session lock is
   assert.equal(persisted.issues[String(issueNumber)]?.attempt_count, 4);
   assert.equal(persisted.issues[String(issueNumber)]?.implementation_attempt_count, 3);
   assert.equal(persisted.issues[String(issueNumber)]?.repair_attempt_count, 1);
+  assert.equal(persisted.issues[String(issueNumber)]?.state, "queued");
+  assert.equal(
+    persisted.issues[String(issueNumber)]?.blocked_reason,
+    "verification",
+  );
+  assert.equal(
+    persisted.issues[String(issueNumber)]?.last_failure_context?.command,
+    "npm run verify:images",
+  );
+  assert.equal(
+    persisted.issues[String(issueNumber)]?.last_failure_signature,
+    "verification:images",
+  );
+  assert.equal(
+    persisted.issues[String(issueNumber)]?.blocked_verification_retry_count,
+    1,
+  );
+
+  const dryRunResult = await runPreparedIssue({
+    ...preparedContext,
+    options: { dryRun: true },
+  });
+  assert.match(dryRunResult, /Dry run: would invoke Codex for issue #122/);
+  const persistedAfterDryRun = JSON.parse(
+    await fs.readFile(fixture.stateFile, "utf8"),
+  ) as SupervisorStateFile;
+  assert.equal(persistedAfterDryRun.issues[String(issueNumber)]?.state, "queued");
+  assert.equal(
+    persistedAfterDryRun.issues[String(issueNumber)]?.blocked_reason,
+    "verification",
+  );
+  assert.equal(
+    persistedAfterDryRun.issues[String(issueNumber)]?.last_failure_context
+      ?.command,
+    "npm run verify:images",
+  );
+  assert.equal(
+    persistedAfterDryRun.issues[String(issueNumber)]?.attempt_count,
+    4,
+  );
+  assert.equal(
+    persistedAfterDryRun.issues[String(issueNumber)]
+      ?.blocked_verification_retry_count,
+    1,
+  );
 });
 
 test("runPreparedIssue refreshes current-head manual-review repair state before a dry-run turn", async () => {

--- a/src/supervisor/supervisor-execution-cleanup.test.ts
+++ b/src/supervisor/supervisor-execution-cleanup.test.ts
@@ -360,7 +360,7 @@ test("recovered independent verification survives preparation and Supervisor pre
     `${message}\n${JSON.stringify(state.issues[String(issueNumber)])}`,
   );
   assert.match(message, /Codex reported blocked for issue #122/);
-  assert.equal(blockedReasonAtAgentDispatch, null);
+  assert.equal(blockedReasonAtAgentDispatch, "verification");
   const updated = state.issues[String(issueNumber)]!;
   assert.equal(updated.state, "blocked");
   assert.equal(updated.blocked_reason, "verification");

--- a/src/supervisor/supervisor-execution-policy.test.ts
+++ b/src/supervisor/supervisor-execution-policy.test.ts
@@ -153,7 +153,37 @@ test("shouldAutoRetryBlockedVerification respects implementation budgets and rep
       }),
       config,
     ),
+    false,
+  );
+  assert.equal(
+    shouldAutoRetryBlockedVerification(
+      createRecord({
+        last_error: "Verification blocked: prerequisite not satisfied.",
+        blocked_reason: "verification",
+        last_failure_context: {
+          category: "blocked",
+          summary: "Codex reported blocked for issue #102.",
+          signature: "verification:images",
+          command: "npm run verify:images",
+          details: ["structured_blocked_reason=verification"],
+          url: null,
+          updated_at: "2026-07-11T12:40:00Z",
+        },
+      }),
+      config,
+    ),
     true,
+  );
+  assert.equal(
+    shouldAutoRetryBlockedVerification(
+      createRecord({
+        last_error:
+          "Tracked durable artifacts failed workstation-local path hygiene before publication.",
+        blocked_reason: "verification",
+      }),
+      config,
+    ),
+    false,
   );
   assert.equal(
     shouldAutoRetryBlockedVerification(
@@ -180,6 +210,15 @@ test("shouldAutoRetryBlockedVerification respects implementation budgets and rep
       createRecord({
         last_error: "Verification blocked: prerequisite not satisfied.",
         blocked_reason: "verification",
+        last_failure_context: {
+          category: "blocked",
+          summary: "Codex reported blocked for issue #102.",
+          signature: "verification:images",
+          command: "npm run verify:images",
+          details: ["structured_blocked_reason=verification"],
+          url: null,
+          updated_at: "2026-07-11T12:40:00Z",
+        },
         pr_number: null,
         last_tracked_pr_progress_summary:
           "blocked_turn_pr_reconciliation=absent branch=codex/issue-102",
@@ -198,7 +237,10 @@ test("shouldAutoRetryBlockedVerification respects implementation budgets and rep
           summary: "Independent verifier remains blocked.",
           signature: "verification:images",
           command: "npm run verify:images",
-          details: ["review_repair_terminal_blocked_reason=secrets"],
+          details: [
+            "structured_blocked_reason=verification",
+            "review_repair_terminal_blocked_reason=secrets",
+          ],
           url: null,
           updated_at: "2026-07-11T12:40:00Z",
         },
@@ -238,6 +280,15 @@ test("shouldAutoRetryBlockedVerification respects implementation budgets and rep
       createRecord({
         last_error: "Verification blocked: prerequisite not satisfied.",
         blocked_reason: "verification",
+        last_failure_context: {
+          category: "blocked",
+          summary: "Codex reported blocked for issue #102.",
+          signature: "verification:images",
+          command: "npm run verify:images",
+          details: ["structured_blocked_reason=verification"],
+          url: null,
+          updated_at: "2026-07-11T12:40:00Z",
+        },
         pr_number: null,
         last_tracked_pr_progress_summary:
           "blocked_turn_pr_reconciliation=ambiguous branch=codex/issue-102 reason=no_unique_canonical_open_pr candidates=#201,#202",

--- a/src/supervisor/supervisor-execution-policy.test.ts
+++ b/src/supervisor/supervisor-execution-policy.test.ts
@@ -158,6 +158,28 @@ test("shouldAutoRetryBlockedVerification respects implementation budgets and rep
   assert.equal(
     shouldAutoRetryBlockedVerification(
       createRecord({
+        last_error: "Need permission before continuing.",
+        blocked_reason: "verification",
+        last_failure_context: {
+          category: "blocked",
+          summary: "Independent verifier remains blocked.",
+          signature: "verification:images",
+          command: "npm run verify:images",
+          details: [
+            "structured_blocked_reason=verification",
+            "review_repair_interruption_blocked_reason=permissions",
+          ],
+          url: null,
+          updated_at: "2026-07-11T12:40:00Z",
+        },
+      }),
+      config,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldAutoRetryBlockedVerification(
+      createRecord({
         last_error: "Verification blocked: prerequisite not satisfied.",
         blocked_reason: "verification",
         last_failure_context: {
@@ -166,6 +188,27 @@ test("shouldAutoRetryBlockedVerification respects implementation budgets and rep
           signature: "verification:images",
           command: "npm run verify:images",
           details: ["structured_blocked_reason=verification"],
+          url: null,
+          updated_at: "2026-07-11T12:40:00Z",
+        },
+      }),
+      config,
+    ),
+    true,
+  );
+  assert.equal(
+    shouldAutoRetryBlockedVerification(
+      createRecord({
+        issue_number: 102,
+        pr_number: 42,
+        last_error: "Codex reported blocked for issue #102.",
+        blocked_reason: "verification",
+        last_failure_context: {
+          category: "blocked",
+          summary: "Codex reported blocked for issue #102.",
+          signature: "verification:images",
+          command: "npm run verify:images",
+          details: [],
           url: null,
           updated_at: "2026-07-11T12:40:00Z",
         },

--- a/src/supervisor/supervisor-execution-policy.test.ts
+++ b/src/supervisor/supervisor-execution-policy.test.ts
@@ -198,6 +198,19 @@ test("shouldAutoRetryBlockedVerification respects implementation budgets and rep
   assert.equal(
     shouldAutoRetryBlockedVerification(
       createRecord({
+        last_error: "Verification failed: vitest assertion still failing.",
+        blocked_reason: "unknown",
+        pr_number: null,
+        last_tracked_pr_progress_summary:
+          "blocked_turn_pr_reconciliation=absent branch=codex/issue-102",
+      }),
+      config,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldAutoRetryBlockedVerification(
+      createRecord({
         last_error: "Prerequisite not satisfied.",
         blocked_reason: "unknown",
       }),

--- a/src/supervisor/supervisor-execution-policy.test.ts
+++ b/src/supervisor/supervisor-execution-policy.test.ts
@@ -148,6 +148,94 @@ test("shouldAutoRetryBlockedVerification respects implementation budgets and rep
   assert.equal(
     shouldAutoRetryBlockedVerification(
       createRecord({
+        last_error: "Verification blocked: prerequisite not satisfied.",
+        blocked_reason: "verification",
+      }),
+      config,
+    ),
+    true,
+  );
+  assert.equal(
+    shouldAutoRetryBlockedVerification(
+      createRecord({
+        last_error: "Verification failed: vitest assertion still failing.",
+        blocked_reason: "unknown",
+      }),
+      config,
+    ),
+    true,
+  );
+  assert.equal(
+    shouldAutoRetryBlockedVerification(
+      createRecord({
+        last_error: "Prerequisite not satisfied.",
+        blocked_reason: "unknown",
+      }),
+      config,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldAutoRetryBlockedVerification(
+      createRecord({
+        last_error: "Need token before continuing.",
+        blocked_reason: "verification",
+        last_failure_context: {
+          category: "blocked",
+          summary: "Independent verifier remains blocked.",
+          signature: "verification:images",
+          command: "npm run verify:images",
+          details: ["review_repair_terminal_blocked_reason=secrets"],
+          url: null,
+          updated_at: "2026-07-11T12:40:00Z",
+        },
+      }),
+      config,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldAutoRetryBlockedVerification(
+      createRecord({
+        implementation_attempt_count: config.maxImplementationAttemptsPerIssue,
+        repair_attempt_count: 0,
+        pr_number: 42,
+        last_error: "Verification failed: vitest assertion still failing.",
+        blocked_reason: "verification",
+      }),
+      config,
+    ),
+    true,
+  );
+  assert.equal(
+    shouldAutoRetryBlockedVerification(
+      createRecord({
+        implementation_attempt_count: 0,
+        repair_attempt_count: config.maxRepairAttemptsPerIssue,
+        pr_number: 42,
+        last_error: "Verification failed: vitest assertion still failing.",
+        blocked_reason: "verification",
+      }),
+      config,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldAutoRetryBlockedVerification(
+      createRecord({
+        last_error: "Verification blocked: prerequisite not satisfied.",
+        blocked_reason: "verification",
+        pr_number: null,
+        last_tracked_pr_progress_summary:
+          "blocked_turn_pr_reconciliation=ambiguous branch=codex/issue-102 reason=no_unique_canonical_open_pr candidates=#201,#202",
+      }),
+      config,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldAutoRetryBlockedVerification(
+      createRecord({
         last_error: "Verification failed: vitest assertion still failing.",
         blocked_reason: "verification",
       }),

--- a/src/supervisor/supervisor-execution-policy.test.ts
+++ b/src/supervisor/supervisor-execution-policy.test.ts
@@ -178,6 +178,19 @@ test("shouldAutoRetryBlockedVerification respects implementation budgets and rep
   assert.equal(
     shouldAutoRetryBlockedVerification(
       createRecord({
+        last_error: "Verification blocked: prerequisite not satisfied.",
+        blocked_reason: "verification",
+        pr_number: null,
+        last_tracked_pr_progress_summary:
+          "blocked_turn_pr_reconciliation=absent branch=codex/issue-102",
+      }),
+      config,
+    ),
+    false,
+  );
+  assert.equal(
+    shouldAutoRetryBlockedVerification(
+      createRecord({
         last_error: "Need token before continuing.",
         blocked_reason: "verification",
         last_failure_context: {

--- a/src/supervisor/supervisor-execution-policy.ts
+++ b/src/supervisor/supervisor-execution-policy.ts
@@ -1,6 +1,7 @@
 import { shouldAutoRetryTimeout } from "./supervisor-failure-helpers";
 import { GitHubPullRequest, IssueRunRecord, SupervisorConfig } from "../core/types";
 import { isTerminalState } from "../core/utils";
+import { hasBlockedTurnVerificationProvenance } from "./blocked-turn-pr-reconciliation";
 
 export type AttemptLane = "implementation" | "repair";
 
@@ -78,10 +79,16 @@ export function hasAttemptBudgetRemaining(
 }
 
 export function shouldAutoRetryBlockedVerification(record: IssueRunRecord, config: SupervisorConfig): boolean {
-  const unresolvedBlockedTurnPullRequest =
+  const hasUnresolvedBlockedTurnPullRequestDiagnostic =
     record.pr_number === null &&
     /(?:^| \| )blocked_turn_pr_reconciliation=(?:absent|ambiguous|error)\b/u.test(
       record.last_tracked_pr_progress_summary ?? "",
+    );
+  const unresolvedBlockedTurnPullRequest =
+    hasUnresolvedBlockedTurnPullRequestDiagnostic &&
+    (
+      record.blocked_reason !== "verification" ||
+      hasBlockedTurnVerificationProvenance(record)
     );
   return (
     record.state === "blocked" &&

--- a/src/supervisor/supervisor-execution-policy.ts
+++ b/src/supervisor/supervisor-execution-policy.ts
@@ -6,6 +6,27 @@ export type AttemptLane = "implementation" | "repair";
 
 const VERIFICATION_KEYWORD_PATTERN = /\b(playwright|e2e|vitest|assertion|verification|tests?)\b/;
 
+function hasVerificationRetryHardBlocker(
+  message: string | null | undefined,
+): boolean {
+  const lower = message?.toLowerCase() ?? "";
+  return (
+    lower.includes("missing permissions") ||
+    lower.includes("missing secrets") ||
+    lower.includes("unclear requirements")
+  );
+}
+
+function hasPreservedReviewRepairHardBlocker(record: IssueRunRecord): boolean {
+  return (
+    record.last_failure_context?.details.some((detail) =>
+      /^review_repair_terminal_blocked_reason=(?:permissions|secrets|requirements|clarification)$/u.test(
+        detail,
+      )
+    ) ?? false
+  );
+}
+
 export function formatExecutionReadyMissingFields(fields: string[]): string {
   return fields.join(", ");
 }
@@ -22,10 +43,7 @@ export function isVerificationBlockedMessage(message: string | null | undefined)
     lower.includes("failing") ||
     lower.includes("failed") ||
     lower.includes("still failing");
-  const hardBlocker =
-    lower.includes("missing permissions") ||
-    lower.includes("missing secrets") ||
-    lower.includes("unclear requirements");
+  const hardBlocker = hasVerificationRetryHardBlocker(message);
 
   return mentionsVerification && mentionsFailure && !hardBlocker;
 }
@@ -51,10 +69,23 @@ export function hasAttemptBudgetRemaining(
 }
 
 export function shouldAutoRetryBlockedVerification(record: IssueRunRecord, config: SupervisorConfig): boolean {
+  const unresolvedBlockedTurnPullRequest =
+    record.pr_number === null &&
+    /(?:^| \| )blocked_turn_pr_reconciliation=(?:absent|ambiguous|error)\b/u.test(
+      record.last_tracked_pr_progress_summary ?? "",
+    );
   return (
     record.state === "blocked" &&
-    isVerificationBlockedMessage(record.last_error) &&
-    hasAttemptBudgetRemaining(record, config, "implementation") &&
+    !unresolvedBlockedTurnPullRequest &&
+    (
+      (
+        record.blocked_reason === "verification" &&
+        !hasVerificationRetryHardBlocker(record.last_error) &&
+        !hasPreservedReviewRepairHardBlocker(record)
+      ) ||
+      isVerificationBlockedMessage(record.last_error)
+    ) &&
+    hasAttemptBudgetRemaining(record, config, attemptLane(record, null)) &&
     record.blocked_verification_retry_count < config.blockedVerificationRetryLimit &&
     record.repeated_blocker_count < config.sameBlockerRepeatLimit &&
     record.repeated_failure_signature_count < config.sameFailureSignatureRepeatLimit

--- a/src/supervisor/supervisor-execution-policy.ts
+++ b/src/supervisor/supervisor-execution-policy.ts
@@ -27,6 +27,15 @@ function hasPreservedReviewRepairHardBlocker(record: IssueRunRecord): boolean {
   );
 }
 
+function hasStructuredVerificationBlockedReason(record: IssueRunRecord): boolean {
+  return (
+    record.blocked_reason === "verification" &&
+    record.last_failure_context?.details.includes(
+      "structured_blocked_reason=verification",
+    ) === true
+  );
+}
+
 export function formatExecutionReadyMissingFields(fields: string[]): string {
   return fields.join(", ");
 }
@@ -77,11 +86,11 @@ export function shouldAutoRetryBlockedVerification(record: IssueRunRecord, confi
   return (
     record.state === "blocked" &&
     !unresolvedBlockedTurnPullRequest &&
+    !hasPreservedReviewRepairHardBlocker(record) &&
     (
       (
-        record.blocked_reason === "verification" &&
-        !hasVerificationRetryHardBlocker(record.last_error) &&
-        !hasPreservedReviewRepairHardBlocker(record)
+        hasStructuredVerificationBlockedReason(record) &&
+        !hasVerificationRetryHardBlocker(record.last_error)
       ) ||
       isVerificationBlockedMessage(record.last_error)
     ) &&

--- a/src/supervisor/supervisor-execution-policy.ts
+++ b/src/supervisor/supervisor-execution-policy.ts
@@ -21,19 +21,10 @@ function hasVerificationRetryHardBlocker(
 function hasPreservedReviewRepairHardBlocker(record: IssueRunRecord): boolean {
   return (
     record.last_failure_context?.details.some((detail) =>
-      /^review_repair_terminal_blocked_reason=(?:permissions|secrets|requirements|clarification)$/u.test(
+      /^review_repair_(?:interruption|terminal)_blocked_reason=(?:permissions|secrets|requirements|clarification)$/u.test(
         detail,
       )
     ) ?? false
-  );
-}
-
-function hasStructuredVerificationBlockedReason(record: IssueRunRecord): boolean {
-  return (
-    record.blocked_reason === "verification" &&
-    record.last_failure_context?.details.includes(
-      "structured_blocked_reason=verification",
-    ) === true
   );
 }
 
@@ -96,7 +87,7 @@ export function shouldAutoRetryBlockedVerification(record: IssueRunRecord, confi
     !hasPreservedReviewRepairHardBlocker(record) &&
     (
       (
-        hasStructuredVerificationBlockedReason(record) &&
+        hasBlockedTurnVerificationProvenance(record) &&
         !hasVerificationRetryHardBlocker(record.last_error)
       ) ||
       isVerificationBlockedMessage(record.last_error)

--- a/src/supervisor/supervisor-failure-helpers.ts
+++ b/src/supervisor/supervisor-failure-helpers.ts
@@ -14,6 +14,10 @@ import {
   executionMetricsRetentionRootPath,
   syncExecutionMetricsRunSummarySafely,
 } from "./execution-metrics-run-summary";
+import {
+  preserveIndependentVerificationBlockerPatch,
+  type IndependentVerificationBlockerSnapshot,
+} from "./independent-verification-blocker";
 
 type AuthFailureGitHub = Pick<GitHubClient, "authStatus">;
 type FailureHelperStateStore = Pick<StateStore, "save" | "touch">;
@@ -132,6 +136,7 @@ export async function recoverUnexpectedCodexTurnFailure(args: {
   error: unknown;
   workspaceStatus: Pick<WorkspaceStatus, "hasUncommittedChanges" | "headSha"> | null;
   pr: Pick<GitHubPullRequest, "number" | "headRefOid" | "createdAt" | "mergedAt"> | null;
+  independentVerificationBlocker?: IndependentVerificationBlockerSnapshot | null;
 }): Promise<IssueRunRecord> {
   const { config, stateStore, state, record, issue, journalSync, error, workspaceStatus, pr } = args;
   const message = error instanceof Error ? error.stack ?? error.message : String(error);
@@ -152,7 +157,7 @@ export async function recoverUnexpectedCodexTurnFailure(args: {
     ],
   );
 
-  const updated = stateStore.touch(record, {
+  const recoveryPatch: Partial<IssueRunRecord> = {
     state: record.pr_number !== null ? record.state : "failed",
     last_error: record.pr_number !== null ? record.last_error : truncatePreservingStartAndEnd(message),
     last_failure_kind: record.pr_number !== null ? record.last_failure_kind : failureKind,
@@ -166,7 +171,27 @@ export async function recoverUnexpectedCodexTurnFailure(args: {
     blocked_reason: record.pr_number !== null ? record.blocked_reason : null,
     timeout_retry_count:
       failureKind === "timeout" ? record.timeout_retry_count + 1 : record.timeout_retry_count,
-  });
+  };
+  const carrierAwareRecoveryPatch = args.independentVerificationBlocker
+    ? {
+        ...recoveryPatch,
+        state: "failed" as const,
+        last_error: truncatePreservingStartAndEnd(message),
+        last_failure_kind: failureKind,
+        last_failure_context: failureContext,
+        ...applyFailureSignature(record, failureContext),
+        blocked_reason: null,
+      }
+    : recoveryPatch;
+  const updated = stateStore.touch(
+    record,
+    args.independentVerificationBlocker
+      ? preserveIndependentVerificationBlockerPatch(
+          args.independentVerificationBlocker,
+          carrierAwareRecoveryPatch,
+        )
+      : carrierAwareRecoveryPatch,
+  );
   state.issues[String(record.issue_number)] = updated;
   if (state.activeIssueNumber === record.issue_number) {
     state.activeIssueNumber = null;

--- a/src/supervisor/supervisor-recovery-failure-flows.test.ts
+++ b/src/supervisor/supervisor-recovery-failure-flows.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import test, { mock } from "node:test";
 import { GitHubIssue, GitHubPullRequest, IssueRunRecord, SupervisorStateFile } from "../core/types";
 import { recoverUnexpectedCodexTurnFailure } from "./supervisor-failure-helpers";
+import { independentVerificationBlockerSnapshot } from "./independent-verification-blocker";
 import { Supervisor } from "./supervisor";
 import {
   branchName,
@@ -100,6 +101,103 @@ test("recoverUnexpectedCodexTurnFailure fails closed when post-turn refresh blow
   ]);
   assert.equal(state.issues[String(issueNumber)], updated);
   assert.equal(syncedRecord, updated);
+});
+
+test("recoverUnexpectedCodexTurnFailure restores a pre-preparation verifier and nests the unexpected failure", async () => {
+  const issueNumber = 2447;
+  const failureContext = {
+    category: "blocked" as const,
+    summary: "Independent image verification remains blocked.",
+    signature: "verification:images",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-12T00:00:00Z",
+  };
+  const prePreparationRecord = createRecord({
+    issue_number: issueNumber,
+    state: "addressing_review",
+    pr_number: 2451,
+    blocked_reason: "verification",
+    last_error: failureContext.summary,
+    last_failure_context: failureContext,
+    last_failure_signature: failureContext.signature,
+    repeated_failure_signature_count: 3,
+    last_blocker_signature: "verification:images",
+    repeated_blocker_count: 2,
+    blocked_verification_retry_count: 1,
+  });
+  const carriedVerifier = independentVerificationBlockerSnapshot(
+    prePreparationRecord,
+  );
+  assert.ok(carriedVerifier);
+  const preparedRecord = createRecord({
+    ...prePreparationRecord,
+    state: "addressing_review",
+    blocked_reason: null,
+    last_error: null,
+    last_failure_context: null,
+    last_failure_signature: null,
+    repeated_failure_signature_count: 0,
+    last_blocker_signature: null,
+    repeated_blocker_count: 0,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: issueNumber,
+    issues: { [String(issueNumber)]: preparedRecord },
+  };
+  const stateStore = {
+    touch(current: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return { ...current, ...patch, updated_at: "2026-07-12T00:05:00Z" };
+    },
+    async save(): Promise<void> {
+      return undefined;
+    },
+  };
+
+  const updated = await recoverUnexpectedCodexTurnFailure({
+    config: { stateFile: "/tmp/state.json" },
+    stateStore: stateStore as unknown as Parameters<
+      typeof recoverUnexpectedCodexTurnFailure
+    >[0]["stateStore"],
+    state,
+    record: preparedRecord,
+    issue: {
+      number: issueNumber,
+      title: "Carry verifier through unexpected failure",
+      body: runnableCodexIssueBody("Carry verifier through unexpected failure."),
+      createdAt: "2026-07-11T00:00:00Z",
+      updatedAt: "2026-07-12T00:00:00Z",
+      url: `https://example.test/issues/${issueNumber}`,
+      labels: [],
+      state: "OPEN",
+    },
+    journalSync: async () => undefined,
+    error: new Error("preparePrompt exploded before the verifier ran"),
+    workspaceStatus: {
+      hasUncommittedChanges: false,
+      headSha: "head-2451",
+    },
+    pr: {
+      number: 2451,
+      headRefOid: "head-2451",
+      createdAt: "2026-07-11T00:00:00Z",
+      mergedAt: null,
+    },
+    independentVerificationBlocker: carriedVerifier,
+  });
+
+  assert.equal(updated.state, "blocked");
+  assert.equal(updated.blocked_reason, "verification");
+  assert.equal(updated.last_failure_context?.command, "npm run verify:images");
+  assert.equal(updated.last_failure_signature, "verification:images");
+  assert.equal(updated.repeated_failure_signature_count, 3);
+  assert.equal(updated.blocked_verification_retry_count, 1);
+  assert.match(updated.last_runtime_error ?? "", /preparePrompt exploded/);
+  assert.match(
+    updated.last_failure_context?.details.join("\n") ?? "",
+    /review_repair_interruption_detail=.*preparePrompt exploded/,
+  );
 });
 
 test("recoverUnexpectedCodexTurnFailure preserves dirty recovery context and timeout bookkeeping", async () => {

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -1624,6 +1624,141 @@ test("buildIssueExplainDto marks still-valid Codex review repair targets runnabl
   assert.doesNotMatch(rendered, /^reason_\d+=local_state blocked$/m);
 });
 
+test("issue explain distinguishes scheduled blocked-turn review repair from diagnostic-only PR lookup", async () => {
+  const config = createConfig({
+    reviewBotLogins: ["chatgpt-codex-connector"],
+  });
+  const scheduledIssue = createIssue({
+    number: 1700,
+    title: "Resume blocked-turn review repair",
+  });
+  const scheduledBranch = "codex/issue-1700";
+  const scheduledPr = createPullRequest({
+    number: 1701,
+    headRefName: scheduledBranch,
+    headRefOid: "head-1701",
+  });
+  const scheduledState = createSupervisorState({
+    activeIssueNumber: null,
+    issues: [
+      createRecord({
+        issue_number: scheduledIssue.number,
+        branch: scheduledBranch,
+        state: "addressing_review",
+        blocked_reason: "verification",
+        pr_number: scheduledPr.number,
+        last_head_sha: scheduledPr.headRefOid,
+        last_failure_context: {
+          category: "blocked",
+          summary: "Independent verifier remains blocked.",
+          signature: "gitops-images-high-critical",
+          command: "npm run verify:images",
+          details: ["structured_blocked_reason=verification"],
+          url: null,
+          updated_at: "2026-07-11T12:00:00Z",
+        },
+      }),
+    ],
+  });
+  const scheduledRendered = renderIssueExplainDto(
+    await buildIssueExplainDto(
+      {
+        getIssue: async () => scheduledIssue,
+        listAllIssues: async () => [scheduledIssue],
+        listCandidateIssues: async () => [scheduledIssue],
+        resolvePullRequestForBranch: async () => scheduledPr,
+        getChecks: async () => [],
+        getUnresolvedReviewThreads: async () => [],
+      },
+      config,
+      scheduledState,
+      scheduledIssue.number,
+    ),
+  );
+  assert.match(scheduledRendered, /^state=addressing_review$/m);
+  assert.match(scheduledRendered, /^runnable=yes$/m);
+  assert.match(
+    scheduledRendered,
+    /^blocked_turn_pr_reconciliation=scheduled_review_repair issue=#1700 pr=#1701 independent_verification_blocker=carried$/m,
+  );
+  assert.doesNotMatch(
+    scheduledRendered,
+    /no_active_tracked_record .*classification=manual_review_required/,
+  );
+
+  const diagnosticIssue = createIssue({
+    number: 1702,
+    title: "Diagnose ambiguous blocked-turn PR",
+  });
+  const diagnosticHead = "head-1703";
+  const diagnosticPr = createPullRequest({
+    number: 1703,
+    headRefName: "codex/issue-1702",
+    headRefOid: diagnosticHead,
+    configuredBotCurrentHeadObservedAt: "2026-07-11T12:50:00Z",
+    configuredBotLatestReviewedCommitSha: diagnosticHead,
+  });
+  const diagnosticThread = createReviewThread({
+    id: "thread-1703-p2",
+    path: "src/recovery.ts",
+    line: 42,
+    comments: {
+      nodes: [
+        {
+          id: "comment-1703-p2",
+          body: "P2: Repair the current-head lifecycle gap.",
+          createdAt: "2026-07-11T12:50:00Z",
+          url: "https://example.test/pr/1703#discussion_r1",
+          author: {
+            login: "chatgpt-codex-connector",
+            typeName: "Bot",
+          },
+        },
+      ],
+    },
+  });
+  const diagnosticState = createSupervisorState({
+    activeIssueNumber: null,
+    issues: [
+      createRecord({
+        issue_number: diagnosticIssue.number,
+        branch: "codex/issue-1702",
+        state: "blocked",
+        blocked_reason: "verification",
+        pr_number: null,
+        last_head_sha: diagnosticHead,
+        last_tracked_pr_progress_summary:
+          "blocked_turn_pr_reconciliation=ambiguous branch=codex/issue-1702 reason=no_unique_canonical_open_pr candidates=#1703,#1704",
+      }),
+    ],
+  });
+  const diagnosticRendered = renderIssueExplainDto(
+    await buildIssueExplainDto(
+      {
+        getIssue: async () => diagnosticIssue,
+        listAllIssues: async () => [diagnosticIssue],
+        listCandidateIssues: async () => [diagnosticIssue],
+        resolvePullRequestForBranch: async () => diagnosticPr,
+        getChecks: async () => [],
+        getUnresolvedReviewThreads: async () => [diagnosticThread],
+      },
+      config,
+      diagnosticState,
+      diagnosticIssue.number,
+    ),
+  );
+  assert.match(diagnosticRendered, /^state=blocked$/m);
+  assert.match(diagnosticRendered, /^runnable=no$/m);
+  assert.match(
+    diagnosticRendered,
+    /^blocked_turn_pr_reconciliation=ambiguous branch=codex\/issue-1702 reason=no_unique_canonical_open_pr candidates=#1703,#1704$/m,
+  );
+  assert.match(
+    diagnosticRendered,
+    /^codex_connector_operator_diagnostic .* next_action=repair_must_fix_findings$/m,
+  );
+});
+
 test("buildIssueExplainDto reports dependency root blockers for stale configured-bot predecessors", async () => {
   const fixture = await createSupervisorFixture();
   const rootIssue = createIssue({

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -365,6 +365,35 @@ test("buildNonRunnableLocalStateReasons keeps retry-budget ordering stable", () 
   ]);
 });
 
+test("buildNonRunnableLocalStateReasons reports exhausted repair budget for tracked verification retries", () => {
+  const config = createConfig({
+    maxImplementationAttemptsPerIssue: 5,
+    maxRepairAttemptsPerIssue: 2,
+  });
+  const reasons = buildNonRunnableLocalStateReasons(
+    createRecord({
+      issue_number: 605,
+      blocked_reason: "verification",
+      pr_number: 42,
+      implementation_attempt_count: 1,
+      repair_attempt_count: config.maxRepairAttemptsPerIssue,
+      last_error: "Verification failed: vitest assertion still failing.",
+      last_failure_kind: null,
+      last_failure_context: null,
+      last_failure_signature: "verification-failure",
+      blocked_verification_retry_count: 0,
+      repeated_blocker_count: 0,
+      repeated_failure_signature_count: 0,
+    }),
+    config,
+  );
+
+  assert.deepEqual(reasons, [
+    `retry_budget repair_attempt_count=${config.maxRepairAttemptsPerIssue}/${config.maxRepairAttemptsPerIssue}`,
+    "local_state blocked",
+  ]);
+});
+
 test("buildIssueExplainSummary reports retryable timeout failures as timeout_retry pending", async () => {
   const config = createConfig({
     timeoutRetryLimit: 2,

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -10,6 +10,8 @@ import {
 } from "../issue-metadata";
 import {
   attemptBudgetForLane,
+  attemptLane,
+  attemptsUsedForLane,
   formatExecutionReadyMissingFields,
   hasAttemptBudgetRemaining,
   isEligibleForSelection,
@@ -299,9 +301,10 @@ export function buildNonRunnableLocalStateReasons(record: IssueRunRecord, config
     ) {
       reasons.push(`manual_block ${record.blocked_reason}`);
     } else if (record.blocked_reason === "verification" && !shouldAutoRetryBlockedVerification(record, config)) {
-      if (!hasAttemptBudgetRemaining(record, config, "implementation")) {
+      const retryLane = attemptLane(record, null);
+      if (!hasAttemptBudgetRemaining(record, config, retryLane)) {
         reasons.push(
-          `retry_budget implementation_attempt_count=${record.implementation_attempt_count}/${attemptBudgetForLane(config, "implementation")}`,
+          `retry_budget ${retryLane}_attempt_count=${attemptsUsedForLane(record, retryLane)}/${attemptBudgetForLane(config, retryLane)}`,
         );
       }
       if (record.blocked_verification_retry_count >= config.blockedVerificationRetryLimit) {

--- a/src/supervisor/supervisor-selection-issue-explain.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.ts
@@ -68,6 +68,7 @@ import {
   maybeBuildIssueActivityContext,
   type SupervisorIssueActivityContextDto,
 } from "./supervisor-operator-activity-context";
+import { blockedTurnPullRequestReconciliationStatusLine } from "./blocked-turn-pr-reconciliation";
 import { formatPreMergeEvaluationStatusLine, loadPreMergeEvaluationDto } from "./supervisor-pre-merge-evaluation";
 import { summarizePreservedPartialWork } from "./supervisor-preserved-partial-work";
 import {
@@ -147,6 +148,7 @@ export interface SupervisorExplainDto {
   codexConnectorConvergenceSummary?: string | null;
   noActiveTrackedRecordSummary?: string | null;
   trackedPrRetryabilitySummary?: string | null;
+  blockedTurnPrReconciliationSummary?: string | null;
   trackedPrReadyPromotionMaintenanceSummary?: string | null;
   trackedPrMismatchSummary: string | null;
   trackedPrMismatchDetailLines?: string[];
@@ -684,6 +686,8 @@ export async function buildIssueExplainDto(
           `signal=${record.last_tracked_pr_progress_summary.replace(/\s+/g, "_")}`,
         ].join(" ")
         : null,
+    blockedTurnPrReconciliationSummary:
+      blockedTurnPullRequestReconciliationStatusLine(record ?? null),
     trackedPrReadyPromotionMaintenanceSummary,
     trackedPrMismatchSummary: trackedPrMismatch?.summaryLine ?? null,
     trackedPrMismatchDetailLines: trackedPrMismatch?.detailLines ?? [],
@@ -782,6 +786,9 @@ export function renderIssueExplainDto(dto: SupervisorExplainDto): string {
     ...(dto.codexConnectorConvergenceSummary ? [dto.codexConnectorConvergenceSummary] : []),
     ...(dto.noActiveTrackedRecordSummary ? [dto.noActiveTrackedRecordSummary] : []),
     ...(dto.trackedPrRetryabilitySummary ? [dto.trackedPrRetryabilitySummary] : []),
+    ...(dto.blockedTurnPrReconciliationSummary
+      ? [dto.blockedTurnPrReconciliationSummary]
+      : []),
     ...(dto.trackedPrReadyPromotionMaintenanceSummary ? [dto.trackedPrReadyPromotionMaintenanceSummary] : []),
     ...(dto.trackedPrMismatchSummary ? [dto.trackedPrMismatchSummary] : []),
     ...(dto.trackedPrMismatchDetailLines ? dto.trackedPrMismatchDetailLines : []),

--- a/src/supervisor/supervisor-status-rendering.test.ts
+++ b/src/supervisor/supervisor-status-rendering.test.ts
@@ -820,3 +820,76 @@ test("formatDetailedStatus renders a compact latest recovery summary for the act
     /latest_recovery issue=#91 at=2026-03-13T00:20:00Z reason=tracked_pr_head_advanced detail=resumed issue #91 from blocked to reproducing after tracked PR #191 advanced from head-old-191 to head-new-191/,
   );
 });
+
+test("formatDetailedStatus distinguishes scheduled blocked-turn repair from diagnostic-only PR reconciliation", () => {
+  const scheduledRecord = createRecord({
+    issue_number: 1700,
+    state: "addressing_review",
+    branch: "codex/issue-1700",
+    pr_number: 1701,
+    blocked_reason: "verification",
+    last_failure_context: {
+      category: "blocked",
+      summary: "Independent verification remains blocked.",
+      signature: "verification:independent",
+      command: "npm run verify:images",
+      details: ["structured_blocked_reason=verification"],
+      url: null,
+      updated_at: "2026-07-11T12:45:00Z",
+    },
+  });
+  const scheduledStatus = formatDetailedStatus({
+    config: createConfig(),
+    activeRecord: scheduledRecord,
+    latestRecord: scheduledRecord,
+    latestRecoveryRecord: null,
+    trackedIssueCount: 1,
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+  });
+
+  assert.match(scheduledStatus, /^state=addressing_review$/m);
+  assert.match(
+    scheduledStatus,
+    /^blocked_turn_pr_reconciliation=scheduled_review_repair issue=#1700 pr=#1701 independent_verification_blocker=carried$/m,
+  );
+  assert.doesNotMatch(
+    scheduledStatus,
+    /no_active_tracked_record .*classification=manual_review_required/,
+  );
+
+  const diagnosticRecord = createRecord({
+    issue_number: 1702,
+    state: "blocked",
+    branch: "codex/issue-1702",
+    pr_number: null,
+    blocked_reason: "verification",
+    last_tracked_pr_progress_summary:
+      "blocked_turn_pr_reconciliation=ambiguous branch=codex/issue-1702 reason=no_unique_canonical_open_pr candidates=#1703,#1704",
+  });
+  const diagnosticStatus = formatDetailedStatus({
+    config: createConfig(),
+    activeRecord: null,
+    latestRecord: diagnosticRecord,
+    latestRecoveryRecord: null,
+    trackedIssueCount: 1,
+    pr: null,
+    checks: [],
+    reviewThreads: [],
+  });
+
+  assert.match(diagnosticStatus, /^No active issue\.$/m);
+  assert.match(
+    diagnosticStatus,
+    /^no_active_tracked_record issue=#1702 classification=manual_review_required state=blocked reason=verification$/m,
+  );
+  assert.match(
+    diagnosticStatus,
+    /^blocked_turn_pr_reconciliation=ambiguous branch=codex\/issue-1702 reason=no_unique_canonical_open_pr candidates=#1703,#1704$/m,
+  );
+  assert.doesNotMatch(
+    diagnosticStatus,
+    /blocked_turn_pr_reconciliation=scheduled_review_repair/,
+  );
+});

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -669,8 +669,34 @@ export class Supervisor {
         state: nextState,
         ...incrementAttemptCounters(record, preRunAttemptLane),
         ...addressingReviewStrategyPatch(record, nextState),
-        last_failure_context: inferFailureContext(this.config, record, pr, checks, reviewThreads),
-        blocked_reason: null,
+        ...(independentVerificationBlocker
+          ? {
+              last_error: independentVerificationBlocker.lastError,
+              last_failure_kind: null,
+              last_failure_context:
+                independentVerificationBlocker.lastFailureContext,
+              last_failure_signature:
+                independentVerificationBlocker.lastFailureSignature,
+              repeated_failure_signature_count:
+                independentVerificationBlocker.repeatedFailureSignatureCount,
+              last_blocker_signature:
+                independentVerificationBlocker.lastBlockerSignature,
+              repeated_blocker_count:
+                independentVerificationBlocker.repeatedBlockerCount,
+              blocked_verification_retry_count:
+                independentVerificationBlocker.blockedVerificationRetryCount,
+              blocked_reason: "verification" as const,
+            }
+          : {
+              last_failure_context: inferFailureContext(
+                this.config,
+                record,
+                pr,
+                checks,
+                reviewThreads,
+              ),
+              blocked_reason: null,
+            }),
       });
       state.issues[String(record.issue_number)] = record;
       await this.stateStore.save(state);

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -639,7 +639,9 @@ export class Supervisor {
       : inferStateWithoutPullRequest(record, workspaceStatus);
 
     if (options.dryRun) {
-      record = this.stateStore.touch(record, { state: nextState });
+      if (!independentVerificationBlocker) {
+        record = this.stateStore.touch(record, { state: nextState });
+      }
       state.issues[String(record.issue_number)] = record;
       await this.stateStore.save(state);
       return {

--- a/src/supervisor/supervisor.ts
+++ b/src/supervisor/supervisor.ts
@@ -49,6 +49,7 @@ import {
   CodexTurnShortCircuit,
   executeCodexTurnPhase,
 } from "../run-once-turn-execution";
+import { independentVerificationBlockerSnapshot } from "./independent-verification-blocker";
 import {
   handlePostTurnPullRequestTransitionsPhase,
   PostTurnPullRequestContext,
@@ -630,6 +631,9 @@ export class Supervisor {
 
   private async executeCodexTurn(context: CodexTurnContext): Promise<CodexTurnResult | CodexTurnShortCircuit> {
     let { state, record, pr, checks, reviewThreads, workspaceStatus, syncJournal, options } = context;
+    const independentVerificationBlocker =
+      context.independentVerificationBlocker ??
+      independentVerificationBlockerSnapshot(record);
     const nextState = pr
       ? inferStateFromPullRequest(this.config, record, pr, checks, reviewThreads)
       : inferStateWithoutPullRequest(record, workspaceStatus);
@@ -678,6 +682,7 @@ export class Supervisor {
           ...context,
           record,
           reviewThreads,
+          independentVerificationBlocker,
         },
         sessionLock,
         acquireSessionLock: async (sessionId) => acquireFileLock(

--- a/src/turn-execution-failure-helpers.test.ts
+++ b/src/turn-execution-failure-helpers.test.ts
@@ -1,9 +1,15 @@
 import assert from "node:assert/strict";
 import fs from "node:fs/promises";
 import test, { mock } from "node:test";
-import { persistCodexTurnExitFailure, persistHintedCodexTurnState } from "./turn-execution-failure-helpers";
-import { SupervisorStateFile } from "./core/types";
+import {
+  persistCodexTurnExecutionFailure,
+  persistCodexTurnExitFailure,
+  persistHintedCodexTurnState,
+  persistMissingCodexJournalHandoff,
+} from "./turn-execution-failure-helpers";
+import { FailureContext, SupervisorStateFile } from "./core/types";
 import { createRecord } from "./turn-execution-test-helpers";
+import { independentVerificationBlockerSnapshot } from "./supervisor/independent-verification-blocker";
 
 test("persistHintedCodexTurnState records blocked reasons and repeated blocker bookkeeping from Codex hints", async () => {
   const state: SupervisorStateFile = {
@@ -259,4 +265,145 @@ test("persistCodexTurnExitFailure skips issue-definition freshness when labels a
   assert.equal(updated.state, "failed");
   assert.equal(updated.issue_definition_fingerprint, "existing-fingerprint");
   assert.equal(updated.issue_definition_updated_at, "2026-03-24T02:59:00Z");
+});
+
+test("early Codex failure persistence keeps a carried verifier across timeout, nonzero exit, and missing handoff", async () => {
+  const verifierContext = {
+    category: "blocked" as const,
+    summary: "Independent image verification remains blocked.",
+    signature: "verification:images",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-12T00:00:00Z",
+  };
+  const carriedRecord = createRecord({
+    issue_number: 2447,
+    state: "addressing_review",
+    pr_number: 2451,
+    blocked_reason: "verification",
+    last_error: verifierContext.summary,
+    last_failure_context: verifierContext,
+    last_failure_signature: verifierContext.signature,
+    repeated_failure_signature_count: 3,
+    last_blocker_signature: "verification:images",
+    repeated_blocker_count: 2,
+    blocked_verification_retry_count: 1,
+    timeout_retry_count: 2,
+  });
+  const carriedVerifier = independentVerificationBlockerSnapshot(carriedRecord);
+  assert.ok(carriedVerifier);
+  const buildCodexFailureContext = (
+    category: FailureContext["category"],
+    summary: string,
+    details: string[],
+  ) => ({
+    category,
+    summary,
+    signature: `${category}:${summary}`,
+    command: null,
+    details,
+    url: null,
+    updated_at: "2026-07-12T00:05:00Z",
+  });
+  const applyFailureSignature = () => ({
+    last_failure_signature: "superseding-failure",
+    repeated_failure_signature_count: 1,
+  });
+  const stateStore = {
+    touch: (record: typeof carriedRecord, patch: Partial<typeof carriedRecord>) => ({
+      ...record,
+      ...patch,
+      updated_at: "2026-07-12T00:05:00Z",
+    }),
+    save: async () => undefined,
+  };
+
+  const scenarios = [
+    {
+      name: "timeout",
+      run: async (state: SupervisorStateFile) =>
+        persistCodexTurnExecutionFailure({
+          stateStore,
+          state,
+          record: carriedRecord,
+          issue: { createdAt: "2026-07-11T00:00:00Z" },
+          syncJournal: async () => undefined,
+          issueNumber: 2447,
+          error: new Error("Command timed out after 1800000ms: codex exec"),
+          classifyFailure: () => "timeout",
+          buildCodexFailureContext,
+          applyFailureSignature,
+          preservedVerificationBlocker: carriedVerifier,
+        }),
+      expectedDetail: /review_repair_interruption_detail=.*timed out/i,
+      expectedTimeoutCount: 3,
+    },
+    {
+      name: "nonzero exit",
+      run: async (state: SupervisorStateFile) =>
+        persistCodexTurnExitFailure({
+          stateStore,
+          state,
+          record: carriedRecord,
+          issue: { createdAt: "2026-07-11T00:00:00Z" },
+          syncJournal: async () => undefined,
+          issueNumber: 2447,
+          codexResult: {
+            lastMessage: "Review repair command failed.",
+            stderr: "permission denied",
+            stdout: "",
+          },
+          classifyFailure: () => "command_error",
+          buildCodexFailureContext,
+          applyFailureSignature,
+          preservedVerificationBlocker: carriedVerifier,
+        }),
+      expectedDetail: /review_repair_interruption_detail=.*permission denied/i,
+      expectedTimeoutCount: 2,
+    },
+    {
+      name: "missing handoff",
+      run: async (state: SupervisorStateFile) =>
+        persistMissingCodexJournalHandoff({
+          stateStore,
+          state,
+          record: carriedRecord,
+          issue: { createdAt: "2026-07-11T00:00:00Z" },
+          syncJournal: async () => undefined,
+          issueNumber: 2447,
+          buildCodexFailureContext,
+          applyFailureSignature,
+          preservedVerificationBlocker: carriedVerifier,
+        }),
+      expectedDetail: /review_repair_interruption_blocked_reason=handoff_missing/,
+      expectedTimeoutCount: 2,
+    },
+  ];
+
+  for (const scenario of scenarios) {
+    const state: SupervisorStateFile = {
+      activeIssueNumber: 2447,
+      issues: { "2447": carriedRecord },
+    };
+    const updated = await scenario.run(state);
+    assert.equal(updated.state, "blocked", scenario.name);
+    assert.equal(updated.blocked_reason, "verification", scenario.name);
+    assert.equal(
+      updated.last_failure_context?.command,
+      "npm run verify:images",
+      scenario.name,
+    );
+    assert.equal(updated.last_failure_signature, "verification:images", scenario.name);
+    assert.equal(updated.repeated_failure_signature_count, 3, scenario.name);
+    assert.equal(updated.last_blocker_signature, "verification:images", scenario.name);
+    assert.equal(updated.repeated_blocker_count, 2, scenario.name);
+    assert.equal(updated.blocked_verification_retry_count, 1, scenario.name);
+    assert.equal(updated.timeout_retry_count, scenario.expectedTimeoutCount, scenario.name);
+    assert.match(
+      updated.last_failure_context?.details.join("\n") ?? "",
+      scenario.expectedDetail,
+      scenario.name,
+    );
+  }
 });

--- a/src/turn-execution-failure-helpers.ts
+++ b/src/turn-execution-failure-helpers.ts
@@ -80,6 +80,16 @@ interface PersistHintedCodexTurnStateArgs {
   hintedState: "blocked" | "failed";
   hintedBlockedReason: IssueRunRecord["blocked_reason"];
   hintedFailureSignature: string | null;
+  hintedVerificationCommand?: string | null;
+  preservedVerificationBlocker?: {
+    blockedVerificationRetryCount: number;
+    lastBlockerSignature: string | null;
+    lastError: string | null;
+    lastFailureContext: FailureContext;
+    lastFailureSignature: string | null;
+    repeatedBlockerCount: number;
+    repeatedFailureSignatureCount: number;
+  } | null;
   buildCodexFailureContext: (
     category: FailureContext["category"],
     summary: string,
@@ -258,9 +268,35 @@ export async function persistHintedCodexTurnState(args: PersistHintedCodexTurnSt
     `Codex reported ${args.hintedState} for issue #${args.issueNumber}.`,
     [truncate(args.lastMessage, 2000) ?? "No additional summary."],
   );
+  if (
+    args.hintedState === "blocked" &&
+    args.hintedBlockedReason === "verification"
+  ) {
+    failureContext.details = [
+      ...failureContext.details,
+      "structured_blocked_reason=verification",
+    ];
+  }
   if (args.hintedFailureSignature) {
     failureContext.signature = args.hintedFailureSignature;
   }
+  if (args.hintedVerificationCommand) {
+    failureContext.command = args.hintedVerificationCommand;
+  }
+
+  const preservedVerificationBlocker = args.preservedVerificationBlocker ?? null;
+  const preservedFailureContext = preservedVerificationBlocker
+    ? {
+        ...preservedVerificationBlocker.lastFailureContext,
+        details: [
+          ...preservedVerificationBlocker.lastFailureContext.details,
+          `review_repair_terminal_state=${args.hintedState}`,
+          `review_repair_terminal_blocked_reason=${args.hintedBlockedReason ?? "unknown"}`,
+          ...failureContext.details,
+        ],
+        updated_at: failureContext.updated_at,
+      }
+    : null;
 
   return persistTurnFailurePatch({
     stateStore: args.stateStore,
@@ -270,14 +306,49 @@ export async function persistHintedCodexTurnState(args: PersistHintedCodexTurnSt
     syncJournal: args.syncJournal,
     retentionRootPath: args.retentionRootPath,
     patch: {
-      state: args.hintedState,
-      last_error: truncate(args.lastMessage),
-      last_failure_kind: args.hintedState === "failed" ? "codex_failed" : null,
-      last_failure_context: failureContext,
-      ...args.applyFailureSignature(args.record, failureContext),
-      ...nextBlockerTracking(args.record, args.hintedState, args.lastMessage, args.normalizeBlockerSignature),
-      blocked_reason:
-        args.hintedState === "blocked"
+      state: preservedVerificationBlocker ? "blocked" : args.hintedState,
+      last_error: preservedVerificationBlocker
+        ? truncate(
+            [
+              preservedVerificationBlocker.lastError,
+              `Review repair turn reported ${args.hintedState} (${args.hintedBlockedReason ?? "unknown"}): ${args.lastMessage}`,
+            ]
+              .filter((value): value is string => Boolean(value))
+              .join("\n"),
+          )
+        : truncate(args.lastMessage),
+      last_failure_kind:
+        preservedVerificationBlocker
+          ? null
+          : args.hintedState === "failed"
+            ? "codex_failed"
+            : null,
+      last_failure_context: preservedFailureContext ?? failureContext,
+      ...(preservedVerificationBlocker
+        ? {
+            last_failure_signature:
+              preservedVerificationBlocker.lastFailureSignature,
+            repeated_failure_signature_count:
+              preservedVerificationBlocker.repeatedFailureSignatureCount,
+            last_blocker_signature:
+              preservedVerificationBlocker.lastBlockerSignature,
+            repeated_blocker_count:
+              preservedVerificationBlocker.repeatedBlockerCount,
+            blocked_verification_retry_count:
+              preservedVerificationBlocker.blockedVerificationRetryCount,
+          }
+        : {
+            ...args.applyFailureSignature(args.record, failureContext),
+            ...nextBlockerTracking(
+              args.record,
+              args.hintedState,
+              args.lastMessage,
+              args.normalizeBlockerSignature,
+            ),
+          }),
+      blocked_reason: preservedVerificationBlocker
+        ? "verification"
+        : args.hintedState === "blocked"
           ? args.hintedBlockedReason ??
             (args.isVerificationBlockedMessage(args.lastMessage) ? "verification" : "unknown")
           : null,

--- a/src/turn-execution-failure-helpers.ts
+++ b/src/turn-execution-failure-helpers.ts
@@ -3,6 +3,11 @@ import { CodexTurnResult, FailureContext, GitHubIssue, IssueRunRecord, Superviso
 import { issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
 import { truncate, truncatePreservingStartAndEnd } from "./core/utils";
 import { syncExecutionMetricsRunSummarySafely } from "./supervisor/execution-metrics-run-summary";
+import {
+  preserveIndependentVerificationBlockerPatch,
+  type IndependentVerificationBlockerSnapshot,
+  type IndependentVerificationBlockerPersistenceOptions,
+} from "./supervisor/independent-verification-blocker";
 
 type TurnExecutionFailureStateStore = Pick<StateStore, "save" | "touch">;
 type IssueDefinitionAwareIssue = Pick<GitHubIssue, "createdAt">
@@ -27,6 +32,7 @@ interface PersistTurnExecutionFailureArgs {
     failureContext: FailureContext | null,
   ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
   retentionRootPath?: string;
+  preservedVerificationBlocker?: IndependentVerificationBlockerSnapshot | null;
 }
 
 interface PersistCodexExitFailureArgs {
@@ -48,6 +54,7 @@ interface PersistCodexExitFailureArgs {
     failureContext: FailureContext | null,
   ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
   retentionRootPath?: string;
+  preservedVerificationBlocker?: IndependentVerificationBlockerSnapshot | null;
 }
 
 interface PersistMissingJournalHandoffArgs {
@@ -67,6 +74,7 @@ interface PersistMissingJournalHandoffArgs {
     failureContext: FailureContext | null,
   ) => Pick<IssueRunRecord, "last_failure_signature" | "repeated_failure_signature_count">;
   retentionRootPath?: string;
+  preservedVerificationBlocker?: IndependentVerificationBlockerSnapshot | null;
 }
 
 interface PersistHintedCodexTurnStateArgs {
@@ -81,15 +89,7 @@ interface PersistHintedCodexTurnStateArgs {
   hintedBlockedReason: IssueRunRecord["blocked_reason"];
   hintedFailureSignature: string | null;
   hintedVerificationCommand?: string | null;
-  preservedVerificationBlocker?: {
-    blockedVerificationRetryCount: number;
-    lastBlockerSignature: string | null;
-    lastError: string | null;
-    lastFailureContext: FailureContext;
-    lastFailureSignature: string | null;
-    repeatedBlockerCount: number;
-    repeatedFailureSignatureCount: number;
-  } | null;
+  preservedVerificationBlocker?: IndependentVerificationBlockerSnapshot | null;
   buildCodexFailureContext: (
     category: FailureContext["category"],
     summary: string,
@@ -140,6 +140,8 @@ async function persistTurnFailurePatch(args: {
   syncJournal: (record: IssueRunRecord) => Promise<void>;
   patch: Partial<IssueRunRecord>;
   retentionRootPath?: string;
+  preservedVerificationBlocker?: IndependentVerificationBlockerSnapshot | null;
+  preservationOptions?: IndependentVerificationBlockerPersistenceOptions;
 }): Promise<IssueRunRecord> {
   let issueDefinitionPatch: ReturnType<typeof issueDefinitionFreshnessPatch> | null = null;
   if (
@@ -163,7 +165,14 @@ async function persistTurnFailurePatch(args: {
         ...issueDefinitionPatch,
       }
     : args.patch;
-  const updated = args.stateStore.touch(args.record, effectivePatch);
+  const persistencePatch = args.preservedVerificationBlocker
+    ? preserveIndependentVerificationBlockerPatch(
+        args.preservedVerificationBlocker,
+        effectivePatch,
+        args.preservationOptions,
+      )
+    : effectivePatch;
+  const updated = args.stateStore.touch(args.record, persistencePatch);
   args.state.issues[String(args.record.issue_number)] = updated;
   await args.stateStore.save(args.state);
   await syncExecutionMetricsRunSummarySafely({
@@ -193,6 +202,7 @@ export async function persistCodexTurnExecutionFailure(args: PersistTurnExecutio
     issue: args.issue,
     syncJournal: args.syncJournal,
     retentionRootPath: args.retentionRootPath,
+    preservedVerificationBlocker: args.preservedVerificationBlocker,
     patch: {
       state: "failed",
       last_error: truncatePreservingStartAndEnd(message),
@@ -223,6 +233,7 @@ export async function persistCodexTurnExitFailure(args: PersistCodexExitFailureA
     issue: args.issue,
     syncJournal: args.syncJournal,
     retentionRootPath: args.retentionRootPath,
+    preservedVerificationBlocker: args.preservedVerificationBlocker,
     patch: {
       state: "failed",
       last_error: truncatePreservingStartAndEnd(failureOutput),
@@ -251,6 +262,7 @@ export async function persistMissingCodexJournalHandoff(
     issue: args.issue,
     syncJournal: args.syncJournal,
     retentionRootPath: args.retentionRootPath,
+    preservedVerificationBlocker: args.preservedVerificationBlocker,
     patch: {
       state: "blocked",
       last_error: truncate(failureContext.summary),
@@ -284,20 +296,6 @@ export async function persistHintedCodexTurnState(args: PersistHintedCodexTurnSt
     failureContext.command = args.hintedVerificationCommand;
   }
 
-  const preservedVerificationBlocker = args.preservedVerificationBlocker ?? null;
-  const preservedFailureContext = preservedVerificationBlocker
-    ? {
-        ...preservedVerificationBlocker.lastFailureContext,
-        details: [
-          ...preservedVerificationBlocker.lastFailureContext.details,
-          `review_repair_terminal_state=${args.hintedState}`,
-          `review_repair_terminal_blocked_reason=${args.hintedBlockedReason ?? "unknown"}`,
-          ...failureContext.details,
-        ],
-        updated_at: failureContext.updated_at,
-      }
-    : null;
-
   return persistTurnFailurePatch({
     stateStore: args.stateStore,
     state: args.state,
@@ -305,50 +303,25 @@ export async function persistHintedCodexTurnState(args: PersistHintedCodexTurnSt
     issue: args.issue,
     syncJournal: args.syncJournal,
     retentionRootPath: args.retentionRootPath,
+    preservedVerificationBlocker: args.preservedVerificationBlocker,
+    preservationOptions: {
+      diagnosticPrefix: "review_repair_terminal",
+    },
     patch: {
-      state: preservedVerificationBlocker ? "blocked" : args.hintedState,
-      last_error: preservedVerificationBlocker
-        ? truncate(
-            [
-              preservedVerificationBlocker.lastError,
-              `Review repair turn reported ${args.hintedState} (${args.hintedBlockedReason ?? "unknown"}): ${args.lastMessage}`,
-            ]
-              .filter((value): value is string => Boolean(value))
-              .join("\n"),
-          )
-        : truncate(args.lastMessage),
+      state: args.hintedState,
+      last_error: truncate(args.lastMessage),
       last_failure_kind:
-        preservedVerificationBlocker
-          ? null
-          : args.hintedState === "failed"
-            ? "codex_failed"
-            : null,
-      last_failure_context: preservedFailureContext ?? failureContext,
-      ...(preservedVerificationBlocker
-        ? {
-            last_failure_signature:
-              preservedVerificationBlocker.lastFailureSignature,
-            repeated_failure_signature_count:
-              preservedVerificationBlocker.repeatedFailureSignatureCount,
-            last_blocker_signature:
-              preservedVerificationBlocker.lastBlockerSignature,
-            repeated_blocker_count:
-              preservedVerificationBlocker.repeatedBlockerCount,
-            blocked_verification_retry_count:
-              preservedVerificationBlocker.blockedVerificationRetryCount,
-          }
-        : {
-            ...args.applyFailureSignature(args.record, failureContext),
-            ...nextBlockerTracking(
-              args.record,
-              args.hintedState,
-              args.lastMessage,
-              args.normalizeBlockerSignature,
-            ),
-          }),
-      blocked_reason: preservedVerificationBlocker
-        ? "verification"
-        : args.hintedState === "blocked"
+        args.hintedState === "failed" ? "codex_failed" : null,
+      last_failure_context: failureContext,
+      ...args.applyFailureSignature(args.record, failureContext),
+      ...nextBlockerTracking(
+        args.record,
+        args.hintedState,
+        args.lastMessage,
+        args.normalizeBlockerSignature,
+      ),
+      blocked_reason:
+        args.hintedState === "blocked"
           ? args.hintedBlockedReason ??
             (args.isVerificationBlockedMessage(args.lastMessage) ? "verification" : "unknown")
           : null,

--- a/src/turn-execution-orchestration.test.ts
+++ b/src/turn-execution-orchestration.test.ts
@@ -2377,6 +2377,81 @@ test("prepareCodexTurnPrompt falls back to the full start prompt when the runner
   assert.match(prompt, /The fresh session still needs the issue body\./);
 });
 
+test("prepareCodexTurnPrompt projects an independent verifier override into the prompt without mutating lifecycle state", async () => {
+  const failureContextOverride = {
+    category: "blocked" as const,
+    summary: "Codex reported blocked for issue #102.",
+    signature: "verification:images",
+    command: "npm run verify:images",
+    details: ["structured_blocked_reason=verification"],
+    url: null,
+    updated_at: "2026-07-11T12:40:00Z",
+  };
+  const record = createRecord({
+    state: "ready_to_merge",
+    pr_number: 202,
+    blocked_reason: null,
+    last_error: null,
+    last_failure_context: null,
+    last_failure_signature: null,
+  });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 102,
+    issues: { "102": record },
+  };
+
+  const prepared = await prepareCodexTurnPrompt({
+    config: createConfig(),
+    stateStore: {
+      touch: (currentRecord, patch) => ({
+        ...currentRecord,
+        ...patch,
+        updated_at: currentRecord.updated_at,
+      }),
+      save: async () => undefined,
+    },
+    state,
+    record,
+    issue: createIssue({
+      title: "Retry the independent image verifier",
+      body: "## Summary\nRerun the exact carried verifier before PR promotion.",
+    }),
+    previousCodexSummary: null,
+    previousError: failureContextOverride.summary,
+    workspacePath: path.join("/tmp/workspaces", "issue-102"),
+    journalPath: path.join(
+      "/tmp/workspaces",
+      "issue-102/.codex-supervisor/issue-journal.md",
+    ),
+    journalContent: "## Codex Working Notes\n### Current Handoff\n- Rerun the carried verifier.",
+    syncJournal: async () => undefined,
+    memoryArtifacts: {
+      alwaysReadFiles: [],
+      onDemandFiles: [],
+      contextIndexPath: "/tmp/context-index.md",
+      agentsPath: "/tmp/AGENTS.generated.md",
+    },
+    pr: createPullRequest({ number: 202, headRefOid: "head-202" }),
+    checks: [],
+    reviewThreads: [],
+    github: {
+      getExternalReviewSurface: async () => {
+        throw new Error("unexpected getExternalReviewSurface call");
+      },
+    },
+    failureContextOverride,
+    agentRunnerCapabilities: { supportsResume: false },
+    loadChangedFiles: async () => [],
+  });
+
+  assert.equal(
+    prepared.turnContext.failureContext?.command,
+    "npm run verify:images",
+  );
+  assert.equal(prepared.record.last_failure_context, null);
+  assert.match(buildCodexPrompt(prepared.turnContext), /npm run verify:images/);
+});
+
 test("prepareCodexTurnPrompt computes change classes for start prompts", async () => {
   const state: SupervisorStateFile = {
     activeIssueNumber: 102,

--- a/src/turn-execution-orchestration.ts
+++ b/src/turn-execution-orchestration.ts
@@ -39,6 +39,7 @@ import {
 import { IssueJournalSync, MemoryArtifacts } from "./run-once-issue-preparation";
 import { StateStore } from "./core/state-store";
 import {
+  FailureContext,
   GitHubIssue,
   GitHubPullRequest,
   IssueRunRecord,
@@ -288,6 +289,7 @@ export async function prepareCodexTurnPrompt(args: {
   checks: import("./core/types").PullRequestCheck[];
   reviewThreads: ReviewThread[];
   github: Pick<GitHubClient, "getExternalReviewSurface">;
+  failureContextOverride?: FailureContext | null;
   agentRunnerCapabilities?: Pick<AgentRunnerCapabilities, "supportsResume">;
   loadChangedFiles?: (config: SupervisorConfig, workspacePath: string) => Promise<string[]>;
 }): Promise<{
@@ -383,7 +385,10 @@ export async function prepareCodexTurnPrompt(args: {
     branch: record.branch,
     journalPath: args.journalPath,
     journalExcerpt: truncate(args.journalContent, 5000),
-    failureContext: record.last_failure_context,
+    failureContext:
+      args.failureContextOverride === undefined
+        ? record.last_failure_context
+        : args.failureContextOverride,
     previousSummary: args.previousCodexSummary,
     previousError: args.previousError,
   };


### PR DESCRIPTION
## Summary
- reconcile the workspace and a uniquely owned, same-repository branch PR before persisting structured `blocked` or `failed` turns
- recover legacy blocked records with no PR binding and schedule current-head configured-bot repair when required
- preserve independent verification blockers through review repair until the exact verifier reports passing evidence
- distinguish scheduled repair from diagnostic-only reconciliation in `status --why` and `explain`

## Safety boundaries
- bound branch discovery to two raw candidates, reject forks/shared branches/multiple matches, and hydrate only the unique canonical candidate
- fail closed on absent, ambiguous, unsupported, changed-during-hydration, or errored PR discovery
- keep structured permissions, secrets, requirements, and clarification blockers authoritative while carrying a verifier blocker
- apply retry and repeat caps against the correct implementation or repair attempt lane

## Verification
- `npm test` — 2,936 passed
- `npm run verify:supervisor-pre-pr`
- `npx tsx --test src/run-once-turn-execution.test.ts src/turn-execution-failure-helpers.test.ts src/recovery-blocked-issue-reconciliation.test.ts src/supervisor/blocked-turn-pr-reconciliation.test.ts src/supervisor/supervisor-execution-policy.test.ts src/supervisor/supervisor-selection-issue-explain.test.ts src/supervisor/supervisor-status-rendering.test.ts src/github/github.test.ts` — 190 passed
- `node dist/index.js issue-lint 2447 --config supervisor.config.codex.json` — execution ready

Closes #2447