### PR TITLE
Fail closed on dependencies outside candidate inventory

### DIFF
--- a/src/family-directory-layout.test.ts
+++ b/src/family-directory-layout.test.ts
@@ -199,6 +199,7 @@ const EXPECTED_FAMILY_FILES = {
     "types.ts",
   ],
   "issue-metadata": [
+    "dependency-issue-inventory.ts",
     "index.ts",
     "issue-metadata-change-classification.ts",
     "issue-metadata-change-risk-decision.ts",

--- a/src/issue-metadata/dependency-issue-inventory.test.ts
+++ b/src/issue-metadata/dependency-issue-inventory.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { GitHubIssue } from "../core/types";
+import { hydrateDependencyIssueInventory } from "./dependency-issue-inventory";
+
+function createIssue(number: number, overrides: Partial<GitHubIssue> = {}): GitHubIssue {
+  return {
+    number,
+    title: `Issue ${number}`,
+    body: "Depends on: none",
+    createdAt: "2026-07-14T00:00:00Z",
+    updatedAt: "2026-07-14T00:00:00Z",
+    url: `https://example.test/issues/${number}`,
+    labels: [],
+    state: "OPEN",
+    ...overrides,
+  };
+}
+
+test("hydrateDependencyIssueInventory ignores dependency numbers from malformed metadata", async () => {
+  const issue = createIssue(92, {
+    body: "Depends on: #999999, blocked by #oops",
+  });
+  let lookupCount = 0;
+
+  const issues = await hydrateDependencyIssueInventory(
+    {
+      getIssue: async () => {
+        lookupCount += 1;
+        throw new Error("unexpected dependency lookup");
+      },
+    },
+    [issue],
+  );
+
+  assert.deepEqual(issues, [issue]);
+  assert.equal(lookupCount, 0);
+});
+
+test("hydrateDependencyIssueInventory does not recurse through closed dependencies", async () => {
+  const child = createIssue(92, { body: "Depends on: #91" });
+  const closedDependency = createIssue(91, {
+    body: "Depends on: #90",
+    state: "CLOSED",
+  });
+  const requestedIssueNumbers: number[] = [];
+
+  const issues = await hydrateDependencyIssueInventory(
+    {
+      getIssue: async (issueNumber) => {
+        requestedIssueNumbers.push(issueNumber);
+        assert.equal(issueNumber, 91);
+        return closedDependency;
+      },
+    },
+    [child],
+  );
+
+  assert.deepEqual(requestedIssueNumbers, [91]);
+  assert.deepEqual(issues.map((issue) => issue.number), [92, 91]);
+});
+
+test("hydrateDependencyIssueInventory only traverses dependencies from the supplied roots", async () => {
+  const skipped = createIssue(91, { body: "Depends on: #999999" });
+  const runnable = createIssue(92);
+  let lookupCount = 0;
+
+  const issues = await hydrateDependencyIssueInventory(
+    {
+      getIssue: async () => {
+        lookupCount += 1;
+        throw new Error("unexpected dependency lookup");
+      },
+    },
+    [skipped, runnable],
+    [runnable],
+  );
+
+  assert.deepEqual(issues, [skipped, runnable]);
+  assert.equal(lookupCount, 0);
+});

--- a/src/issue-metadata/dependency-issue-inventory.ts
+++ b/src/issue-metadata/dependency-issue-inventory.ts
@@ -1,0 +1,47 @@
+import { GitHubIssue } from "../core/types";
+import { parseIssueMetadata } from "./issue-metadata";
+
+interface DependencyIssueLookup {
+  getIssue(issueNumber: number): Promise<GitHubIssue>;
+}
+
+export async function hydrateDependencyIssueInventory(
+  github: DependencyIssueLookup,
+  initialIssues: GitHubIssue[],
+): Promise<GitHubIssue[]> {
+  const issueByNumber = new Map(initialIssues.map((issue) => [issue.number, issue]));
+  const pendingIssues = [...initialIssues];
+
+  for (let index = 0; index < pendingIssues.length; index += 1) {
+    const issue = pendingIssues[index];
+    for (const dependencyNumber of parseIssueMetadata(issue).dependsOn) {
+      if (issueByNumber.has(dependencyNumber)) {
+        continue;
+      }
+
+      let dependencyIssue: GitHubIssue;
+      try {
+        dependencyIssue = await github.getIssue(dependencyNumber);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        throw new Error(
+          `Failed to resolve dependency issue #${dependencyNumber} referenced by issue #${issue.number}; ` +
+          `refusing to continue without authoritative dependency state: ${message}`,
+          { cause: error },
+        );
+      }
+
+      if (dependencyIssue.number !== dependencyNumber) {
+        throw new Error(
+          `Dependency lookup for issue #${dependencyNumber} referenced by issue #${issue.number} ` +
+          `returned issue #${dependencyIssue.number}; refusing to continue without authoritative dependency state.`,
+        );
+      }
+
+      issueByNumber.set(dependencyNumber, dependencyIssue);
+      pendingIssues.push(dependencyIssue);
+    }
+  }
+
+  return [...issueByNumber.values()];
+}

--- a/src/issue-metadata/dependency-issue-inventory.ts
+++ b/src/issue-metadata/dependency-issue-inventory.ts
@@ -1,5 +1,5 @@
 import { GitHubIssue } from "../core/types";
-import { parseIssueMetadata } from "./issue-metadata";
+import { parseIssueMetadata, validateIssueMetadataSyntax } from "./issue-metadata";
 
 interface DependencyIssueLookup {
   getIssue(issueNumber: number): Promise<GitHubIssue>;
@@ -8,38 +8,46 @@ interface DependencyIssueLookup {
 export async function hydrateDependencyIssueInventory(
   github: DependencyIssueLookup,
   initialIssues: GitHubIssue[],
+  rootIssues: GitHubIssue[] = initialIssues,
 ): Promise<GitHubIssue[]> {
   const issueByNumber = new Map(initialIssues.map((issue) => [issue.number, issue]));
-  const pendingIssues = [...initialIssues];
+  const pendingIssues = [...new Map(rootIssues.map((issue) => [issue.number, issue])).values()];
+  const scheduledIssueNumbers = new Set(pendingIssues.map((issue) => issue.number));
 
   for (let index = 0; index < pendingIssues.length; index += 1) {
     const issue = pendingIssues[index];
+    if (issue.state === "CLOSED" || validateIssueMetadataSyntax(issue).length > 0) {
+      continue;
+    }
+
     for (const dependencyNumber of parseIssueMetadata(issue).dependsOn) {
-      if (issueByNumber.has(dependencyNumber)) {
-        continue;
+      let dependencyIssue = issueByNumber.get(dependencyNumber);
+      if (!dependencyIssue) {
+        try {
+          dependencyIssue = await github.getIssue(dependencyNumber);
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new Error(
+            `Failed to resolve dependency issue #${dependencyNumber} referenced by issue #${issue.number}; ` +
+            `refusing to continue without authoritative dependency state: ${message}`,
+            { cause: error },
+          );
+        }
+
+        if (dependencyIssue.number !== dependencyNumber) {
+          throw new Error(
+            `Dependency lookup for issue #${dependencyNumber} referenced by issue #${issue.number} ` +
+            `returned issue #${dependencyIssue.number}; refusing to continue without authoritative dependency state.`,
+          );
+        }
+
+        issueByNumber.set(dependencyNumber, dependencyIssue);
       }
 
-      let dependencyIssue: GitHubIssue;
-      try {
-        dependencyIssue = await github.getIssue(dependencyNumber);
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(
-          `Failed to resolve dependency issue #${dependencyNumber} referenced by issue #${issue.number}; ` +
-          `refusing to continue without authoritative dependency state: ${message}`,
-          { cause: error },
-        );
+      if (!scheduledIssueNumbers.has(dependencyNumber)) {
+        scheduledIssueNumbers.add(dependencyNumber);
+        pendingIssues.push(dependencyIssue);
       }
-
-      if (dependencyIssue.number !== dependencyNumber) {
-        throw new Error(
-          `Dependency lookup for issue #${dependencyNumber} referenced by issue #${issue.number} ` +
-          `returned issue #${dependencyIssue.number}; refusing to continue without authoritative dependency state.`,
-        );
-      }
-
-      issueByNumber.set(dependencyNumber, dependencyIssue);
-      pendingIssues.push(dependencyIssue);
     }
   }
 

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -280,11 +280,11 @@ test("reconcileRecoverableBlockedIssueStates requeues requirements-blocked issue
   assert.equal(updated.last_failure_context, null);
   assert.equal(updated.last_failure_signature, null);
   assert.equal(updated.repeated_failure_signature_count, 0);
-  assert.equal(updated.last_recovery_reason, "requirements_recovered: requeued issue #366 after execution-ready metadata was added");
+  assert.equal(updated.last_recovery_reason, "requirements_recovered: requeued issue #366 after execution-ready metadata and dependency gates became satisfied");
   assert.ok(updated.last_recovery_at);
   assert.equal(saveCalls, 1);
   assert.deepEqual(recoveryEvents.map((event) => event.reason), [
-    "requirements_recovered: requeued issue #366 after execution-ready metadata was added",
+    "requirements_recovered: requeued issue #366 after execution-ready metadata and dependency gates became satisfied",
   ]);
 });
 
@@ -377,6 +377,138 @@ test("reconcileRecoverableBlockedIssueStates clears the machine-managed requirem
   assert.equal(updatedComments[0]?.commentId, 3661);
   assert.match(updatedComments[0]?.body ?? "", /no longer current/i);
   assert.match(updatedComments[0]?.body ?? "", /execution-ready/i);
+});
+
+test("reconcileRecoverableBlockedIssueStates keeps requirements blocked until an authoritative dependency becomes done", async () => {
+  const config = createConfig({ issueLabel: "codex" });
+  const blockedRecord = createRecord({
+    issue_number: 92,
+    state: "blocked",
+    blocked_reason: "requirements",
+    last_error: "Waiting for depends on #91.",
+  });
+  const state = createSupervisorState({ issues: [blockedRecord] });
+  const dependencyIssue = createIssue({
+    number: 91,
+    labels: [],
+    state: "OPEN",
+  });
+  const blockedIssue = createIssue({
+    number: 92,
+    labels: [{ name: "codex" }],
+    body: executionReadyBody("Wait for the dependency.").replace("Depends on: none", "Depends on: #91"),
+  });
+  let saveCalls = 0;
+  const stateStore = {
+    touch(record: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+      return { ...record, ...patch, updated_at: "2026-07-14T00:00:00Z" };
+    },
+    async save(): Promise<void> {
+      saveCalls += 1;
+    },
+  };
+  const github = {
+    getPullRequestIfExists: async () => {
+      throw new Error("unexpected getPullRequestIfExists call");
+    },
+    getIssue: async () => {
+      throw new Error("unexpected getIssue call");
+    },
+    getChecks: async () => {
+      throw new Error("unexpected getChecks call");
+    },
+    getUnresolvedReviewThreads: async () => {
+      throw new Error("unexpected getUnresolvedReviewThreads call");
+    },
+  };
+
+  const blockedEvents = await reconcileRecoverableBlockedIssueStates(
+    github,
+    stateStore,
+    state,
+    config,
+    [dependencyIssue, blockedIssue],
+    { shouldAutoRetryHandoffMissing },
+  );
+
+  assert.deepEqual(blockedEvents, []);
+  assert.equal(state.issues["92"]?.state, "blocked");
+  assert.equal(state.issues["92"]?.implementation_attempt_count, blockedRecord.implementation_attempt_count);
+  assert.equal(saveCalls, 0);
+
+  state.issues["91"] = createRecord({ issue_number: 91, state: "done" });
+  const recoveredEvents = await reconcileRecoverableBlockedIssueStates(
+    github,
+    stateStore,
+    state,
+    config,
+    [{ ...dependencyIssue, state: "CLOSED" }, blockedIssue],
+    { shouldAutoRetryHandoffMissing },
+  );
+
+  assert.equal(state.issues["92"]?.state, "queued");
+  assert.equal(saveCalls, 1);
+  assert.deepEqual(recoveredEvents.map((event) => event.reason), [
+    "requirements_recovered: requeued issue #92 after execution-ready metadata and dependency gates became satisfied",
+  ]);
+});
+
+test("reconcileRecoverableBlockedIssueStates does not requeue an issue after its configured candidate label is removed", async () => {
+  const config = createConfig({ issueLabel: "codex" });
+  const blockedRecord = createRecord({
+    issue_number: 92,
+    state: "blocked",
+    blocked_reason: "requirements",
+  });
+  const state = createSupervisorState({
+    issues: [
+      createRecord({ issue_number: 91, state: "done" }),
+      blockedRecord,
+    ],
+  });
+  const issues = [
+    createIssue({ number: 91, labels: [], state: "CLOSED" }),
+    createIssue({
+      number: 92,
+      labels: [{ name: "status:blocked-upstream" }],
+      body: executionReadyBody("Keep the issue out of the candidate queue.")
+        .replace("Depends on: none", "Depends on: #91"),
+    }),
+  ];
+  let saveCalls = 0;
+
+  const events = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getIssue: async () => {
+        throw new Error("unexpected getIssue call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+    },
+    {
+      touch(record: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
+        return { ...record, ...patch };
+      },
+      async save(): Promise<void> {
+        saveCalls += 1;
+      },
+    },
+    state,
+    config,
+    issues,
+    { shouldAutoRetryHandoffMissing },
+  );
+
+  assert.deepEqual(events, []);
+  assert.equal(state.issues["92"]?.state, "blocked");
+  assert.equal(saveCalls, 0);
 });
 
 test("reconcileRecoverableBlockedIssueStates resumes conflicted tracked PR handoff-missing issues into conflict repair", async () => {

--- a/src/recovery-blocked-issue-reconciliation.test.ts
+++ b/src/recovery-blocked-issue-reconciliation.test.ts
@@ -511,6 +511,47 @@ test("reconcileRecoverableBlockedIssueStates does not requeue an issue after its
   assert.equal(saveCalls, 0);
 });
 
+test("reconcileRecoverableBlockedIssueStates does not hydrate unrelated dependencies during tracked-PR-only recovery", async () => {
+  const unrelatedIssue = createIssue({
+    number: 92,
+    body: executionReadyBody("Unrelated dependency during tracked PR recovery.")
+      .replace("Depends on: none", "Depends on: #999999"),
+  });
+  let dependencyLookups = 0;
+
+  const events = await reconcileRecoverableBlockedIssueStates(
+    {
+      getPullRequestIfExists: async () => {
+        throw new Error("unexpected getPullRequestIfExists call");
+      },
+      getIssue: async () => {
+        dependencyLookups += 1;
+        throw new Error("unexpected getIssue call");
+      },
+      getChecks: async () => {
+        throw new Error("unexpected getChecks call");
+      },
+      getUnresolvedReviewThreads: async () => {
+        throw new Error("unexpected getUnresolvedReviewThreads call");
+      },
+    },
+    {
+      touch: (record: IssueRunRecord, patch: Partial<IssueRunRecord>) => ({ ...record, ...patch }),
+      save: async () => {
+        throw new Error("unexpected save call");
+      },
+    },
+    createSupervisorState(),
+    createConfig({ issueLabel: "codex" }),
+    [unrelatedIssue],
+    { shouldAutoRetryHandoffMissing },
+    { onlyTrackedPrStates: true },
+  );
+
+  assert.deepEqual(events, []);
+  assert.equal(dependencyLookups, 0);
+});
+
 test("reconcileRecoverableBlockedIssueStates resumes conflicted tracked PR handoff-missing issues into conflict repair", async () => {
   const config = createConfig();
   const state: SupervisorStateFile = createSupervisorState({

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -283,8 +283,7 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
 ): Promise<RecoveryEvent[]> {
   let changed = false;
   const recoveryEvents: RecoveryEvent[] = [];
-  const dependencyIssues = await hydrateDependencyIssueInventory(github, issues);
-  const issuesByNumber = new Map(dependencyIssues.map((issue) => [issue.number, issue]));
+  const issuesByNumber = new Map(issues.map((issue) => [issue.number, issue]));
   const inferStateFromPullRequestImpl = deps.inferStateFromPullRequest ?? inferStateFromPullRequest;
   const inferFailureContextImpl = deps.inferFailureContext ?? inferFailureContext;
   const blockedReasonForLifecycleStateImpl =
@@ -1090,6 +1089,8 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         continue;
       }
 
+      const initialDependencyIssues = issuesByNumber.has(issue.number) ? issues : [...issues, issue];
+      const dependencyIssues = await hydrateDependencyIssueInventory(github, initialDependencyIssues, [issue]);
       if (findBlockingIssue(issue, dependencyIssues, state)) {
         continue;
       }

--- a/src/recovery-blocked-issue-reconciliation.ts
+++ b/src/recovery-blocked-issue-reconciliation.ts
@@ -14,10 +14,12 @@ import {
   shouldReconcileTrackedPrUnknownAuthBlocker,
 } from "./supervisor/supervisor-execution-policy";
 import {
+  findBlockingIssue,
   findHighRiskBlockingAmbiguity,
   hasAvailableIssueLabels,
   lintExecutionReadyIssueBody,
 } from "./issue-metadata";
+import { hydrateDependencyIssueInventory } from "./issue-metadata/dependency-issue-inventory";
 import { buildIssueDefinitionFingerprint, issueDefinitionFreshnessPatch } from "./issue-definition-freshness";
 import { RecoveryEvent } from "./run-once-cycle-prelude";
 import { StateStore } from "./core/state-store";
@@ -63,6 +65,17 @@ import {
   hasBlockedTurnVerificationProvenance,
   reconcileBlockedTurnPullRequest,
 } from "./supervisor/blocked-turn-pr-reconciliation";
+
+function hasConfiguredCandidateLabel(config: SupervisorConfig, issue: GitHubIssue): boolean {
+  if (!config.issueLabel) {
+    return true;
+  }
+
+  const normalizedIssueLabel = config.issueLabel.trim().toLowerCase();
+  return (issue.labels ?? []).some(
+    (label) => label.name.trim().toLowerCase() === normalizedIssueLabel,
+  );
+}
 
 export { codexConnectorChurnStopEvidenceSource } from "./recovery-codex-connector-churn";
 
@@ -270,7 +283,8 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
 ): Promise<RecoveryEvent[]> {
   let changed = false;
   const recoveryEvents: RecoveryEvent[] = [];
-  const issuesByNumber = new Map(issues.map((issue) => [issue.number, issue]));
+  const dependencyIssues = await hydrateDependencyIssueInventory(github, issues);
+  const issuesByNumber = new Map(dependencyIssues.map((issue) => [issue.number, issue]));
   const inferStateFromPullRequestImpl = deps.inferStateFromPullRequest ?? inferStateFromPullRequest;
   const inferFailureContextImpl = deps.inferFailureContext ?? inferFailureContext;
   const blockedReasonForLifecycleStateImpl =
@@ -1067,7 +1081,7 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
     }
 
     if (record.state === "blocked" && record.blocked_reason === "requirements") {
-      if (!hasAvailableIssueLabels(issue)) {
+      if (!hasAvailableIssueLabels(issue) || !hasConfiguredCandidateLabel(config, issue)) {
         continue;
       }
 
@@ -1076,9 +1090,13 @@ export async function reconcileRecoverableBlockedIssueStatesInModule(
         continue;
       }
 
+      if (findBlockingIssue(issue, dependencyIssues, state)) {
+        continue;
+      }
+
       const recoveryEvent = buildRecoveryEvent(
         record.issue_number,
-        `requirements_recovered: requeued issue #${record.issue_number} after execution-ready metadata was added`,
+        `requirements_recovered: requeued issue #${record.issue_number} after execution-ready metadata and dependency gates became satisfied`,
       );
       const updated = stateStore.touch(record, {
         state: "queued",

--- a/src/recovery-family-boundaries.test.ts
+++ b/src/recovery-family-boundaries.test.ts
@@ -194,7 +194,7 @@ test("blocked recovery boundary requeues requirements blockers without aggregate
   assert.equal(state.issues["366"]?.last_failure_signature, null);
   assert.equal(state.issues["366"]?.repeated_failure_signature_count, 0);
   assert.deepEqual(recoveryEvents.map((event) => event.reason), [
-    "requirements_recovered: requeued issue #366 after execution-ready metadata was added",
+    "requirements_recovered: requeued issue #366 after execution-ready metadata and dependency gates became satisfied",
   ]);
 });
 

--- a/src/run-once-cycle-prelude.test.ts
+++ b/src/run-once-cycle-prelude.test.ts
@@ -661,7 +661,7 @@ test("runOnceCyclePrelude requeues rehydrated requirements-blocked no-PR records
   const calls: string[] = [];
   const recoveryEvent: RecoveryEvent = {
     issueNumber: 77,
-    reason: "requirements_recovered: requeued issue #77 after execution-ready metadata was added",
+    reason: "requirements_recovered: requeued issue #77 after execution-ready metadata and dependency gates became satisfied",
     at: "2026-03-26T00:06:00Z",
   };
 

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -112,6 +112,23 @@ ${summary}
 - npm test -- src/run-once-issue-selection.test.ts`;
 }
 
+function selectionIssue(
+  number: number,
+  overrides: Partial<GitHubIssue> = {},
+): GitHubIssue {
+  return {
+    number,
+    title: `Issue ${number}`,
+    body: executionReadyBody(`Implement issue ${number}.`),
+    createdAt: `2026-07-14T00:${String(number % 60).padStart(2, "0")}:00Z`,
+    updatedAt: `2026-07-14T00:${String(number % 60).padStart(2, "0")}:00Z`,
+    url: `https://example.test/issues/${number}`,
+    labels: [{ name: "codex" }],
+    state: "OPEN",
+    ...overrides,
+  };
+}
+
 function createTouchStateStore(savedStates: SupervisorStateFile[]) {
   return {
     touch(record: IssueRunRecord, patch: Partial<IssueRunRecord>): IssueRunRecord {
@@ -2871,5 +2888,139 @@ Execution order: 2 of 2`,
   assert.deepEqual(requestedIssueNumbers, [93]);
   assert.equal(state.activeIssueNumber, 93);
   assert.equal(state.issues["92"], undefined);
+  assert.equal(savedStates.length, 1);
+});
+
+test("resolveRunnableIssueContext blocks a labeled child on an open unlabeled dependency outside the candidate inventory", async () => {
+  const config = createConfig({ issueLabel: "codex" });
+  const dependencyIssue = selectionIssue(91, { labels: [] });
+  const childIssue = selectionIssue(92, {
+    body: `${executionReadyBody("Keep the child blocked.")}\n\nDepends on: #91`,
+  });
+  const requestedIssueNumbers: number[] = [];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [childIssue],
+      getIssue: async (issueNumber) => {
+        requestedIssueNumbers.push(issueNumber);
+        assert.equal(issueNumber, 91);
+        return dependencyIssue;
+      },
+    },
+    config,
+    stateStore: createTouchStateStore([]),
+    state: { activeIssueNumber: null, issues: {} },
+    currentRecord: null,
+  });
+
+  assert.equal(result, "No matching open issue found.");
+  assert.deepEqual(requestedIssueNumbers, [91]);
+});
+
+test("resolveRunnableIssueContext hydrates transitive unlabeled dependencies without making them selectable", async () => {
+  const config = createConfig({ issueLabel: "codex" });
+  const rootDependency = selectionIssue(91, { labels: [] });
+  const unlabeledParent = selectionIssue(92, {
+    labels: [],
+    body: `${executionReadyBody("Wait for the root dependency.")}\n\nDepends on: #91`,
+  });
+  const grandchild = selectionIssue(93, {
+    body: `${executionReadyBody("Wait for the parent.")}\n\nDepends on: #92`,
+  });
+  const issuesByNumber = new Map([
+    [91, rootDependency],
+    [92, unlabeledParent],
+  ]);
+  const requestedIssueNumbers: number[] = [];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [grandchild],
+      getIssue: async (issueNumber) => {
+        requestedIssueNumbers.push(issueNumber);
+        const issue = issuesByNumber.get(issueNumber);
+        assert.ok(issue);
+        return issue;
+      },
+    },
+    config,
+    stateStore: createTouchStateStore([]),
+    state: { activeIssueNumber: null, issues: {} },
+    currentRecord: null,
+  });
+
+  assert.equal(result, "No matching open issue found.");
+  assert.deepEqual(requestedIssueNumbers, [92, 91]);
+});
+
+test("resolveRunnableIssueContext fails closed when an out-of-window dependency lookup fails", async () => {
+  const childIssue = selectionIssue(92, {
+    body: `${executionReadyBody("Keep lookup failures blocked.")}\n\nDepends on: #91`,
+  });
+
+  await assert.rejects(
+    resolveRunnableIssueContext({
+      github: {
+        listCandidateIssues: async () => [childIssue],
+        getIssue: async () => {
+          throw new Error("GitHub lookup unavailable");
+        },
+      },
+      config: createConfig({ issueLabel: "codex" }),
+      stateStore: createTouchStateStore([]),
+      state: { activeIssueNumber: null, issues: {} },
+      currentRecord: null,
+    }),
+    /Failed to resolve dependency issue #91 referenced by issue #92; refusing to continue without authoritative dependency state: GitHub lookup unavailable/,
+  );
+});
+
+test("resolveRunnableIssueContext rechecks out-of-window dependencies before continuing an active reservation", async () => {
+  const dependencyIssue = selectionIssue(91, { labels: [] });
+  const childIssue = selectionIssue(92, {
+    labels: [],
+    body: `${executionReadyBody("Recheck the active issue dependency.")}\n\nDepends on: #91`,
+  });
+  const record = createRecord(92, { implementation_attempt_count: 7 });
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 92,
+    issues: { "92": record },
+  };
+  const savedStates: SupervisorStateFile[] = [];
+  const requestedIssueNumbers: number[] = [];
+  let released = false;
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [],
+      getIssue: async (issueNumber) => {
+        requestedIssueNumbers.push(issueNumber);
+        if (issueNumber === 92) {
+          return childIssue;
+        }
+        assert.equal(issueNumber, 91);
+        return dependencyIssue;
+      },
+    },
+    config: createConfig({ issueLabel: "codex" }),
+    stateStore: createTouchStateStore(savedStates),
+    state,
+    currentRecord: record,
+    acquireIssueLock: async () => ({
+      acquired: true,
+      release: async () => {
+        released = true;
+      },
+    }),
+  });
+
+  assert.ok(typeof result !== "string");
+  assert.equal(result.kind, "restart");
+  assert.deepEqual(requestedIssueNumbers, [92, 91]);
+  assert.equal(state.activeIssueNumber, null);
+  assert.equal(state.issues["92"]?.implementation_attempt_count, 7);
+  assert.match(state.issues["92"]?.last_error ?? "", /Waiting for depends on #91/);
+  assert.equal(released, true);
   assert.equal(savedStates.length, 1);
 });

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -795,7 +795,7 @@ Parallelizable: No
       }),
       syncIssueJournal: async () => {},
     }),
