### PR TITLE
Keep normalized review JSON parseable and fail soft

### DIFF
--- a/src/core/journal.ts
+++ b/src/core/journal.ts
@@ -2,7 +2,7 @@ import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { GitHubIssue, IssueRunRecord, SupervisorConfig } from "./types";
-import { ensureDir, truncate, writeFileAtomic } from "./utils";
+import { ensureDir, truncate, writeFileAtomic, writeJsonAtomic } from "./utils";
 
 const NOTES_MARKER = "## Codex Working Notes";
 export const DEFAULT_ISSUE_JOURNAL_RELATIVE_PATH = ".codex-supervisor/issues/{issueNumber}/issue-journal.md";
@@ -363,6 +363,36 @@ export function normalizeDurableTrackedArtifactContent(
   additionalSafeRoots: Iterable<string> = [],
 ): string {
   return normalizeDurableJournalText(content, workspacePath, additionalSafeRoots);
+}
+
+export function normalizeDurableTrackedArtifactJson<T>(
+  value: T,
+  workspacePath: string,
+  additionalSafeRoots: Iterable<string> = [],
+): T {
+  const safeRoots = [...additionalSafeRoots];
+  return JSON.parse(
+    JSON.stringify(value, (_key, nestedValue) =>
+      typeof nestedValue === "string"
+        ? normalizeDurableTrackedArtifactContent(nestedValue, workspacePath, safeRoots)
+        : nestedValue
+    ),
+  ) as T;
+}
+
+export async function writeDurableTrackedArtifactJsonAtomic<T>(
+  filePath: string,
+  value: T,
+  workspacePath: string,
+  additionalSafeRoots: Iterable<string> = [],
+): Promise<T> {
+  const normalized = normalizeDurableTrackedArtifactJson(
+    value,
+    workspacePath,
+    additionalSafeRoots,
+  );
+  await writeJsonAtomic(filePath, normalized);
+  return normalized;
 }
 
 function truncateSummaryBody(summary: string, maxLength: number): string {

--- a/src/external-review/external-review-miss-persistence.ts
+++ b/src/external-review/external-review-miss-persistence.ts
@@ -1,7 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { ensureDir } from "../core/utils";
-import { normalizeDurableTrackedArtifactContent } from "../core/journal";
+import {
+  normalizeDurableTrackedArtifactContent,
+  writeDurableTrackedArtifactJsonAtomic,
+} from "../core/journal";
 import {
   classifyExternalReviewFinding,
   type LocalReviewArtifactLike,
@@ -77,10 +80,10 @@ export async function writeExternalReviewMissArtifact(args: {
     localReviewHeadSha: localArtifact.headSha ?? null,
   });
 
-  await fs.writeFile(
+  await writeDurableTrackedArtifactJsonAtomic(
     artifactPath,
-    normalizeDurableTrackedArtifactContent(`${JSON.stringify(artifact, null, 2)}\n`, args.artifactDir),
-    "utf8",
+    artifact,
+    args.artifactDir,
   );
   await fs.writeFile(digestPath, normalizeDurableTrackedArtifactContent(digest, args.artifactDir), "utf8");
 

--- a/src/local-review/artifacts.test.ts
+++ b/src/local-review/artifacts.test.ts
@@ -339,6 +339,9 @@ test("writeLocalReviewArtifacts rewrites repo-local absolute paths and redacts h
     localReviewArtifactDir: await fs.mkdtemp(path.join(os.tmpdir(), "local-review-artifacts-")),
   });
   const leakedHostPath = `/${"Users"}/alice/Documents/AegisOps-phase5-6-review-files/blocker.md`;
+  const windowsHomePath = ["C:", "Users", "me", "repo"].join("\\");
+  const escapedTomlProjectKey =
+    `[projects."${windowsHomePath.replace(/\\/g, "\\\\")}"]`;
   const roleResults = [
     {
       role: "reviewer",
@@ -348,7 +351,20 @@ test("writeLocalReviewArtifacts rewrites repo-local absolute paths and redacts h
       routing: GENERIC_ROUTING,
       exitCode: 0,
       rawOutput: `Absolute repo path: ${repoFilePath}\nHost-local note: ${leakedHostPath}`,
-      findings: [],
+      findings: [
+        {
+          role: "reviewer",
+          title: "Normalize quoted TOML project keys",
+          body: escapedTomlProjectKey,
+          file: "config.toml",
+          start: 1,
+          end: 1,
+          severity: "medium" as const,
+          confidence: 0.9,
+          category: "portability",
+          evidence: escapedTomlProjectKey,
+        },
+      ],
     },
   ];
   const finalized = finalizeLocalReview({
@@ -376,9 +392,22 @@ test("writeLocalReviewArtifacts rewrites repo-local absolute paths and redacts h
     verifierReport: null,
   });
   const summary = await fs.readFile(artifacts.summaryPath, "utf8");
+  const findingsDocument = await fs.readFile(artifacts.findingsPath, "utf8");
+  const findingsArtifact = JSON.parse(findingsDocument) as {
+    actionableFindings: Array<{ body: string; evidence: string }>;
+  };
 
   assert.match(summary, /Absolute repo path: src\/auth\.ts/);
   assert.match(summary, /Host-local note: <redacted-local-path>/);
   assert.doesNotMatch(summary, new RegExp(repoFilePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.doesNotMatch(summary, new RegExp(leakedHostPath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  assert.equal(
+    findingsArtifact.actionableFindings[0]?.body,
+    '[projects."<redacted-local-path>"]',
+  );
+  assert.equal(
+    findingsArtifact.actionableFindings[0]?.evidence,
+    '[projects."<redacted-local-path>"]',
+  );
+  assert.doesNotMatch(findingsDocument, /C:\\\\Users/u);
 });

--- a/src/local-review/artifacts.ts
+++ b/src/local-review/artifacts.ts
@@ -6,7 +6,10 @@ import {
   prependTrustedGeneratedDurableArtifactMarkdownMarker,
   withTrustedGeneratedDurableArtifactProvenance,
 } from "../durable-artifact-provenance";
-import { normalizeDurableTrackedArtifactContent } from "../core/journal";
+import {
+  normalizeDurableTrackedArtifactContent,
+  writeDurableTrackedArtifactJsonAtomic,
+} from "../core/journal";
 import { createPostMergeAuditResult, renderPostMergeAuditContractSummary } from "./post-merge-audit";
 import {
   type FinalizedLocalReview,
@@ -243,11 +246,11 @@ export async function writeLocalReviewArtifacts(args: {
     "utf8",
   );
 
-  const findingsDocument = `${JSON.stringify(withTrustedGeneratedDurableArtifactProvenance(args.finalized.artifact), null, 2)}\n`;
-  await fs.writeFile(
+  await writeDurableTrackedArtifactJsonAtomic(
     findingsPath,
-    normalizeDurableTrackedArtifactContent(findingsDocument, args.workspacePath, [args.config.localReviewArtifactDir]),
-    "utf8",
+    withTrustedGeneratedDurableArtifactProvenance(args.finalized.artifact),
+    args.workspacePath,
+    [args.config.localReviewArtifactDir],
   );
 
   return { summaryPath, findingsPath, rawOutput };

--- a/src/supervisor/post-merge-audit-artifact.ts
+++ b/src/supervisor/post-merge-audit-artifact.ts
@@ -7,6 +7,7 @@ import {
 } from "../durable-artifact-provenance";
 import {
   extractIssueJournalHandoff,
+  normalizeDurableTrackedArtifactJson,
   normalizeDurableTrackedArtifactContent,
   readIssueJournal,
   type IssueJournalHandoff,
@@ -511,13 +512,11 @@ export async function syncPostMergeAuditArtifact(args: {
     issueNumber: args.issue.number,
     headSha: args.pullRequest.headRefOid,
   });
-  const normalizedArtifact = JSON.parse(
-    normalizeDurableTrackedArtifactContent(
-      `${JSON.stringify(artifact, null, 2)}\n`,
-      args.nextRecord.workspace,
-      [args.config.localReviewArtifactDir],
-    ),
-  ) as PostMergeAuditArtifact;
+  const normalizedArtifact = normalizeDurableTrackedArtifactJson(
+    artifact,
+    args.nextRecord.workspace,
+    [args.config.localReviewArtifactDir],
+  );
   return writePostMergeAuditArtifactSafely(args.issue.number, artifactPath, normalizedArtifact);
 }
 

--- a/src/supervisor/pre-merge-assessment-snapshot.test.ts
+++ b/src/supervisor/pre-merge-assessment-snapshot.test.ts
@@ -291,3 +291,56 @@ test("writePreMergeAssessmentSnapshot captures typed PR, CI, review, local-revie
   assert.equal(snapshot.localReview.summary.finalEvaluationOutcome, "fix_blocked");
   assert.equal(snapshot.localReview.artifact.finalEvaluation.mustFixCount, 1);
 });
+
+test("writePreMergeAssessmentSnapshot fails soft on malformed local-review JSON", async () => {
+  const workspacePath = await fs.mkdtemp(path.join(os.tmpdir(), "pre-merge-malformed-review-"));
+  const reviewDir = path.join(workspacePath, "reviews");
+  const summaryPath = path.join(reviewDir, "head-head-916.md");
+  const artifactPath = path.join(reviewDir, "head-head-916.json");
+  const malformedDocument = '{"actionableFindings":[{"body":"unterminated}]';
+  await fs.mkdir(reviewDir, { recursive: true });
+  await fs.writeFile(summaryPath, "# local review\n", "utf8");
+  await fs.writeFile(artifactPath, malformedDocument, "utf8");
+
+  const persistedPath = await writePreMergeAssessmentSnapshot({
+    config: createConfig({ localReviewArtifactDir: reviewDir }),
+    capturedAt: "2026-03-24T00:15:00Z",
+    issue: createIssue(),
+    record: createRecord(summaryPath),
+    workspacePath,
+    pr: createPullRequest(),
+    checks: [],
+    reviewThreads: [],
+  });
+
+  const snapshot = JSON.parse(await fs.readFile(persistedPath, "utf8"));
+  assert.equal(snapshot.pullRequest.number, 930);
+  assert.equal(snapshot.localReview.summary.available, false);
+  assert.equal(snapshot.localReview.artifact, null);
+  assert.deepEqual(snapshot.localReview.summary.artifactWarning, {
+    code: "malformed_local_review_artifact",
+    artifactPath,
+    parseFailureClass: "SyntaxError",
+  });
+  assert.equal(await fs.readFile(artifactPath, "utf8"), malformedDocument);
+
+  await fs.writeFile(
+    artifactPath,
+    `${JSON.stringify({ finalEvaluation: { outcome: "mergeable" } })}\n`,
+    "utf8",
+  );
+  const recoveredPath = await writePreMergeAssessmentSnapshot({
+    config: createConfig({ localReviewArtifactDir: reviewDir }),
+    capturedAt: "2026-03-24T00:16:00Z",
+    issue: createIssue(),
+    record: createRecord(summaryPath),
+    workspacePath,
+    pr: createPullRequest(),
+    checks: [],
+    reviewThreads: [],
+  });
+  const recovered = JSON.parse(await fs.readFile(recoveredPath, "utf8"));
+  assert.equal(recovered.localReview.summary.available, true);
+  assert.equal(recovered.localReview.summary.artifactWarning, null);
+  assert.equal(recovered.localReview.summary.finalEvaluationOutcome, "mergeable");
+});

--- a/src/supervisor/pre-merge-assessment-snapshot.ts
+++ b/src/supervisor/pre-merge-assessment-snapshot.ts
@@ -90,6 +90,11 @@ export interface PreMergeAssessmentSnapshot {
       verifiedMaxSeverity: IssueRunRecord["local_review_verified_max_severity"];
       degraded: boolean;
       finalEvaluationOutcome: LocalReviewArtifact["finalEvaluation"]["outcome"] | null;
+      artifactWarning: {
+        code: "malformed_local_review_artifact";
+        artifactPath: string;
+        parseFailureClass: string;
+      } | null;
     };
     artifact: LocalReviewArtifact | null;
   };
@@ -107,16 +112,39 @@ function localReviewArtifactPath(summaryPath: string | null): string | null {
 async function loadLocalReviewArtifact(record: Pick<IssueRunRecord, "local_review_summary_path">): Promise<{
   artifactPath: string | null;
   artifact: LocalReviewArtifact | null;
+  artifactWarning: PreMergeAssessmentSnapshot["localReview"]["summary"]["artifactWarning"];
 }> {
   const artifactPath = localReviewArtifactPath(record.local_review_summary_path);
   if (!artifactPath) {
-    return { artifactPath: null, artifact: null };
+    return { artifactPath: null, artifact: null, artifactWarning: null };
   }
 
-  return {
-    artifactPath,
-    artifact: await readJsonIfExists<LocalReviewArtifact>(artifactPath),
-  };
+  try {
+    return {
+      artifactPath,
+      artifact: await readJsonIfExists<LocalReviewArtifact>(artifactPath),
+      artifactWarning: null,
+    };
+  } catch (error) {
+    const parseError = error instanceof SyntaxError
+      ? error
+      : error instanceof Error && error.cause instanceof SyntaxError
+        ? error.cause
+        : null;
+    if (!parseError) {
+      throw error;
+    }
+    const artifactWarning = {
+      code: "malformed_local_review_artifact" as const,
+      artifactPath,
+      parseFailureClass: parseError.name,
+    };
+    console.warn(
+      "Malformed local-review artifact is unavailable for pre-merge assessment.",
+      artifactWarning,
+    );
+    return { artifactPath, artifact: null, artifactWarning };
+  }
 }
 
 function summarizeCheckBuckets(checks: PullRequestCheck[]): PreMergeAssessmentSnapshot["checks"]["summary"] {
@@ -172,6 +200,7 @@ export function buildPreMergeAssessmentSnapshot(args: {
   reviewThreads: ReviewThread[];
   localReviewArtifactPath: string | null;
   localReviewArtifact: LocalReviewArtifact | null;
+  localReviewArtifactWarning?: PreMergeAssessmentSnapshot["localReview"]["summary"]["artifactWarning"];
 }): PreMergeAssessmentSnapshot {
   const { config, capturedAt, issue, record, pr, checks, reviewThreads, localReviewArtifactPath, localReviewArtifact } = args;
   const manualThreads = manualReviewThreads(config, reviewThreads);
@@ -250,6 +279,7 @@ export function buildPreMergeAssessmentSnapshot(args: {
         verifiedMaxSeverity: record.local_review_verified_max_severity,
         degraded: record.local_review_degraded,
         finalEvaluationOutcome: localReviewArtifact?.finalEvaluation.outcome ?? null,
+        artifactWarning: args.localReviewArtifactWarning ?? null,
       },
       artifact: localReviewArtifact,
     },
@@ -271,6 +301,7 @@ export async function writePreMergeAssessmentSnapshot(args: {
     ...args,
     localReviewArtifactPath: localReview.artifactPath,
     localReviewArtifact: localReview.artifact,
+    localReviewArtifactWarning: localReview.artifactWarning,
   });
   const artifactPath = preMergeAssessmentSnapshotPath(args.workspacePath);
   await writeJsonAtomic(artifactPath, snapshot);


### PR DESCRIPTION
## Summary
- normalize path-bearing JSON string values before serialization
- write local-review and external-review JSON artifacts atomically through one JSON-safe helper
- keep post-merge audit normalization structured
- fail soft when pre-merge assessment encounters malformed local-review JSON

## Root cause
Structured review artifacts were serialized before text-level path normalization. Replacing paths inside escaped JSON could consume syntax-significant escapes, and the pre-merge reader allowed the resulting parse error to abort the supervisor cycle.

## Behavior
Malformed local-review files remain available for diagnosis. Pre-merge assessment records a structured warning, treats the payload as unavailable, and continues PR hydration. A later valid artifact supersedes the warning without state editing.

## Verification
- `npx tsx --test src/local-review/artifacts.test.ts src/external-review/external-review-miss-persistence.test.ts src/supervisor/post-merge-audit-artifact.test.ts src/supervisor/pre-merge-assessment-snapshot.test.ts` — 16 passed
- `npm test` — 2,968 passed
- `npm run verify:supervisor-pre-pr`
- `node dist/index.js issue-lint 2448 --config supervisor.config.codex.json` — execution ready
- `git diff --check`

Closes #2448