### PR TITLE
Restore bounded Codex review retries

### DIFF
--- a/src/codex-connector-review-request-decision.test.ts
+++ b/src/codex-connector-review-request-decision.test.ts
@@ -154,6 +154,7 @@ test("codexConnectorReviewRequestPolicy returns retry outcome after the no-respo
   assert.deepEqual(
     policy({
       recordRequest: { requestedAt: "2026-05-08T03:10:00Z", headSha: "head-1995" },
+      hasRequestCommentIdentity: true,
       retryAnchorAt: "2026-05-08T03:10:00Z",
     }),
     {
@@ -505,7 +506,7 @@ test("codexConnectorReviewRequestAction selects retry after the same-head reques
   });
 });
 
-test("codexConnectorReviewRequestAction suppresses retry when the same-head request comment is still tracked", () => {
+test("codexConnectorReviewRequestAction retries after the wait when the same-head initial comment is tracked", () => {
   const scenario = createCodexConnectorRequestRetryScenario();
 
   assert.deepEqual(
@@ -524,11 +525,11 @@ test("codexConnectorReviewRequestAction suppresses retry when the same-head requ
       configuredThreads: scenario.configuredThreads,
       now: scenario.now,
     }),
-    { kind: "none" },
+    { kind: "retry", retryCount: 0, retryAttempt: 1 },
   );
 });
 
-test("codexConnectorReviewRequestAction suppresses retry when the same-head request comment is hydrated from GitHub", () => {
+test("codexConnectorReviewRequestAction retries after the wait when the same-head initial comment is hydrated", () => {
   const scenario = createCodexConnectorRequestRetryScenario();
 
   assert.deepEqual(
@@ -543,7 +544,39 @@ test("codexConnectorReviewRequestAction suppresses retry when the same-head requ
       configuredThreads: scenario.configuredThreads,
       now: scenario.now,
     }),
-    { kind: "none" },
+    { kind: "retry", retryCount: 0, retryAttempt: 1 },
+  );
+});
+
+test("codexConnectorReviewRequestPolicy dedupes a tracked same-head request before the retry wait expires", () => {
+  assert.deepEqual(
+    policy({
+      recordRequest: { requestedAt: "2026-05-08T03:25:00Z", headSha: "head-1995" },
+      hasRequestCommentIdentity: true,
+      retryAnchorAt: "2026-05-08T03:25:00Z",
+    }),
+    {
+      outcome: "advisory",
+      reason: "request_comment_identity_present",
+      action: { kind: "none" },
+    },
+  );
+});
+
+test("codexConnectorReviewRequestPolicy allows the next configured attempt after its retry wait", () => {
+  assert.deepEqual(
+    policy({
+      recordRequest: { requestedAt: "2026-05-08T03:00:00Z", headSha: "head-1995" },
+      hasRequestCommentIdentity: true,
+      retryLimit: 2,
+      retryCountForCurrentHead: 1,
+      retryAnchorAt: "2026-05-08T03:10:00Z",
+    }),
+    {
+      outcome: "request_retry",
+      reason: "retry_ready",
+      action: { kind: "retry", retryCount: 1, retryAttempt: 2 },
+    },
   );
 });
 

--- a/src/codex-connector-review-request-decision.ts
+++ b/src/codex-connector-review-request-decision.ts
@@ -345,14 +345,6 @@ export function codexConnectorReviewRequestPolicy(
     };
   }
 
-  if (args.hasRequestCommentIdentity) {
-    return {
-      outcome: "advisory",
-      reason: "request_comment_identity_present",
-      action: { kind: "none" },
-    };
-  }
-
   if (args.retryLimit <= 0) {
     return {
       outcome: "wait",
@@ -371,6 +363,14 @@ export function codexConnectorReviewRequestPolicy(
 
   const waitUntil = args.retryAnchorAt ? addMinutes(args.retryAnchorAt, args.retryNoResponseMinutes) : null;
   if (!waitUntil || args.nowMs < Date.parse(waitUntil)) {
+    if (args.hasRequestCommentIdentity) {
+      return {
+        outcome: "advisory",
+        reason: "request_comment_identity_present",
+        action: { kind: "none" },
+      };
+    }
+
     return {
       outcome: "wait",
       reason: "retry_wait_not_elapsed",

--- a/src/post-turn-pull-request-codex-connector.test.ts
+++ b/src/post-turn-pull-request-codex-connector.test.ts
@@ -182,9 +182,9 @@ test("handlePostTurnPullRequestTransitionsPhase does not request Codex Connector
   }
 });
 
-test("handlePostTurnPullRequestTransitionsPhase retries Codex Connector review once after same-head request gets no response", async () => {
+test("handlePostTurnPullRequestTransitionsPhase retries VeriDoc #301 once when the tracked initial request gets no response", async () => {
   const originalDateNow = Date.now;
-  Date.now = () => Date.parse("2026-05-08T04:00:00Z");
+  Date.now = () => Date.parse("2026-07-13T21:35:58Z");
   try {
     const config = createConfig({
       reviewBotLogins: ["chatgpt-codex-connector"],
@@ -195,31 +195,41 @@ test("handlePostTurnPullRequestTransitionsPhase retries Codex Connector review o
       codexConnectorReviewRequestRetryLimit: 1,
       codexConnectorReviewRequestRetryMode: "plain",
     });
-    const issue = createIssue({ number: 1976, title: "Retry Codex Connector review after no response" });
+    const issue = createIssue({ number: 286, title: "P12-12: accessibility and keyboard review" });
     const pr = createPullRequest({
-      number: 1976,
-      title: "Retry Codex Connector review after no response",
+      number: 301,
+      title: "P12-12: accessibility and keyboard review",
       isDraft: false,
-      headRefOid: "head-1976",
-      currentHeadCiGreenAt: "2026-05-08T03:09:36Z",
+      headRefOid: "2105e73f653a58c5621113e25f475fb4ef14250d",
+      currentHeadCiGreenAt: "2026-07-13T15:23:37Z",
       configuredBotCurrentHeadObservedAt: null,
-      codexConnectorReviewRequestedAt: "2026-05-08T03:30:00Z",
-      codexConnectorReviewRequestedHeadSha: "head-1976",
+      configuredBotLatestReviewedCommitSha: "90ad7184cf",
+      codexConnectorReviewRequestedAt: "2026-07-13T15:36:06Z",
+      codexConnectorReviewRequestedHeadSha: "2105e73f653a58c5621113e25f475fb4ef14250d",
+      codexConnectorReviewRequestCommentDatabaseId: 4959714385,
+      codexConnectorReviewRequestCommentNodeId: "IC_veridoc_301_initial",
+      codexConnectorReviewRequestCommentUrl:
+        "https://github.com/TommyKammy/VeriDoc/pull/301#issuecomment-4959714385",
     });
     const record = createRecord({
       issue_number: issue.number,
       state: "waiting_ci",
       pr_number: pr.number,
       last_head_sha: pr.headRefOid,
-      review_wait_started_at: "2026-05-08T03:09:36Z",
+      review_wait_started_at: "2026-07-13T15:29:08.765Z",
       review_wait_head_sha: pr.headRefOid,
-      copilot_review_timed_out_at: "2026-05-08T03:19:36.000Z",
+      copilot_review_timed_out_at: "2026-07-13T15:35:38.765Z",
       copilot_review_timeout_action: "request_review_comment",
-      codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
+      codex_connector_review_requested_observed_at: "2026-07-13T15:36:06Z",
       codex_connector_review_requested_head_sha: pr.headRefOid,
       codex_connector_review_request_retry_count: 0,
       codex_connector_review_request_retry_head_sha: null,
       codex_connector_review_request_last_retried_at: null,
+      codex_connector_review_request_comment_identity_status: "available",
+      codex_connector_review_request_comment_database_id: 4959714385,
+      codex_connector_review_request_comment_node_id: "IC_veridoc_301_initial",
+      codex_connector_review_request_comment_url:
+        "https://github.com/TommyKammy/VeriDoc/pull/301#issuecomment-4959714385",
     });
     const state: SupervisorStateFile = {
       activeIssueNumber: issue.number,
@@ -234,16 +244,16 @@ test("handlePostTurnPullRequestTransitionsPhase retries Codex Connector review o
         addIssueComment: async (issueNumber, body) => {
           comments.push({ issueNumber, body });
           return {
-            databaseId: 1924001,
-            nodeId: "IC_kwDOissue1924_request",
-            url: "https://github.com/owner/repo/issues/1924#issuecomment-1924001",
+            databaseId: 4959999999,
+            nodeId: "IC_veridoc_301_retry_1",
+            url: "https://github.com/TommyKammy/VeriDoc/pull/301#issuecomment-4959999999",
           };
         },
       }),
       context: createPostTurnContext({
         issue,
         pr,
-        workspacePath: "/tmp/workspaces/issue-1976",
+        workspacePath: "/tmp/workspaces/issue-286",
         state,
         record,
       }),
@@ -265,17 +275,17 @@ test("handlePostTurnPullRequestTransitionsPhase retries Codex Connector review o
 
     assert.deepEqual(comments, [{ issueNumber: pr.number, body: "@codex review" }]);
     assert.equal(result.record.state, "waiting_ci");
-    assert.equal(result.record.codex_connector_review_requested_observed_at, "2026-05-08T03:30:00Z");
+    assert.equal(result.record.codex_connector_review_requested_observed_at, "2026-07-13T15:36:06Z");
     assert.equal(result.record.codex_connector_review_requested_head_sha, pr.headRefOid);
     assert.equal(result.record.codex_connector_review_request_retry_count, 1);
     assert.equal(result.record.codex_connector_review_request_retry_head_sha, pr.headRefOid);
     assert.ok(result.record.codex_connector_review_request_last_retried_at);
     assert.equal(result.record.codex_connector_review_request_comment_identity_status, "available");
-    assert.equal(result.record.codex_connector_review_request_comment_database_id, 1924001);
-    assert.equal(result.record.codex_connector_review_request_comment_node_id, "IC_kwDOissue1924_request");
+    assert.equal(result.record.codex_connector_review_request_comment_database_id, 4959999999);
+    assert.equal(result.record.codex_connector_review_request_comment_node_id, "IC_veridoc_301_retry_1");
     assert.equal(
       result.record.codex_connector_review_request_comment_url,
-      "https://github.com/owner/repo/issues/1924#issuecomment-1924001",
+      "https://github.com/TommyKammy/VeriDoc/pull/301#issuecomment-4959999999",
     );
 
     const duplicateCycle = await handlePostTurnPullRequestTransitionsPhase({
@@ -289,7 +299,7 @@ test("handlePostTurnPullRequestTransitionsPhase retries Codex Connector review o
       context: createPostTurnContext({
         issue,
         pr,
-        workspacePath: "/tmp/workspaces/issue-1976",
+        workspacePath: "/tmp/workspaces/issue-286",
         state,
         record: result.record,
       }),
@@ -311,6 +321,8 @@ test("handlePostTurnPullRequestTransitionsPhase retries Codex Connector review o
 
     assert.equal(comments.length, 1);
     assert.equal(duplicateCycle.record.codex_connector_review_request_retry_count, 1);
+    assert.equal(duplicateCycle.record.codex_connector_review_request_comment_database_id, 4959999999);
+    assert.equal(duplicateCycle.record.codex_connector_review_request_comment_node_id, "IC_veridoc_301_retry_1");
   } finally {
     Date.now = originalDateNow;
   }

--- a/src/pull-request-state-sync.test.ts
+++ b/src/pull-request-state-sync.test.ts
@@ -146,6 +146,9 @@ test("syncCodexConnectorReviewRequestObservation clears request identity after c
       codex_connector_review_request_comment_database_id: 44001,
       codex_connector_review_request_comment_node_id: "IC_head_current",
       codex_connector_review_request_comment_url: "https://github.com/owner/repo/issues/44#issuecomment-44001",
+      codex_connector_review_request_retry_count: 1,
+      codex_connector_review_request_retry_head_sha: "head-current",
+      codex_connector_review_request_last_retried_at: "2026-03-13T01:05:00Z",
     }),
     createPullRequest({
       number: 44,
@@ -162,9 +165,50 @@ test("syncCodexConnectorReviewRequestObservation clears request identity after c
   assert.deepEqual(cleared, {
     codex_connector_review_requested_observed_at: null,
     codex_connector_review_requested_head_sha: null,
+    codex_connector_review_request_retry_count: 0,
+    codex_connector_review_request_retry_head_sha: null,
+    codex_connector_review_request_last_retried_at: null,
     codex_connector_review_request_comment_identity_status: null,
     codex_connector_review_request_comment_database_id: null,
     codex_connector_review_request_comment_node_id: null,
     codex_connector_review_request_comment_url: null,
+  });
+});
+
+test("syncCodexConnectorReviewRequestObservation preserves latest retry identity over hydrated initial identity", () => {
+  const patch = syncCodexConnectorReviewRequestObservation(
+    createRecord({
+      issue_number: 1923,
+      codex_connector_review_requested_observed_at: "2026-03-13T01:00:00Z",
+      codex_connector_review_requested_head_sha: "head-current",
+      codex_connector_review_request_retry_count: 1,
+      codex_connector_review_request_retry_head_sha: "head-current",
+      codex_connector_review_request_last_retried_at: "2026-03-13T01:10:00Z",
+      codex_connector_review_request_comment_identity_status: "available",
+      codex_connector_review_request_comment_database_id: 44002,
+      codex_connector_review_request_comment_node_id: "IC_head_current_retry_1",
+      codex_connector_review_request_comment_url: "https://github.com/owner/repo/issues/44#issuecomment-44002",
+    }),
+    createPullRequest({
+      number: 44,
+      headRefOid: "head-current",
+      codexConnectorReviewRequestedAt: "2026-03-13T01:00:00Z",
+      codexConnectorReviewRequestedHeadSha: "head-current",
+      codexConnectorReviewRequestCommentDatabaseId: 44001,
+      codexConnectorReviewRequestCommentNodeId: "IC_head_current_initial",
+      codexConnectorReviewRequestCommentUrl: "https://github.com/owner/repo/issues/44#issuecomment-44001",
+    }),
+  );
+
+  assert.deepEqual(patch, {
+    codex_connector_review_requested_observed_at: "2026-03-13T01:00:00Z",
+    codex_connector_review_requested_head_sha: "head-current",
+    codex_connector_review_request_retry_count: 1,
+    codex_connector_review_request_retry_head_sha: "head-current",
+    codex_connector_review_request_last_retried_at: "2026-03-13T01:10:00Z",
+    codex_connector_review_request_comment_identity_status: "available",
+    codex_connector_review_request_comment_database_id: 44002,
+    codex_connector_review_request_comment_node_id: "IC_head_current_retry_1",
+    codex_connector_review_request_comment_url: "https://github.com/owner/repo/issues/44#issuecomment-44002",
   });
 });

--- a/src/pull-request-state-sync.ts
+++ b/src/pull-request-state-sync.ts
@@ -79,18 +79,29 @@ export function syncCodexConnectorReviewRequestObservation(
   record: IssueRunRecord,
   pr: GitHubPullRequest,
 ): Pick<
-  IssueRunRecord,
-  | "codex_connector_review_requested_observed_at"
-  | "codex_connector_review_requested_head_sha"
-  | "codex_connector_review_request_comment_identity_status"
-  | "codex_connector_review_request_comment_database_id"
-  | "codex_connector_review_request_comment_node_id"
-  | "codex_connector_review_request_comment_url"
-> {
+    IssueRunRecord,
+    | "codex_connector_review_requested_observed_at"
+    | "codex_connector_review_requested_head_sha"
+    | "codex_connector_review_request_comment_identity_status"
+    | "codex_connector_review_request_comment_database_id"
+    | "codex_connector_review_request_comment_node_id"
+    | "codex_connector_review_request_comment_url"
+  > &
+    Partial<
+      Pick<
+        IssueRunRecord,
+        | "codex_connector_review_request_retry_count"
+        | "codex_connector_review_request_retry_head_sha"
+        | "codex_connector_review_request_last_retried_at"
+      >
+    > {
   if (pr.configuredBotCurrentHeadObservedAt) {
     return {
       codex_connector_review_requested_observed_at: null,
       codex_connector_review_requested_head_sha: null,
+      codex_connector_review_request_retry_count: 0,
+      codex_connector_review_request_retry_head_sha: null,
+      codex_connector_review_request_last_retried_at: null,
       codex_connector_review_request_comment_identity_status: null,
       codex_connector_review_request_comment_database_id: null,
       codex_connector_review_request_comment_node_id: null,
@@ -102,32 +113,53 @@ export function syncCodexConnectorReviewRequestObservation(
     pr.codexConnectorReviewRequestedAt &&
     pr.codexConnectorReviewRequestedHeadSha === pr.headRefOid
   ) {
+    const currentHeadRetryCount =
+      record.codex_connector_review_request_retry_head_sha === pr.headRefOid
+        ? record.codex_connector_review_request_retry_count ?? 0
+        : 0;
+    const preserveLatestRetryIdentity = currentHeadRetryCount > 0;
     return {
       codex_connector_review_requested_observed_at: pr.codexConnectorReviewRequestedAt,
       codex_connector_review_requested_head_sha: pr.headRefOid,
       codex_connector_review_request_comment_identity_status:
-        pr.codexConnectorReviewRequestCommentDatabaseId ||
-        pr.codexConnectorReviewRequestCommentNodeId ||
-        pr.codexConnectorReviewRequestCommentUrl
-          ? "available"
-          : record.codex_connector_review_requested_head_sha === pr.headRefOid
-            ? record.codex_connector_review_request_comment_identity_status ?? null
-            : null,
+        preserveLatestRetryIdentity
+          ? record.codex_connector_review_request_comment_identity_status ?? null
+          : pr.codexConnectorReviewRequestCommentDatabaseId ||
+              pr.codexConnectorReviewRequestCommentNodeId ||
+              pr.codexConnectorReviewRequestCommentUrl
+            ? "available"
+            : record.codex_connector_review_requested_head_sha === pr.headRefOid
+              ? record.codex_connector_review_request_comment_identity_status ?? null
+              : null,
       codex_connector_review_request_comment_database_id:
-        pr.codexConnectorReviewRequestCommentDatabaseId ??
-        (record.codex_connector_review_requested_head_sha === pr.headRefOid
+        preserveLatestRetryIdentity
           ? record.codex_connector_review_request_comment_database_id ?? null
-          : null),
+          : pr.codexConnectorReviewRequestCommentDatabaseId ??
+            (record.codex_connector_review_requested_head_sha === pr.headRefOid
+              ? record.codex_connector_review_request_comment_database_id ?? null
+              : null),
       codex_connector_review_request_comment_node_id:
-        pr.codexConnectorReviewRequestCommentNodeId ??
-        (record.codex_connector_review_requested_head_sha === pr.headRefOid
+        preserveLatestRetryIdentity
           ? record.codex_connector_review_request_comment_node_id ?? null
-          : null),
+          : pr.codexConnectorReviewRequestCommentNodeId ??
+            (record.codex_connector_review_requested_head_sha === pr.headRefOid
+              ? record.codex_connector_review_request_comment_node_id ?? null
+              : null),
       codex_connector_review_request_comment_url:
-        pr.codexConnectorReviewRequestCommentUrl ??
-        (record.codex_connector_review_requested_head_sha === pr.headRefOid
+        preserveLatestRetryIdentity
           ? record.codex_connector_review_request_comment_url ?? null
-          : null),
+          : pr.codexConnectorReviewRequestCommentUrl ??
+            (record.codex_connector_review_requested_head_sha === pr.headRefOid
+              ? record.codex_connector_review_request_comment_url ?? null
+              : null),
+      ...(preserveLatestRetryIdentity
+        ? {
+            codex_connector_review_request_retry_count: currentHeadRetryCount,
+            codex_connector_review_request_retry_head_sha: pr.headRefOid,
+            codex_connector_review_request_last_retried_at:
+              record.codex_connector_review_request_last_retried_at ?? null,
+          }
+        : {}),
     };
   }
 

--- a/src/supervisor/codex-connector-diagnostics-presenter.ts
+++ b/src/supervisor/codex-connector-diagnostics-presenter.ts
@@ -26,7 +26,6 @@ import {
   latestCodexConnectorReviewComment,
 } from "../codex-connector-review-policy";
 import { configuredBotCurrentHeadSignalWaitWindow } from "./review-bot-wait-windows";
-import { hasCodexConnectorReviewRequestCommentIdentity } from "../codex-connector-review-request-identity";
 import {
   formatStaleReviewMetadataConvergenceDiagnostic,
   formatStaleReviewResidueOperatorDiagnostic,
@@ -312,14 +311,10 @@ export function formatCodexConnectorReviewFallbackDiagnostic(args: {
     : null;
   const timeoutAction = args.config.configuredBotCurrentHeadSignalTimeoutAction ?? args.config.copilotReviewTimeoutAction;
   const retryConfigured = timeoutAction === "request_review_comment";
-  const existingRequestCommentIdentity = requestMatchesCurrentHead
-    ? hasCodexConnectorReviewRequestCommentIdentity({ record: args.record, pr: args.pr })
-    : false;
   const requestNoResponseElapsed = Boolean(
     retryConfigured &&
     requestMatchesCurrentHead &&
     !currentHeadObservedAt &&
-    !existingRequestCommentIdentity &&
     retryWaitUntil &&
     Date.now() >= Date.parse(retryWaitUntil),
   );

--- a/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
+++ b/src/supervisor/supervisor-diagnostics-codex-connector-status.test.ts
@@ -41,6 +41,11 @@ test("status surfaces Codex Connector review-request fallback lifecycle for the 
     recordOverrides: {
       codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
       codex_connector_review_requested_head_sha: "head-1925",
+      codex_connector_review_request_comment_identity_status: "available",
+      codex_connector_review_request_comment_database_id: 2925001,
+      codex_connector_review_request_comment_node_id: "IC_head_1925_initial",
+      codex_connector_review_request_comment_url:
+        "https://github.com/owner/repo/pull/2925#issuecomment-2925001",
     },
   });
   await writeSupervisorState(fixture, scenario.state);
@@ -72,7 +77,7 @@ test("status surfaces Codex Connector review-request fallback lifecycle for the 
 
   assert.match(
     report.detailedStatusLines.join("\n"),
-    /^codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-1925 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1925 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-05-08T03:40:00\.000Z request_comment_identity=unavailable next_action=retry_request_review_comment wait_until=2026-05-08T03:19:36\.000Z$/m,
+    /^codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-1925 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1925 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-05-08T03:40:00\.000Z request_comment_identity=database_id=2925001,node_id=IC_head_1925_initial,url=https:\/\/github\.com\/owner\/repo\/pull\/2925#issuecomment-2925001 next_action=retry_request_review_comment wait_until=2026-05-08T03:19:36\.000Z$/m,
   );
   assert.match(
     report.detailedStatusLines.join("\n"),

--- a/src/supervisor/supervisor-diagnostics-explain-codex-connector.test.ts
+++ b/src/supervisor/supervisor-diagnostics-explain-codex-connector.test.ts
@@ -153,6 +153,11 @@ test("explain surfaces Codex Connector review-request fallback lifecycle for the
         last_head_sha: "head-1925",
         codex_connector_review_requested_observed_at: "2026-05-08T03:30:00Z",
         codex_connector_review_requested_head_sha: "head-1925",
+        codex_connector_review_request_comment_identity_status: "available",
+        codex_connector_review_request_comment_database_id: 2925001,
+        codex_connector_review_request_comment_node_id: "IC_head_1925_initial",
+        codex_connector_review_request_comment_url:
+          "https://github.com/owner/repo/pull/2925#issuecomment-2925001",
       }),
     },
   };
@@ -197,7 +202,7 @@ test("explain surfaces Codex Connector review-request fallback lifecycle for the
 
   assert.match(
     explanation,
-    /^codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-1925 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1925 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-05-08T03:40:00\.000Z request_comment_identity=unavailable next_action=retry_request_review_comment wait_until=2026-05-08T03:19:36\.000Z$/m,
+    /^codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-1925 current_head_observed_at=none required_checks_green_at=2026-05-08T03:09:36Z timeout_action=request_review_comment requested_at=2026-05-08T03:30:00Z requested_head_sha=head-1925 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-05-08T03:40:00\.000Z request_comment_identity=database_id=2925001,node_id=IC_head_1925_initial,url=https:\/\/github\.com\/owner\/repo\/pull\/2925#issuecomment-2925001 next_action=retry_request_review_comment wait_until=2026-05-08T03:19:36\.000Z$/m,
   );
   assert.match(
     explanation,

--- a/src/supervisor/supervisor-status-review-bot.test.ts
+++ b/src/supervisor/supervisor-status-review-bot.test.ts
@@ -1532,7 +1532,7 @@ test("formatCodexConnectorReviewFallbackDiagnostic surfaces Codex Connector wait
         }),
         pr: waitingPr,
       }),
-      "codex_connector_review_fallback status=request_posted provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=2026-03-16T00:00:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion wait_until=2026-03-16T00:20:00.000Z",
+      "codex_connector_review_fallback status=request_posted_no_current_head_signal provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=2026-03-16T00:00:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion retry_status=eligible retry_count=0 retry_limit=1 retry_wait_until=2026-03-16T00:10:00.000Z request_comment_identity=database_id=340001,node_id=IC_kwDOhead340,url=https://github.com/owner/repo/issues/340#issuecomment-340001 next_action=retry_request_review_comment wait_until=2026-03-16T00:20:00.000Z",
     );
 
     assert.equal(
@@ -1544,10 +1544,14 @@ test("formatCodexConnectorReviewFallbackDiagnostic surfaces Codex Connector wait
           codex_connector_review_request_retry_count: 1,
           codex_connector_review_request_retry_head_sha: "head-340",
           codex_connector_review_request_last_retried_at: "2026-03-16T00:01:00.000Z",
+          codex_connector_review_request_comment_identity_status: "available",
+          codex_connector_review_request_comment_database_id: 340002,
+          codex_connector_review_request_comment_node_id: "IC_kwDOhead340_retry1",
+          codex_connector_review_request_comment_url: "https://github.com/owner/repo/issues/340#issuecomment-340002",
         }),
         pr: waitingPr,
       }),
-      "codex_connector_review_fallback status=request_retry_exhausted provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=2026-03-16T00:00:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion retry_status=exhausted retry_count=1 retry_limit=1 retry_wait_until=2026-03-16T00:11:00.000Z request_comment_identity=unavailable next_action=operator_manual_review wait_until=2026-03-16T00:20:00.000Z",
+      "codex_connector_review_fallback status=request_retry_exhausted provider=codex current_head_sha=head-340 current_head_observed_at=none required_checks_green_at=2026-03-16T00:10:00.000Z timeout_action=request_review_comment requested_at=2026-03-16T00:00:00.000Z requested_head_sha=head-340 review_signal=missing note=request_comment_is_not_review_completion retry_status=exhausted retry_count=1 retry_limit=1 retry_wait_until=2026-03-16T00:11:00.000Z request_comment_identity=database_id=340002,node_id=IC_kwDOhead340_retry1,url=https://github.com/owner/repo/issues/340#issuecomment-340002 next_action=operator_manual_review wait_until=2026-03-16T00:20:00.000Z",
     );
 
     assert.equal(

--- a/src/tracked-pr-lifecycle-projection.ts
+++ b/src/tracked-pr-lifecycle-projection.ts
@@ -38,10 +38,7 @@ export interface TrackedPrLifecycleProjection {
   recordForState: IssueRunRecord;
   reviewWaitPatch: Partial<IssueRunRecord>;
   copilotReviewRequestObservationPatch: Partial<IssueRunRecord>;
-  codexConnectorReviewRequestObservationPatch: Pick<
-    IssueRunRecord,
-    "codex_connector_review_requested_observed_at" | "codex_connector_review_requested_head_sha"
-  >;
+  codexConnectorReviewRequestObservationPatch: ReturnType<typeof syncCodexConnectorReviewRequestObservation>;
   copilotReviewTimeoutPatch: Pick<
     IssueRunRecord,
     "copilot_review_timed_out_at" | "copilot_review_timeout_action" | "copilot_review_timeout_reason"


### PR DESCRIPTION
Closes #2455

## Summary

- evaluate the configured Codex Connector retry budget and no-response deadline before treating a tracked same-head request identity as a duplicate
- preserve the latest retry comment identity when GitHub rehydrates the original machine-marked request
- clear request, retry, and comment-identity state after a current-head provider signal
- report retry eligibility and exhaustion even when the request comment has durable identity
- add a regression fixture matching VeriDoc PR #301, including its stale prior success, current head, tracked initial request, green checks, and zero unresolved threads

## Root cause

The request policy returned `request_comment_identity_present` before inspecting the retry limit, retry count, or retry deadline. A successful initial comment mutation therefore made the bounded same-head retry unreachable. The diagnostics presenter used the same identity presence as a permanent exclusion from the no-response state.

The retry lifecycle already persists head-scoped attempt count, retry time, and latest comment identity. This change makes those fields authoritative: identity dedupes repeated cycles before the deadline, while the attempt budget controls retries after the deadline.

## Impact

Tracked Codex Connector PRs can recover from a dropped review request with the configured bounded retry. The merge gate remains fail-closed until a real current-head provider signal arrives, and retries still stop at the configured per-head limit.

## Verification

- focused Codex Connector tests: 124 passed
- `npm run verify:pre-pr`: 2,974 passed
- `node dist/index.js issue-lint 2455 --config supervisor.config.codex.json`: execution ready
- `git diff --check`