-    /Failed to fetch recoverable tracked PR issue #281/,
+    /Failed to resolve dependency issue #281 referenced by issue #282/,
   );
   assert.equal(lockAcquired, true);
 });
@@ -3023,4 +3023,80 @@ test("resolveRunnableIssueContext rechecks out-of-window dependencies before con
   assert.match(state.issues["92"]?.last_error ?? "", /Waiting for depends on #91/);
   assert.equal(released, true);
   assert.equal(savedStates.length, 1);
+});
+
+test("resolveRunnableIssueContext skips title-filtered dependency hydration before reserving a later candidate", async () => {
+  const skippedIssue = selectionIssue(91, {
+    title: "[skip] stale backlog item",
+    body: `${executionReadyBody("Do not hydrate this skipped issue.")}\n\nDepends on: #999999`,
+  });
+  const readyIssue = selectionIssue(92, {
+    body: `${executionReadyBody("Reserve the later ready issue.")}\n\nDepends on: none\nParallelizable: No\n\n## Execution order\n1 of 1`,
+  });
+  const requestedIssueNumbers: number[] = [];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [skippedIssue, readyIssue],
+      getIssue: async (issueNumber) => {
+        requestedIssueNumbers.push(issueNumber);
+        assert.equal(issueNumber, 92);
+        return readyIssue;
+      },
+    },
+    config: createConfig({ skipTitlePrefixes: ["[skip]"] }),
+    stateStore: createTouchStateStore([]),
+    state: { activeIssueNumber: null, issues: {} },
+    currentRecord: null,
+    acquireIssueLock: async () => ({ acquired: true, release: async () => {} }),
+    ensureRecordJournalContext: async (record) => ({
+      workspace: record.workspace,
+      journal_path: `/tmp/workspaces/issue-${record.issue_number}/.codex-supervisor/issue-journal.md`,
+    }),
+    syncIssueJournal: async () => {},
+  });
+
+  assert.ok(typeof result !== "string");
+  assert.equal(result.kind, "ready");
+  assert.equal(result.issue.number, 92);
+  assert.deepEqual(requestedIssueNumbers, [92]);
+});
+
+test("resolveRunnableIssueContext does not hydrate unrelated candidates while continuing an unsequenced active issue", async () => {
+  const activeIssue = selectionIssue(92, { labels: [] });
+  const unrelatedIssue = selectionIssue(91, {
+    body: `${executionReadyBody("Unrelated stale dependency.")}\n\nDepends on: #999999`,
+  });
+  const record = createRecord(92);
+  const state: SupervisorStateFile = {
+    activeIssueNumber: 92,
+    issues: { "92": record },
+  };
+  let candidateListCalls = 0;
+  const requestedIssueNumbers: number[] = [];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => {
+        candidateListCalls += 1;
+        return [unrelatedIssue];
+      },
+      getIssue: async (issueNumber) => {
+        requestedIssueNumbers.push(issueNumber);
+        assert.equal(issueNumber, 92);
+        return activeIssue;
+      },
+    },
+    config: createConfig({ issueLabel: "codex" }),
+    stateStore: createTouchStateStore([]),
+    state,
+    currentRecord: record,
+    acquireIssueLock: async () => ({ acquired: true, release: async () => {} }),
+  });
+
+  assert.ok(typeof result !== "string");
+  assert.equal(result.kind, "ready");
+  assert.equal(result.issue.number, 92);
+  assert.equal(candidateListCalls, 0);
+  assert.deepEqual(requestedIssueNumbers, [92]);
 });

--- a/src/run-once-issue-selection.test.ts
+++ b/src/run-once-issue-selection.test.ts
@@ -3062,6 +3062,50 @@ test("resolveRunnableIssueContext skips title-filtered dependency hydration befo
   assert.deepEqual(requestedIssueNumbers, [92]);
 });
 
+test("resolveRunnableIssueContext skips dependency hydration for terminal ineligible candidates", async () => {
+  const blockedIssue = selectionIssue(91, {
+    body: `${executionReadyBody("Do not hydrate this terminal blocked issue.")}\n\nDepends on: #999999`,
+  });
+  const readyIssue = selectionIssue(92, {
+    body: `${executionReadyBody("Reserve the later ready issue.")}\n\nDepends on: none\nParallelizable: No\n\n## Execution order\n1 of 1`,
+  });
+  const requestedIssueNumbers: number[] = [];
+
+  const result = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [blockedIssue, readyIssue],
+      getIssue: async (issueNumber) => {
+        requestedIssueNumbers.push(issueNumber);
+        assert.equal(issueNumber, 92);
+        return readyIssue;
+      },
+    },
+    config: createConfig(),
+    stateStore: createTouchStateStore([]),
+    state: {
+      activeIssueNumber: null,
+      issues: {
+        "91": createRecord(91, {
+          state: "blocked",
+          blocked_reason: "requirements",
+        }),
+      },
+    },
+    currentRecord: null,
+    acquireIssueLock: async () => ({ acquired: true, release: async () => {} }),
+    ensureRecordJournalContext: async (record) => ({
+      workspace: record.workspace,
+      journal_path: `/tmp/workspaces/issue-${record.issue_number}/.codex-supervisor/issue-journal.md`,
+    }),
+    syncIssueJournal: async () => {},
+  });
+
+  assert.ok(typeof result !== "string");
+  assert.equal(result.kind, "ready");
+  assert.equal(result.issue.number, 92);
+  assert.deepEqual(requestedIssueNumbers, [92]);
+});
+
 test("resolveRunnableIssueContext does not hydrate unrelated candidates while continuing an unsequenced active issue", async () => {
   const activeIssue = selectionIssue(92, { labels: [] });
   const unrelatedIssue = selectionIssue(91, {

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -209,9 +209,17 @@ async function loadSelectableIssueInventory(
   const issues = await github.listCandidateIssues();
   const recoveryIssues = await discoverTrackedPrRecoveryInventoryIssues(github, config, state, issues);
   const candidates = sortIssuesForSelection([...issues, ...recoveryIssues]);
+  const dependencyCandidates = candidates.filter(
+    (issue) => !config.skipTitlePrefixes.some((prefix) => issue.title.startsWith(prefix)),
+  );
+  const initialDependencyIssues = [...candidates, ...dependencyRoots];
   return {
     candidates,
-    dependencyIssues: await hydrateDependencyIssueInventory(github, [...candidates, ...dependencyRoots]),
+    dependencyIssues: await hydrateDependencyIssueInventory(
+      github,
+      initialDependencyIssues,
+      [...dependencyCandidates, ...dependencyRoots],
+    ),
   };
 }
 
@@ -889,9 +897,11 @@ export async function resolveRunnableIssueContext(
         await issueLock.release();
         return { kind: "restart" };
       }
-    } else {
-      const selectionInventory = await loadSelectableIssueInventory(github, config, state, [issue]);
-      const blockingIssue = findBlockingIssue(issue, selectionInventory.dependencyIssues, state);
+    } else if (hasSequencingConstraints) {
+      const dependencyIssues = metadata.executionOrderIndex !== null && metadata.executionOrderIndex > 1
+        ? (await loadSelectableIssueInventory(github, config, state, [issue])).dependencyIssues
+        : await hydrateDependencyIssueInventory(github, [issue]);
+      const blockingIssue = findBlockingIssue(issue, dependencyIssues, state);
       if (blockingIssue) {
         record = stateStore.touch(record, {
           state: "queued",

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -47,6 +47,7 @@ import {
 } from "./supervisor/supervisor-events";
 import { findLatestBlockedPreservedPartialWorkIncident } from "./supervisor/supervisor-preserved-partial-work";
 import { codexConnectorReviewRequestAction } from "./codex-connector-review-request-decision";
+import { hydrateDependencyIssueInventory } from "./issue-metadata/dependency-issue-inventory";
 import { shouldSelectCodexConnectorValidReviewRepair } from "./codex-connector-valid-review-repair-selection";
 import { shouldSelectCodexConnectorVerifiedStaleResidueAutoResolve } from "./supervisor/codex-connector-verified-stale-residue-selection";
 import { configuredBotReviewThreads, manualReviewThreads } from "./review-thread-reporting";
@@ -65,8 +66,8 @@ export interface RestartRunOnce {
 
 type IssueSelectionResult = ReadyIssueContext | RestartRunOnce | string;
 
-type IssueSelectionCandidateGitHub = Pick<GitHubClient, "listCandidateIssues"> &
-  Partial<Pick<GitHubClient, "getIssue" | "getPullRequestIfExists" | "getChecks" | "getUnresolvedReviewThreads">>;
+type IssueSelectionCandidateGitHub = Pick<GitHubClient, "listCandidateIssues" | "getIssue"> &
+  Partial<Pick<GitHubClient, "getPullRequestIfExists" | "getChecks" | "getUnresolvedReviewThreads">>;
 type IssueSelectionGitHub = IssueSelectionCandidateGitHub
   & Pick<GitHubClient, "getIssue">
   & Partial<Pick<GitHubClient, "addIssueComment" | "getIssueComments" | "updateIssueComment">>;
@@ -194,14 +195,24 @@ async function discoverTrackedPrRecoveryInventoryIssues(
   return recoveryIssues;
 }
 
-async function listSelectableIssuesWithRecoveredBlockers(
+interface SelectableIssueInventory {
+  candidates: GitHubIssue[];
+  dependencyIssues: GitHubIssue[];
+}
+
+async function loadSelectableIssueInventory(
   github: IssueSelectionCandidateGitHub,
   config: SupervisorConfig,
   state: SupervisorStateFile,
-): Promise<GitHubIssue[]> {
+  dependencyRoots: GitHubIssue[] = [],
+): Promise<SelectableIssueInventory> {
   const issues = await github.listCandidateIssues();
   const recoveryIssues = await discoverTrackedPrRecoveryInventoryIssues(github, config, state, issues);
-  return sortIssuesForSelection([...issues, ...recoveryIssues]);
+  const candidates = sortIssuesForSelection([...issues, ...recoveryIssues]);
+  return {
+    candidates,
+    dependencyIssues: await hydrateDependencyIssueInventory(github, [...candidates, ...dependencyRoots]),
+  };
 }
 
 interface SelectedIssueRecord {
@@ -243,7 +254,7 @@ interface ResolveRunnableIssueContextArgs {
 }
 
 interface ReserveRunnableIssueSelectionArgs {
-  github: Pick<IssueSelectionGitHub, "listCandidateIssues">;
+  github: IssueSelectionCandidateGitHub;
   config: SupervisorConfig;
   stateStore: Pick<IssueSelectionStateStore, "save">;
   state: SupervisorStateFile;
@@ -507,14 +518,14 @@ async function selectIssueRecord(
   }
 
   if (!record || !isEligibleForSelection(record, config)) {
-    const selectableIssues = await listSelectableIssuesWithRecoveredBlockers(github, config, state);
+    const selectionInventory = await loadSelectableIssueInventory(github, config, state);
     record = null;
-    for (const issue of selectableIssues) {
+    for (const issue of selectionInventory.candidates) {
       if (config.skipTitlePrefixes.some((prefix) => issue.title.startsWith(prefix))) {
         continue;
       }
 
-      if (findBlockingIssue(issue, selectableIssues, state)) {
+      if (findBlockingIssue(issue, selectionInventory.dependencyIssues, state)) {
         continue;
       }
 
@@ -879,8 +890,8 @@ export async function resolveRunnableIssueContext(
         return { kind: "restart" };
       }
     } else {
-      const selectableIssues = await listSelectableIssuesWithRecoveredBlockers(github, config, state);
-      const blockingIssue = findBlockingIssue(issue, selectableIssues, state);
+      const selectionInventory = await loadSelectableIssueInventory(github, config, state, [issue]);
+      const blockingIssue = findBlockingIssue(issue, selectionInventory.dependencyIssues, state);
       if (blockingIssue) {
         record = stateStore.touch(record, {
           state: "queued",

--- a/src/run-once-issue-selection.ts
+++ b/src/run-once-issue-selection.ts
@@ -205,6 +205,7 @@ async function loadSelectableIssueInventory(
   config: SupervisorConfig,
   state: SupervisorStateFile,
   dependencyRoots: GitHubIssue[] = [],
+  hydrateCandidateDependencies = true,
 ): Promise<SelectableIssueInventory> {
   const issues = await github.listCandidateIssues();
   const recoveryIssues = await discoverTrackedPrRecoveryInventoryIssues(github, config, state, issues);
@@ -215,11 +216,13 @@ async function loadSelectableIssueInventory(
   const initialDependencyIssues = [...candidates, ...dependencyRoots];
   return {
     candidates,
-    dependencyIssues: await hydrateDependencyIssueInventory(
-      github,
-      initialDependencyIssues,
-      [...dependencyCandidates, ...dependencyRoots],
-    ),
+    dependencyIssues: hydrateCandidateDependencies
+      ? await hydrateDependencyIssueInventory(
+        github,
+        initialDependencyIssues,
+        [...dependencyCandidates, ...dependencyRoots],
+      )
+      : initialDependencyIssues,
   };
 }
 
@@ -526,14 +529,10 @@ async function selectIssueRecord(
   }
 
   if (!record || !isEligibleForSelection(record, config)) {
-    const selectionInventory = await loadSelectableIssueInventory(github, config, state);
+    const selectionInventory = await loadSelectableIssueInventory(github, config, state, [], false);
     record = null;
     for (const issue of selectionInventory.candidates) {
       if (config.skipTitlePrefixes.some((prefix) => issue.title.startsWith(prefix))) {
-        continue;
-      }
-
-      if (findBlockingIssue(issue, selectionInventory.dependencyIssues, state)) {
         continue;
       }
 
@@ -570,6 +569,15 @@ async function selectIssueRecord(
         })) &&
         !(isAutonomousExecutionTrustBlockedRecord(existing) && trustDecision.allowed)
       ) {
+        continue;
+      }
+
+      selectionInventory.dependencyIssues = await hydrateDependencyIssueInventory(
+        github,
+        selectionInventory.dependencyIssues,
+        [issue],
+      );
+      if (findBlockingIssue(issue, selectionInventory.dependencyIssues, state)) {
         continue;
       }
 

--- a/src/supervisor/supervisor-selection-issue-explain.test.ts
+++ b/src/supervisor/supervisor-selection-issue-explain.test.ts
@@ -1143,7 +1143,7 @@ Parallelizable: No
         last_failure_context: null,
         last_failure_signature: null,
         repeated_failure_signature_count: 0,
-        last_recovery_reason: `requirements_recovered: requeued issue #${issueNumber} after execution-ready metadata was added`,
+        last_recovery_reason: `requirements_recovered: requeued issue #${issueNumber} after execution-ready metadata and dependency gates became satisfied`,
         last_recovery_at: "2026-04-17T00:21:00Z",
         branch: branchName(config, issueNumber),
         workspace: `/tmp/other-host/issue-${issueNumber}`,
@@ -1169,7 +1169,7 @@ Parallelizable: No
   assert.match(explanation, /^selection_reason=ready /m);
   assert.match(
     explanation,
-    /^latest_recovery issue=#610 at=2026-04-17T00:21:00Z reason=requirements_recovered detail=requeued issue #610 after execution-ready metadata was added$/m,
+    /^latest_recovery issue=#610 at=2026-04-17T00:21:00Z reason=requirements_recovered detail=requeued issue #610 after execution-ready metadata and dependency gates became satisfied$/m,
   );
   assert.match(
     explanation,

--- a/src/supervisor/supervisor-status-selection-diagnostics-readiness.test.ts
+++ b/src/supervisor/supervisor-status-selection-diagnostics-readiness.test.ts
@@ -5,6 +5,7 @@ import test, { mock } from "node:test";
 import { StateStore } from "../core/state-store";
 import { GitHubIssue, SupervisorStateFile } from "../core/types";
 import { renderSupervisorStatusDto } from "./supervisor-status-report";
+import { resolveRunnableIssueContext } from "../run-once-issue-selection";
 import { Supervisor } from "./supervisor";
 import {
   branchName,
@@ -419,6 +420,30 @@ Depends on: #91`,
   ]);
   assert.match(report.readinessLines.join("\n"), /runnable_issues=none/);
   assert.match(report.readinessLines.join("\n"), /blocked_issues=#92 blocked_by=depends on #91/);
+
+  const reservationState: SupervisorStateFile = {
+    activeIssueNumber: null,
+    issues: {},
+  };
+  const reservationResult = await resolveRunnableIssueContext({
+    github: {
+      listCandidateIssues: async () => [candidateIssue],
+      getIssue: async (issueNumber) => {
+        assert.equal(issueNumber, 91);
+        return dependencyIssue;
+      },
+    },
+    config: fixture.config,
+    stateStore: {
+      touch: (record, patch) => ({ ...record, ...patch }),
+      save: async () => {},
+    },
+    state: reservationState,
+    currentRecord: null,
+  });
+
+  assert.equal(reservationResult, "No matching open issue found.");
+  assert.equal(reservationState.activeIssueNumber, null);
 });
 
 test("status marks skipped readiness checks explicitly and uses non-conflicting inner separators", async () => {


### PR DESCRIPTION
## Summary

- hydrate explicit `Depends on:` references that fall outside the configured candidate-label window
- keep hydrated dependencies in the gating inventory without making them selectable
- fail closed with an actionable error when authoritative dependency lookup fails
- require candidate-label and dependency readiness before recovering requirements-blocked records
- keep active reservations from continuing when an out-of-window dependency remains blocked

## Root cause

Normal reservation passed only the label-filtered candidate list to `findBlockingIssue`. Missing dependencies were skipped, so removing `codex` from an open dependency could make its children appear runnable. Requirements recovery then requeued lint-clean records without rechecking their candidate label or dependency gates.

## Validation

- focused regression suite: 182 tests passed
- full test suite: 2,980 tests passed
- `npm run verify:supervisor-pre-pr`
- `git diff --cached --check`

Closes #2456